### PR TITLE
remove Z3_MUTEX

### DIFF
--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -14,7 +14,6 @@ repository = "https://github.com/prove-rs/z3.rs.git"
 
 [dependencies]
 log = "0.4"
-lazy_static = "1"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/z3/src/config.rs
+++ b/z3/src/config.rs
@@ -1,14 +1,12 @@
 use std::ffi::CString;
 use z3_sys::*;
 use Config;
-use Z3_MUTEX;
 
 impl Config {
     pub fn new() -> Config {
         Config {
             kvs: Vec::new(),
             z3_cfg: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_config();
                 debug!("new config {:p}", p);
                 p
@@ -19,7 +17,6 @@ impl Config {
         let ks = CString::new(k).unwrap();
         let vs = CString::new(v).unwrap();
         self.kvs.push((ks, vs));
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_set_param_value(
                 self.z3_cfg,
@@ -59,7 +56,6 @@ impl Default for Config {
 
 impl Drop for Config {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_del_config(self.z3_cfg) };
     }
 }

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -5,13 +5,11 @@ use Context;
 use FuncDecl;
 use Sort;
 use Symbol;
-use Z3_MUTEX;
 
 impl Context {
     pub fn new(cfg: &Config) -> Context {
         Context {
             z3_ctx: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_context_rc(cfg.z3_cfg);
                 debug!("new context {:p}", p);
                 p

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -2,7 +2,7 @@ use ast;
 use ast::Ast;
 use std::convert::TryInto;
 use z3_sys::*;
-use {Context, FuncDecl, Sort, Symbol, Z3_MUTEX};
+use {Context, FuncDecl, Sort, Symbol};
 
 impl<'ctx> FuncDecl<'ctx> {
     pub fn new<S: Into<Symbol>>(
@@ -19,8 +19,6 @@ impl<'ctx> FuncDecl<'ctx> {
         Self {
             ctx,
             z3_func_decl: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
-
                 let f = Z3_mk_func_decl(
                     ctx.z3_ctx,
                     name.into().as_z3_symbol(ctx),
@@ -62,7 +60,6 @@ impl<'ctx> FuncDecl<'ctx> {
         let args: Vec<_> = args.iter().map(|a| a.get_z3_ast()).collect();
 
         ast::Dynamic::new(self.ctx, unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
             Z3_mk_app(
                 self.ctx.z3_ctx,
                 self.z3_func_decl,

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -5,13 +5,9 @@
 #[macro_use]
 extern crate log;
 
-#[macro_use]
-extern crate lazy_static;
-
 extern crate z3_sys;
 
 use std::ffi::CString;
-use std::sync::Mutex;
 use z3_sys::*;
 
 pub mod ast;
@@ -23,12 +19,6 @@ mod optimize;
 mod solver;
 mod sort;
 mod symbol;
-
-// Z3 appears to be only mostly-threadsafe, a few initializers
-// and such race; so we mutex-guard all access to the library.
-lazy_static! {
-    static ref Z3_MUTEX: Mutex<()> = Mutex::new(());
-}
 
 /// Configuration used to initialize [logical contexts].
 ///

--- a/z3/src/model.rs
+++ b/z3/src/model.rs
@@ -3,14 +3,12 @@ use z3_sys::*;
 use Model;
 use Optimize;
 use Solver;
-use Z3_MUTEX;
 
 impl<'ctx> Model<'ctx> {
     pub fn of_solver(slv: &Solver<'ctx>) -> Model<'ctx> {
         Model {
             ctx: slv.ctx,
             z3_mdl: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let m = Z3_solver_get_model(slv.ctx.z3_ctx, slv.z3_slv);
                 Z3_model_inc_ref(slv.ctx.z3_ctx, m);
                 m
@@ -22,7 +20,6 @@ impl<'ctx> Model<'ctx> {
         Model {
             ctx: opt.ctx,
             z3_mdl: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let m = Z3_optimize_get_model(opt.ctx.z3_ctx, opt.z3_opt);
                 Z3_model_inc_ref(opt.ctx.z3_ctx, m);
                 m
@@ -36,7 +33,6 @@ impl<'ctx> Model<'ctx> {
     {
         let mut tmp: Z3_ast = ast.get_z3_ast();
         let res = {
-            let guard = Z3_MUTEX.lock().unwrap();
             unsafe {
                 Z3_model_eval(
                     self.ctx.z3_ctx,
@@ -72,7 +68,6 @@ impl<'ctx> std::fmt::Display for Model<'ctx> {
 
 impl<'ctx> Drop for Model<'ctx> {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_model_dec_ref(self.ctx.z3_ctx, self.z3_mdl) };
     }
 }

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -5,7 +5,6 @@ use z3_sys::*;
 use Context;
 use Model;
 use Optimize;
-use Z3_MUTEX;
 
 impl<'ctx> Optimize<'ctx> {
     /// Create a new optimize context.
@@ -13,7 +12,6 @@ impl<'ctx> Optimize<'ctx> {
         Optimize {
             ctx,
             z3_opt: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let opt = Z3_mk_optimize(ctx.z3_ctx);
                 Z3_optimize_inc_ref(ctx.z3_ctx, opt);
                 opt
@@ -28,7 +26,6 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::maximize()`](#method.maximize)
     /// - [`Optimize::minimize()`](#method.minimize)
     pub fn assert(&self, ast: &impl Ast<'ctx>) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_optimize_assert(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
     }
 
@@ -39,7 +36,6 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::assert()`](#method.assert)
     /// - [`Optimize::minimize()`](#method.minimize)
     pub fn maximize(&self, ast: &impl Ast<'ctx>) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_optimize_maximize(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
     }
 
@@ -50,7 +46,6 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::assert()`](#method.assert)
     /// - [`Optimize::maximize()`](#method.maximize)
     pub fn minimize(&self, ast: &impl Ast<'ctx>) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_optimize_minimize(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
     }
 
@@ -64,7 +59,6 @@ impl<'ctx> Optimize<'ctx> {
     ///
     /// - [`Optimize::pop()`](#method.pop)
     pub fn push(&self) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_optimize_push(self.ctx.z3_ctx, self.z3_opt) };
     }
 
@@ -79,7 +73,6 @@ impl<'ctx> Optimize<'ctx> {
     ///
     /// - [`Optimize::push()`](#method.push)
     pub fn pop(&self) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_optimize_pop(self.ctx.z3_ctx, self.z3_opt) };
     }
 
@@ -89,7 +82,6 @@ impl<'ctx> Optimize<'ctx> {
     ///
     /// - [`Optimize::get_model()`](#method.get_model)
     pub fn check(&self) -> bool {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_optimize_check(self.ctx.z3_ctx, self.z3_opt) == Z3_L_TRUE }
     }
 
@@ -120,7 +112,6 @@ impl<'ctx> fmt::Display for Optimize<'ctx> {
 
 impl<'ctx> Drop for Optimize<'ctx> {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_optimize_dec_ref(self.ctx.z3_ctx, self.z3_opt) };
     }
 }

--- a/z3/src/solver.rs
+++ b/z3/src/solver.rs
@@ -6,7 +6,6 @@ use z3_sys::*;
 use Context;
 use Model;
 use Solver;
-use Z3_MUTEX;
 
 impl<'ctx> Solver<'ctx> {
     /// Create a new solver. This solver is a "combined solver"
@@ -51,7 +50,6 @@ impl<'ctx> Solver<'ctx> {
         Solver {
             ctx,
             z3_slv: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let s = Z3_mk_solver(ctx.z3_ctx);
                 Z3_solver_inc_ref(ctx.z3_ctx, s);
                 s
@@ -63,7 +61,6 @@ impl<'ctx> Solver<'ctx> {
         Solver {
             ctx: dest,
             z3_slv: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let s = Z3_solver_translate(self.ctx.z3_ctx, self.z3_slv, dest.z3_ctx);
                 Z3_solver_inc_ref(dest.z3_ctx, s);
                 s
@@ -81,7 +78,6 @@ impl<'ctx> Solver<'ctx> {
     ///
     /// - [`Solver::assert_and_track()`](#method.assert_and_track)
     pub fn assert(&self, ast: &ast::Bool<'ctx>) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_assert(self.ctx.z3_ctx, self.z3_slv, ast.z3_ast) };
     }
 
@@ -100,13 +96,11 @@ impl<'ctx> Solver<'ctx> {
     ///
     /// - [`Solver::assert()`](#method.assert)
     pub fn assert_and_track(&self, ast: &ast::Bool<'ctx>, p: &ast::Bool<'ctx>) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_assert_and_track(self.ctx.z3_ctx, self.z3_slv, ast.z3_ast, p.z3_ast) };
     }
 
     /// Remove all assertions from the solver.
     pub fn reset(&self) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_reset(self.ctx.z3_ctx, self.z3_slv) };
     }
 
@@ -134,7 +128,6 @@ impl<'ctx> Solver<'ctx> {
     /// [model construction is enabled]: struct.Config.html#method.set_model_generation
     /// [proof generation was enabled]: struct.Config.html#method.set_proof_generation
     pub fn check(&self) -> bool {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_check(self.ctx.z3_ctx, self.z3_slv) == Z3_L_TRUE }
     }
 
@@ -150,7 +143,6 @@ impl<'ctx> Solver<'ctx> {
     ///
     /// - [`Solver::check()`](#method.check)
     pub fn check_assumptions(&self, assumptions: &[ast::Bool<'ctx>]) -> bool {
-        let guard = Z3_MUTEX.lock().unwrap();
         let a: Vec<Z3_ast> = assumptions.iter().map(|a| a.z3_ast).collect();
         unsafe {
             Z3_solver_check_assumptions(self.ctx.z3_ctx, self.z3_slv, a.len() as u32, a.as_ptr())
@@ -166,7 +158,6 @@ impl<'ctx> Solver<'ctx> {
     ///
     /// - [`Solver::pop()`](#method.pop)
     pub fn push(&self) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_push(self.ctx.z3_ctx, self.z3_slv) };
     }
 
@@ -176,7 +167,6 @@ impl<'ctx> Solver<'ctx> {
     ///
     /// - [`Solver::push()`](#method.push)
     pub fn pop(&self, n: u32) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_pop(self.ctx.z3_ctx, self.z3_slv, n) };
     }
 
@@ -206,7 +196,6 @@ impl<'ctx> Solver<'ctx> {
     // This seems to actually return an Ast with kind `SortKind::Unknown`, which we don't
     // have an Ast subtype for yet.
     pub fn get_proof(&self) -> impl Ast<'ctx> {
-        let guard = Z3_MUTEX.lock().unwrap();
         ast::Dynamic::new(self.ctx, unsafe {
             Z3_solver_get_proof(self.ctx.z3_ctx, self.z3_slv)
         })
@@ -229,7 +218,6 @@ impl<'ctx> fmt::Display for Solver<'ctx> {
 
 impl<'ctx> Drop for Solver<'ctx> {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_dec_ref(self.ctx.z3_ctx, self.z3_slv) };
     }
 }

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -6,16 +6,12 @@ use Context;
 use FuncDecl;
 use Sort;
 use Symbol;
-use Z3_MUTEX;
 
 impl<'ctx> Sort<'ctx> {
     pub fn uninterpreted(ctx: &'ctx Context, name: Symbol) -> Sort<'ctx> {
         Sort {
             ctx,
-            z3_sort: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
-                Z3_mk_uninterpreted_sort(ctx.z3_ctx, name.as_z3_symbol(ctx))
-            },
+            z3_sort: unsafe { Z3_mk_uninterpreted_sort(ctx.z3_ctx, name.as_z3_symbol(ctx)) },
         }
     }
 
@@ -23,7 +19,6 @@ impl<'ctx> Sort<'ctx> {
         Sort {
             ctx,
             z3_sort: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let s = Z3_mk_bool_sort(ctx.z3_ctx);
                 Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, s));
                 s
@@ -35,7 +30,6 @@ impl<'ctx> Sort<'ctx> {
         Sort {
             ctx,
             z3_sort: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let s = Z3_mk_int_sort(ctx.z3_ctx);
                 Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, s));
                 s
@@ -47,7 +41,6 @@ impl<'ctx> Sort<'ctx> {
         Sort {
             ctx,
             z3_sort: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let s = Z3_mk_real_sort(ctx.z3_ctx);
                 Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, s));
                 s
@@ -59,7 +52,6 @@ impl<'ctx> Sort<'ctx> {
         Sort {
             ctx,
             z3_sort: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let s = Z3_mk_bv_sort(ctx.z3_ctx, sz as ::std::os::raw::c_uint);
                 Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, s));
                 s
@@ -71,7 +63,6 @@ impl<'ctx> Sort<'ctx> {
         Sort {
             ctx,
             z3_sort: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let s = Z3_mk_array_sort(ctx.z3_ctx, domain.z3_sort, range.z3_sort);
                 Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, s));
                 s
@@ -83,7 +74,6 @@ impl<'ctx> Sort<'ctx> {
         Sort {
             ctx,
             z3_sort: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let s = Z3_mk_set_sort(ctx.z3_ctx, elt.z3_sort);
                 Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, s));
                 s


### PR DESCRIPTION
All bindings types contain raw pointers. Types with raw pointers are not Send (https://doc.rust-lang.org/nomicon/send-and-sync.html). So bindings types cannot be send to other threads. Hence we don't need a global lock.