### PR TITLE
Create bitvectors from constants

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -123,6 +123,22 @@ impl<'ctx> Ast<'ctx> {
         })
     }
 
+    pub fn bitvector_from_i64(ctx: &'ctx Context, i: i64, sz: u32) -> Ast<'ctx> {
+        Ast::new(ctx, unsafe {
+            let sort = ctx.bitvector_sort(sz);
+            let guard = Z3_MUTEX.lock().unwrap();
+            Z3_mk_int64(ctx.z3_ctx, i, sort.z3_sort)
+        })
+    }
+
+    pub fn bitvector_from_u64(ctx: &'ctx Context, u: u64, sz: u32) -> Ast<'ctx> {
+        Ast::new(ctx, unsafe {
+            let sort = ctx.bitvector_sort(sz);
+            let guard = Z3_MUTEX.lock().unwrap();
+            Z3_mk_unsigned_int64(ctx.z3_ctx, u, sort.z3_sort)
+        })
+    }
+
     pub fn from_real(ctx: &'ctx Context, num: i32, den: i32) -> Ast<'ctx> {
         Ast::new(ctx, unsafe {
             let guard = Z3_MUTEX.lock().unwrap();

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -102,6 +102,28 @@ fn test_format() {
 }
 
 #[test]
+fn test_bitvectors() {
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+    let a = ctx.named_bitvector_const("a", 64);
+    let b = ctx.named_bitvector_const("b", 64);
+    let two = Ast::bitvector_from_i64(&ctx, 2, 64);
+
+    let solver = Solver::new(&ctx);
+    solver.assert(&a.bvsgt(&b));
+    solver.assert(&b.bvsgt(&two));
+    solver.assert(&b.bvadd(&two).bvsgt(&a));
+    assert!(solver.check());
+
+    let model = solver.get_model();
+    let av = model.eval(&a).unwrap().as_i64().unwrap();
+    let bv = model.eval(&b).unwrap().as_i64().unwrap();
+    assert!(av > bv);
+    assert!(bv > 2);
+    assert!(bv + 2 > av);
+}
+
+#[test]
 fn test_ast_translate() {
     let cfg = Config::new();
     let source = Context::new(&cfg);


### PR DESCRIPTION
Unless I'm missing something, the high-level bindings have no simple way to create bitvector constants.  This PR adds new functions `Ast::bitvector_from_i64()` and `Ast::bitvector_from_u64()` to mirror the existing `Ast::from_i64` and `Ast::from_u64()` which produce integer constants.  Also adds a test using the new functions (actually, no existing tests used bitvectors at all).

Happy to take feedback on anything - function names, function arguments, anything else.  I'm fairly new here.

All the tests in `tests/lib.rs` still pass with this patch.