### PR TITLE
Implement `Clone` for `Ast`

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -263,6 +263,13 @@ impl<'ctx> fmt::Display for Ast<'ctx> {
     }
 }
 
+impl<'ctx> Clone for Ast<'ctx> {
+    fn clone(&self) -> Ast<'ctx> {
+        debug!("clone ast {:p}", self.z3_ast);
+        Ast::new(self.ctx, self.z3_ast)
+    }
+}
+
 impl<'ctx> Drop for Ast<'ctx> {
     fn drop(&mut self) {
         unsafe {

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -69,3 +69,23 @@ fn test_solving_for_model() {
     assert!(yv % 7 == 2);
     assert!(xv + 2 > 7);
 }
+
+#[test]
+fn test_cloning_ast() {
+    let _ = env_logger::try_init();
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+    let x = ctx.named_int_const("x");
+    let y = x.clone();
+    let zero = ctx.from_i64(0);
+
+    let solver = Solver::new(&ctx);
+    solver.assert(&x._eq(&zero));
+    assert!(solver.check());
+
+    let model = solver.get_model();
+    let xv = model.eval(&x).unwrap().as_i64().unwrap();
+    let yv = model.eval(&y).unwrap().as_i64().unwrap();
+    assert_eq!(xv, 0);
+    assert_eq!(yv, 0);
+}


### PR DESCRIPTION
Is there any harm in adding `Clone` to `Ast`?
This is originally from @fitzgen: https://github.com/fitzgen/z3-rs/commit/6c4fa869043e1699abad3329942816923a6b0993