### PR TITLE
Add API support for AST translate.

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -72,6 +72,15 @@ impl<'ctx> Ast<'ctx> {
         }
     }
 
+    pub fn translate<'dest_ctx>(&self, dest: &'dest_ctx Context) -> Ast<'dest_ctx> {
+        Ast::new(
+            dest,unsafe {
+                let guard = Z3_MUTEX.lock().unwrap();
+                Z3_translate(self.ctx.z3_ctx, self.z3_ast, dest.z3_ctx)
+            }
+        )
+    }
+
     pub fn new_const(sym: &Symbol<'ctx>, sort: &Sort<'ctx>) -> Ast<'ctx> {
         Ast::new(sym.ctx, unsafe {
             let guard = Z3_MUTEX.lock().unwrap();

--- a/z3/src/solver.rs
+++ b/z3/src/solver.rs
@@ -58,6 +58,16 @@ impl<'ctx> Solver<'ctx> {
         }
     }
 
+    pub fn translate<'dest_ctx>(&self, dest: &'dest_ctx Context) -> Solver<'dest_ctx> {
+        Solver {
+            ctx: dest,
+            z3_slv: unsafe {
+                let guard = Z3_MUTEX.lock().unwrap();
+                Z3_solver_translate(self.ctx.z3_ctx, self.z3_slv, dest.z3_ctx)
+            }
+        }
+    }
+
     /// Assert a constraint into the solver.
     ///
     /// The functions [`Solver::check()`](#method.check) and

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -119,6 +119,26 @@ fn test_ast_translate() {
 }
 
 #[test]
+fn test_solver_translate() {
+    let cfg = Config::new();
+    let source = Context::new(&cfg);
+    let a = source.named_int_const("a");
+
+    let destination  = Context::new(&cfg);
+    let translated_a = a.translate(&destination);
+
+    let slv = Solver::new(&destination);
+    slv.assert(&translated_a._eq(&destination.from_u64(2)));
+    assert!(slv.check());
+
+    let translated_slv = slv.translate(&source);
+    // Add a new constraint, make the old one unsatisfiable, while the copy remains satisfiable.
+    slv.assert(&translated_a._eq(&destination.from_u64(3)));
+    assert!(! slv.check());
+    assert!(translated_slv.check());
+}
+
+#[test]
 fn test_pb_ops_model() {
     let cfg = Config::new();
     let ctx = Context::new(&cfg);

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -102,6 +102,23 @@ fn test_format() {
 }
 
 #[test]
+fn test_ast_translate() {
+    let cfg = Config::new();
+    let source = Context::new(&cfg);
+    let a = source.named_int_const("a");
+
+    let destination  = Context::new(&cfg);
+    let translated_a = a.translate(&destination);
+
+    let slv = Solver::new(&destination);
+    slv.assert(&translated_a._eq(&destination.from_u64(2)));
+    assert!(slv.check());
+
+    slv.assert(&translated_a._eq(&destination.from_u64(3)));
+    assert!(! slv.check());
+}
+
+#[test]
 fn test_pb_ops_model() {
     let cfg = Config::new();
     let ctx = Context::new(&cfg);


### PR DESCRIPTION
High-level API support for `Z3_translate` operation.

Usage example can be found in the corresponding unit test.