### PR TITLE
Fix tests

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -677,7 +677,7 @@ impl<'ctx> BV<'ctx> {
     /// assert!(solver.check());
     /// let model = solver.get_model();
     ///
-    /// assert_eq!(-3, model.eval(&x).unwrap().as_i64().expect("as_i64() shouldn't fail"));
+    /// assert_eq!(-3, model.eval(&x.to_int(true)).unwrap().as_i64().expect("as_i64() shouldn't fail"));
     /// ```
     pub fn from_int(ast: &Int<'ctx>, sz: u32) -> BV<'ctx> {
         Self::new(ast.ctx, unsafe {


### PR DESCRIPTION
This makes ast::Dynamic not an enum, but just another Ast variant. When it was an enum, the Z3 enumeration type could not be represented as there was no Ast variant. Dynamic is now used both when types are not known at compile time and also when there is now Ast variant like for enumeration. During that I also moved more code into macros to considerably reduce duplication and code size.

There is a caveat: Z3 has no `Z3_sort_kind` for set sorts, so dynamic conversion to set sorts is not possible. I am not sure how to work around that. This is probably an artefact of how Z3 represents sets.

The second commit simply adds a cast in a test case to make it work.