### PR TITLE
Simplify Symbols.

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -261,11 +261,11 @@ impl<'ctx> Ast<'ctx> for Set<'ctx> {
 }
 
 impl<'ctx> Bool<'ctx> {
-    pub fn new_const(sym: &Symbol<'ctx>) -> Bool<'ctx> {
-        let sort = Sort::bool(sym.ctx);
-        Self::new(sym.ctx, unsafe {
+    pub fn new_const(ctx: &'ctx Context, name: Symbol) -> Bool<'ctx> {
+        let sort = Sort::bool(ctx);
+        Self::new(ctx, unsafe {
             let guard = Z3_MUTEX.lock().unwrap();
-            Z3_mk_const(sym.ctx.z3_ctx, sym.z3_sym, sort.z3_sort)
+            Z3_mk_const(ctx.z3_ctx, name.as_z3_symbol(ctx), sort.z3_sort)
         })
     }
 
@@ -385,11 +385,11 @@ impl<'ctx> Bool<'ctx> {
 }
 
 impl<'ctx> Int<'ctx> {
-    pub fn new_const(sym: &Symbol<'ctx>) -> Int<'ctx> {
-        let sort = Sort::int(sym.ctx);
-        Self::new(sym.ctx, unsafe {
+    pub fn new_const(ctx: &'ctx Context, name: Symbol) -> Int<'ctx> {
+        let sort = Sort::int(ctx);
+        Self::new(ctx, unsafe {
             let guard = Z3_MUTEX.lock().unwrap();
-            Z3_mk_const(sym.ctx.z3_ctx, sym.z3_sym, sort.z3_sort)
+            Z3_mk_const(ctx.z3_ctx, name.as_z3_symbol(ctx), sort.z3_sort)
         })
     }
 
@@ -529,11 +529,11 @@ impl<'ctx> Int<'ctx> {
 }
 
 impl<'ctx> Real<'ctx> {
-    pub fn new_const(sym: &Symbol<'ctx>) -> Real<'ctx> {
-        let sort = Sort::real(sym.ctx);
-        Self::new(sym.ctx, unsafe {
+    pub fn new_const(ctx: &'ctx Context, name: Symbol) -> Real<'ctx> {
+        let sort = Sort::real(ctx);
+        Self::new(ctx, unsafe {
             let guard = Z3_MUTEX.lock().unwrap();
-            Z3_mk_const(sym.ctx.z3_ctx, sym.z3_sym, sort.z3_sort)
+            Z3_mk_const(ctx.z3_ctx, name.as_z3_symbol(ctx), sort.z3_sort)
         })
     }
 
@@ -605,11 +605,11 @@ impl<'ctx> Real<'ctx> {
 }
 
 impl<'ctx> BV<'ctx> {
-    pub fn new_const(sym: &Symbol<'ctx>, sz: u32) -> BV<'ctx> {
-        let sort = Sort::bitvector(sym.ctx, sz);
-        Self::new(sym.ctx, unsafe {
+    pub fn new_const(ctx: &'ctx Context, name: Symbol, sz: u32) -> BV<'ctx> {
+        let sort = Sort::bitvector(ctx, sz);
+        Self::new(ctx, unsafe {
             let guard = Z3_MUTEX.lock().unwrap();
-            Z3_mk_const(sym.ctx.z3_ctx, sym.z3_sym, sort.z3_sort)
+            Z3_mk_const(ctx.z3_ctx, name.as_z3_symbol(ctx), sort.z3_sort)
         })
     }
 
@@ -749,11 +749,16 @@ impl<'ctx> BV<'ctx> {
 }
 
 impl<'ctx> Array<'ctx> {
-    pub fn new_const(sym: &Symbol<'ctx>, domain: &Sort<'ctx>, range: &Sort<'ctx>) -> Array<'ctx> {
-        let sort = Sort::array(sym.ctx, domain, range);
-        Self::new(sym.ctx, unsafe {
+    pub fn new_const(
+        ctx: &'ctx Context,
+        name: Symbol,
+        domain: &Sort<'ctx>,
+        range: &Sort<'ctx>,
+    ) -> Array<'ctx> {
+        let sort = Sort::array(ctx, domain, range);
+        Self::new(ctx, unsafe {
             let guard = Z3_MUTEX.lock().unwrap();
-            Z3_mk_const(sym.ctx.z3_ctx, sym.z3_sym, sort.z3_sort)
+            Z3_mk_const(ctx.z3_ctx, name.as_z3_symbol(ctx), sort.z3_sort)
         })
     }
 
@@ -822,11 +827,11 @@ impl<'ctx> Array<'ctx> {
 }
 
 impl<'ctx> Set<'ctx> {
-    pub fn new_const(sym: &Symbol<'ctx>, eltype: &Sort<'ctx>) -> Set<'ctx> {
-        let sort = Sort::set(sym.ctx, eltype);
-        Self::new(sym.ctx, unsafe {
+    pub fn new_const(ctx: &'ctx Context, name: Symbol, eltype: &Sort<'ctx>) -> Set<'ctx> {
+        let sort = Sort::set(ctx, eltype);
+        Self::new(ctx, unsafe {
             let guard = Z3_MUTEX.lock().unwrap();
-            Z3_mk_const(sym.ctx.z3_ctx, sym.z3_sym, sort.z3_sort)
+            Z3_mk_const(ctx.z3_ctx, name.as_z3_symbol(ctx), sort.z3_sort)
         })
     }
 
@@ -901,13 +906,13 @@ impl<'ctx> Set<'ctx> {
 ///
 /// # Examples
 /// ```
-/// # use z3::{ast, Config, Context, Solver};
+/// # use z3::{ast, Config, Context, Solver, Symbol};
 /// # use z3::ast::Ast;
 /// # use std::convert::TryInto;
 /// # let cfg = Config::new();
 /// # let ctx = Context::new(&cfg);
 /// # let solver = Solver::new(&ctx);
-/// let f = ctx.func_decl(ctx.str_sym("f"), &[&ctx.int_sort()], &ctx.int_sort());
+/// let f = ctx.func_decl(Symbol::String("f".to_owned()), &[&ctx.int_sort()], &ctx.int_sort());
 ///
 /// let x: ast::Int = ctx.named_int_const("x");
 /// let f_x: ast::Int = f.apply(&[&x.clone().into()]).try_into().unwrap();

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -66,16 +66,16 @@ impl Context {
     ///
     /// # Examples
     /// ```
-    /// # use z3::{Config, Context, Solver};
+    /// # use z3::{Config, Context, Solver, Symbol};
     /// # let cfg = Config::new();
     /// # let ctx = Context::new(&cfg);
     /// # let solver = Solver::new(&ctx);
     /// let (colors, color_consts, color_testers) = ctx.enumeration_sort(
-    ///     &ctx.str_sym("Color"),
+    ///     Symbol::String("Color".to_owned()),
     ///     &[
-    ///         &ctx.str_sym("Red"),
-    ///         &ctx.str_sym("Green"),
-    ///         &ctx.str_sym("Blue"),
+    ///         Symbol::String("Red".to_owned()),
+    ///         Symbol::String("Green".to_owned()),
+    ///         Symbol::String("Blue".to_owned()),
     ///     ],
     /// );
     ///
@@ -90,26 +90,18 @@ impl Context {
     /// ```
     pub fn enumeration_sort<'ctx>(
         &'ctx self,
-        name: &Symbol<'ctx>,
-        enum_names: &[&Symbol<'ctx>],
+        name: Symbol,
+        enum_names: &[Symbol],
     ) -> (Sort<'ctx>, Vec<FuncDecl<'ctx>>, Vec<FuncDecl<'ctx>>) {
         Sort::enumeration(self, name, enum_names)
     }
 
-    pub fn int_sym(&self, i: u32) -> Symbol {
-        Symbol::from_int(self, i)
-    }
-
-    pub fn str_sym(&self, s: &str) -> Symbol {
-        Symbol::from_string(self, s)
-    }
-
     pub fn named_bool_const(&self, s: &str) -> ast::Bool {
-        ast::Bool::new_const(&self.str_sym(s))
+        ast::Bool::new_const(self, Symbol::String(s.to_owned()))
     }
 
     pub fn numbered_bool_const(&self, i: u32) -> ast::Bool {
-        ast::Bool::new_const(&self.int_sym(i))
+        ast::Bool::new_const(self, Symbol::Int(i))
     }
 
     pub fn fresh_bool_const<'ctx>(&'ctx self, prefix: &str) -> ast::Bool<'ctx> {
@@ -117,11 +109,11 @@ impl Context {
     }
 
     pub fn named_int_const(&self, s: &str) -> ast::Int {
-        ast::Int::new_const(&self.str_sym(s))
+        ast::Int::new_const(self, Symbol::String(s.to_owned()))
     }
 
     pub fn numbered_int_const(&self, i: u32) -> ast::Int {
-        ast::Int::new_const(&self.int_sym(i))
+        ast::Int::new_const(self, Symbol::Int(i))
     }
 
     pub fn fresh_int_const<'ctx>(&'ctx self, prefix: &str) -> ast::Int<'ctx> {
@@ -129,11 +121,11 @@ impl Context {
     }
 
     pub fn named_real_const(&self, s: &str) -> ast::Real {
-        ast::Real::new_const(&self.str_sym(s))
+        ast::Real::new_const(self, Symbol::String(s.to_owned()))
     }
 
     pub fn numbered_real_const(&self, i: u32) -> ast::Real {
-        ast::Real::new_const(&self.int_sym(i))
+        ast::Real::new_const(self, Symbol::Int(i))
     }
 
     pub fn fresh_real_const<'ctx>(&'ctx self, prefix: &str) -> ast::Real<'ctx> {
@@ -141,11 +133,11 @@ impl Context {
     }
 
     pub fn named_bitvector_const(&self, s: &str, sz: u32) -> ast::BV {
-        ast::BV::new_const(&self.str_sym(s), sz)
+        ast::BV::new_const(self, Symbol::String(s.to_owned()), sz)
     }
 
     pub fn numbered_bitvector_const(&self, i: u32, sz: u32) -> ast::BV {
-        ast::BV::new_const(&self.int_sym(i), sz)
+        ast::BV::new_const(self, Symbol::Int(i), sz)
     }
 
     pub fn fresh_bitvector_const<'ctx>(&'ctx self, prefix: &str, sz: u32) -> ast::BV<'ctx> {
@@ -179,7 +171,7 @@ impl Context {
 
     pub fn func_decl<'ctx>(
         &'ctx self,
-        name: Symbol<'ctx>,
+        name: Symbol,
         domain: &[&Sort<'ctx>],
         range: &Sort<'ctx>,
     ) -> FuncDecl<'ctx> {
@@ -190,13 +182,13 @@ impl Context {
     ///
     /// # Examples
     /// ```
-    /// # use z3::{ast, Config, Context, Solver};
+    /// # use z3::{ast, Config, Context, Solver, Symbol};
     /// # use z3::ast::Ast;
     /// # use std::convert::TryInto;
     /// # let cfg = Config::new();
     /// # let ctx = Context::new(&cfg);
     /// # let solver = Solver::new(&ctx);
-    /// let f = ctx.func_decl(ctx.str_sym("f"), &[&ctx.int_sort()], &ctx.int_sort());
+    /// let f = ctx.func_decl(Symbol::String("f".to_owned()), &[&ctx.int_sort()], &ctx.int_sort());
     ///
     /// let x: ast::Int = ctx.named_int_const("x");
     /// let f_x: ast::Int = f.apply(&[&x.clone().into()]).try_into().unwrap();

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -7,11 +7,10 @@ use {Context, FuncDecl, Sort, Symbol, Z3_MUTEX};
 impl<'ctx> FuncDecl<'ctx> {
     pub fn new(
         ctx: &'ctx Context,
-        name: Symbol<'ctx>,
+        name: Symbol,
         domain: &[&Sort<'ctx>],
         range: &Sort<'ctx>,
     ) -> Self {
-        assert_eq!(ctx.z3_ctx, name.ctx.z3_ctx);
         assert!(domain.iter().all(|s| s.ctx.z3_ctx == ctx.z3_ctx));
         assert_eq!(ctx.z3_ctx, range.ctx.z3_ctx);
 
@@ -24,7 +23,7 @@ impl<'ctx> FuncDecl<'ctx> {
 
                 let f = Z3_mk_func_decl(
                     ctx.z3_ctx,
-                    name.z3_sym,
+                    name.as_z3_symbol(ctx),
                     domain.len().try_into().unwrap(),
                     domain.as_ptr(),
                     range.z3_sort,
@@ -45,7 +44,7 @@ impl<'ctx> FuncDecl<'ctx> {
     /// # let ctx = Context::new(&cfg);
     /// let f = FuncDecl::new(
     ///     &ctx,
-    ///     Symbol::from_string(&ctx, "f"),
+    ///     Symbol::String("f".to_owned()),
     ///     &[&Sort::int(&ctx), &Sort::real(&ctx)],
     ///     &Sort::int(&ctx));
     /// assert_eq!(f.arity(), 2);

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -50,10 +50,9 @@ pub struct Context {
 ///
 /// [`Symbol::from_int()`]: struct.Symbol.html#method.from_int
 /// [`Symbol::from_string()`]: struct.Symbol.html#method.from_string
-pub struct Symbol<'ctx> {
-    ctx: &'ctx Context,
-    cst: Option<CString>,
-    z3_sym: Z3_symbol,
+pub enum Symbol {
+    Int(u32),
+    String(String),
 }
 
 /// Sorts represent the various 'types' of [`Ast`s](trait.Ast.html).

--- a/z3/src/symbol.rs
+++ b/z3/src/symbol.rs
@@ -2,43 +2,18 @@ use std::ffi::CString;
 use z3_sys::*;
 use Context;
 use Symbol;
-use Z3_MUTEX;
 
-impl<'ctx> Symbol<'ctx> {
-    /// Create a Z3 symbol using an integer.
-    ///
-    /// NB. Not all integers can be passed to this function.
-    /// The legal range of unsigned integers is 0 to 2^30-1.
-    ///
-    /// # See also:
-    ///
-    /// - [`Symbol::from_string()`](#method.from_string)
-    pub fn from_int(ctx: &Context, i: u32) -> Symbol {
-        Symbol {
-            ctx,
-            cst: None,
-            z3_sym: {
-                let guard = Z3_MUTEX.lock().unwrap();
-                unsafe { Z3_mk_int_symbol(ctx.z3_ctx, i as ::std::os::raw::c_int) }
-            },
-        }
-    }
-
-    /// Create a Z3 symbol using a string.
-    ///
-    /// # See also:
-    ///
-    /// - [`Symbol::from_int()`](#method.from_int)
-    pub fn from_string(ctx: &'ctx Context, s: &str) -> Symbol<'ctx> {
-        let ss = CString::new(s).unwrap();
-        let p = ss.as_ptr();
-        Symbol {
-            ctx,
-            cst: Some(ss),
-            z3_sym: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
-                Z3_mk_string_symbol(ctx.z3_ctx, p)
-            },
+impl Symbol {
+    pub fn as_z3_symbol(&self, ctx: &Context) -> Z3_symbol {
+        match self {
+            Symbol::Int(i) => {
+                unsafe { Z3_mk_int_symbol(ctx.z3_ctx, *i as ::std::os::raw::c_int) }
+            }
+            Symbol::String(s) => {
+                let ss = CString::new(s.clone()).unwrap();
+                let p = ss.as_ptr();
+                unsafe { Z3_mk_string_symbol(ctx.z3_ctx, p) }
+            }
         }
     }
 }

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -191,8 +191,8 @@ fn function_ref_count() {
 
     let int_sort = ctx.int_sort();
 
-    let _f = ctx.func_decl(ctx.str_sym("f"), &[&int_sort], &int_sort);
-    let _g = ctx.func_decl(ctx.str_sym("g"), &[&int_sort], &int_sort);
+    let _f = ctx.func_decl(Symbol::String("f".to_owned()), &[&int_sort], &int_sort);
+    let _g = ctx.func_decl(Symbol::String("g".to_owned()), &[&int_sort], &int_sort);
 
     assert!(solver.check());
 }


### PR DESCRIPTION
Instead of having to pass a context reference and create an
actual symbol, just pass the data for the symbol and let the
function that needs a symbol create it using Symbol::as_z3_symbol().