### PR TITLE
Handle strings returned from Z3 as borrowed.

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1,5 +1,5 @@
 use std::cmp::{Eq, PartialEq};
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use z3_sys::*;
@@ -252,11 +252,11 @@ impl<'ctx> Ast<'ctx> {
 impl<'ctx> fmt::Display for Ast<'ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let p =
-            unsafe { CString::from_raw(Z3_ast_to_string(self.ctx.z3_ctx, self.z3_ast) as *mut i8) };
+            unsafe { CStr::from_ptr(Z3_ast_to_string(self.ctx.z3_ctx, self.z3_ast) as *mut i8) };
         if p.as_ptr().is_null() {
             return Result::Err(fmt::Error);
         }
-        match p.into_string() {
+        match p.to_str() {
             Ok(s) => write!(f, "{}", s),
             Err(_) => Result::Err(fmt::Error),
         }

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::CStr;
 use std::fmt;
 use z3_sys::*;
 use Ast;
@@ -106,12 +106,12 @@ impl<'ctx> Optimize<'ctx> {
 impl<'ctx> fmt::Display for Optimize<'ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let p = unsafe {
-            CString::from_raw(Z3_optimize_to_string(self.ctx.z3_ctx, self.z3_opt) as *mut i8)
+            CStr::from_ptr(Z3_optimize_to_string(self.ctx.z3_ctx, self.z3_opt) as *mut i8)
         };
         if p.as_ptr().is_null() {
             return Result::Err(fmt::Error);
         }
-        match p.into_string() {
+        match p.to_str() {
             Ok(s) => write!(f, "{}", s),
             Err(_) => Result::Err(fmt::Error),
         }

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::CStr;
 use std::fmt;
 use z3_sys::*;
 use Context;
@@ -81,12 +81,12 @@ impl<'ctx> Sort<'ctx> {
 impl<'ctx> fmt::Display for Sort<'ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let p = unsafe {
-            CString::from_raw(Z3_sort_to_string(self.ctx.z3_ctx, self.z3_sort) as *mut i8)
+            CStr::from_ptr(Z3_sort_to_string(self.ctx.z3_ctx, self.z3_sort) as *mut i8)
         };
         if p.as_ptr().is_null() {
             return Result::Err(fmt::Error);
         }
-        match p.into_string() {
+        match p.to_str() {
             Ok(s) => write!(f, "{}", s),
             Err(_) => Result::Err(fmt::Error),
         }

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -89,3 +89,14 @@ fn test_cloning_ast() {
     assert_eq!(xv, 0);
     assert_eq!(yv, 0);
 }
+
+#[test]
+fn test_format() {
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+    let ast = ctx.named_int_const("x");
+    assert_eq!("x", format!("{}", ast));
+
+    let int = ctx.int_sort();
+    assert_eq!("Int", format!("{}", int));
+}


### PR DESCRIPTION
z3.rs doesn't actually own the memory, but wrapping it in a CString will
assume it does and drop the content (and thus free it) when going out of scope.

The new test will crash with a SIGSEGV on the old code.