### PR TITLE
Add datatype variant of Ast and a builder

### DIFF
--- a/z3/src/datatype_builder.rs
+++ b/z3/src/datatype_builder.rs
@@ -1,0 +1,113 @@
+use std::{convert::TryInto, ptr::null_mut};
+use z3_sys::*;
+use {Context, DatatypeSort, DatatypeBuilder, DatatypeVariant, FuncDecl, Sort,Symbol};
+
+impl<'ctx> DatatypeBuilder<'ctx> {
+    pub fn new(ctx: &'ctx Context) -> Self {
+        Self {
+            ctx,
+            variants: Vec::new(),
+        }
+    }
+
+    pub fn variant(mut self, name: &str, fields: &[(&str, &Sort)]) -> Self {
+        let recognizer_name_sym = Symbol::String(format!("is-{}", name)).as_z3_symbol(self.ctx);
+        let name_sym = Symbol::String(name.to_string()).as_z3_symbol(self.ctx);
+
+        assert!(fields
+            .iter()
+            .all(|(name, sort)| sort.ctx.z3_ctx == self.ctx.z3_ctx));
+
+        let mut field_names: Vec<Z3_symbol> = Vec::with_capacity(fields.len());
+        let mut field_sorts = Vec::with_capacity(fields.len());
+
+        for (name, sort) in fields {
+            field_names.push(Symbol::String(name.to_string()).as_z3_symbol(self.ctx));
+            field_sorts.push(sort.z3_sort);
+        }
+
+        // This is unused.
+        // Z3 expects sort_refs in Z3_mk_constructor to be valid, so create it here.
+        let mut sort_refs = Vec::new();
+        sort_refs.resize(fields.len(), 0);
+
+        let constructor = unsafe {
+            Z3_mk_constructor(
+                self.ctx.z3_ctx,
+                name_sym,
+                recognizer_name_sym,
+                fields.len().try_into().unwrap(),
+                field_names.as_ptr(),
+                field_sorts.as_ptr(),
+                sort_refs.as_mut_ptr(),
+            )
+        };
+
+        self.variants.push((fields.len(), constructor));
+        self
+    }
+
+    pub fn finish(self, name: impl Into<Symbol>) -> DatatypeSort<'ctx> {
+        let mut constructors: Vec<_> = self.variants.iter().map(|i| i.1).collect();
+        let name_sym = name.into().as_z3_symbol(self.ctx);
+
+        let sort = unsafe {
+            let s = Z3_mk_datatype(
+                self.ctx.z3_ctx,
+                name_sym,
+                constructors.len().try_into().unwrap(),
+                constructors.as_mut_ptr(),
+            );
+            Z3_inc_ref(self.ctx.z3_ctx, Z3_sort_to_ast(self.ctx.z3_ctx, s));
+            Sort {
+                ctx: self.ctx,
+                z3_sort: s,
+            }
+        };
+
+        // create independent fields
+        let (ctx, variants) = (self.ctx, self.variants);
+
+        let variants = variants
+            .into_iter()
+            .map(|(num_fields, constructor)| {
+                let mut constructor_func: Z3_func_decl = null_mut();
+                let mut tester: Z3_func_decl = null_mut();
+                let mut accessors: Vec<Z3_func_decl> = Vec::new();
+                accessors.resize(num_fields, null_mut());
+
+                unsafe {
+                    // fill fields
+                    Z3_query_constructor(
+                        ctx.z3_ctx,
+                        constructor,
+                        num_fields.try_into().unwrap(),
+                        &mut constructor_func,
+                        &mut tester,
+                        accessors.as_mut_ptr(),
+                    );
+
+                    // convert to Rust types
+                    let constructor = FuncDecl::from_raw(ctx, constructor_func);
+                    let tester = FuncDecl::from_raw(ctx, tester);
+                    let accessors = accessors
+                        .iter()
+                        .map(|f| FuncDecl::from_raw(ctx, *f))
+                        .collect();
+
+                    DatatypeVariant {
+                        constructor,
+                        tester,
+                        accessors,
+                    }
+                }
+            })
+            .collect();
+
+        DatatypeSort {
+            ctx: self.ctx,
+            sort,
+            variants,
+        }
+    }
+}

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -16,20 +16,24 @@ impl<'ctx> FuncDecl<'ctx> {
 
         let domain: Vec<_> = domain.iter().map(|s| s.z3_sort).collect();
 
-        Self {
-            ctx,
-            z3_func_decl: unsafe {
-                let f = Z3_mk_func_decl(
+        unsafe {
+            Self::from_raw(
+                ctx,
+                Z3_mk_func_decl(
                     ctx.z3_ctx,
                     name.into().as_z3_symbol(ctx),
                     domain.len().try_into().unwrap(),
                     domain.as_ptr(),
                     range.z3_sort,
-                );
-                Z3_inc_ref(ctx.z3_ctx, Z3_func_decl_to_ast(ctx.z3_ctx, f));
-                f
-            },
+                ),
+            )
         }
+    }
+
+    pub unsafe fn from_raw(ctx: &'ctx Context, z3_func_decl: Z3_func_decl) -> Self {
+        Z3_inc_ref(ctx.z3_ctx, Z3_func_decl_to_ast(ctx.z3_ctx, z3_func_decl));
+
+        Self { ctx, z3_func_decl }
     }
 
     /// Return the number of arguments of a function declaration.

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -13,6 +13,7 @@ use z3_sys::*;
 pub mod ast;
 mod config;
 mod context;
+mod datatype_builder;
 mod func_decl;
 mod model;
 mod optimize;
@@ -89,4 +90,52 @@ pub struct Optimize<'ctx> {
 pub struct FuncDecl<'ctx> {
     ctx: &'ctx Context,
     z3_func_decl: Z3_func_decl,
+}
+
+/// Build a datatype sort.
+///
+/// Example:
+/// ```
+/// # use z3::{ast::Int, Config, Context, DatatypeBuilder, Solver, Sort, ast::{Ast, Datatype}};
+/// # let cfg = Config::new();
+/// # let ctx = Context::new(&cfg);
+/// # let solver = Solver::new(&ctx);
+/// // Like Rust's Option<int> type
+/// let option_int = DatatypeBuilder::new(&ctx)
+///         .variant("None", &[])
+///         .variant("Some", &[("value", &ctx.int_sort())])
+///         .finish("OptionInt");
+///
+/// // Assert x.is_none()
+/// let x = Datatype::new_const(&ctx, "x", &option_int.sort);
+/// solver.assert(&option_int.variants[0].tester.apply(&[&x.into()]).as_bool().unwrap());
+///
+/// // Assert y == Some(3)
+/// let y = Datatype::new_const(&ctx, "y", &option_int.sort);
+/// let value = option_int.variants[1].constructor.apply(&[&Int::from_i64(&ctx, 3).into()]);
+/// solver.assert(&y._eq(&value.as_datatype().unwrap()));
+///
+/// assert!(solver.check());
+/// let model = solver.get_model();
+///
+/// // Get the value out of Some(3)
+/// let ast = option_int.variants[1].accessors[0].apply(&[&y.into()]);
+/// assert_eq!(3, model.eval(&ast.as_int().unwrap()).unwrap().as_i64().unwrap());
+/// ```
+pub struct DatatypeBuilder<'ctx> {
+    ctx: &'ctx Context,
+    // num_fields and constructor
+    variants: Vec<(usize, Z3_constructor)>,
+}
+
+pub struct DatatypeVariant<'ctx> {
+    pub constructor: FuncDecl<'ctx>,
+    pub tester: FuncDecl<'ctx>,
+    pub accessors: Vec<FuncDecl<'ctx>>,
+}
+
+pub struct DatatypeSort<'ctx> {
+    ctx: &'ctx Context,
+    pub sort: Sort<'ctx>,
+    pub variants: Vec<DatatypeVariant<'ctx>>,
 }

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -136,6 +136,12 @@ impl<'ctx> Sort<'ctx> {
 
         (sort, enum_consts, enum_testers)
     }
+
+    pub fn kind(&self) -> SortKind {
+        unsafe {
+            Z3_get_sort_kind(self.ctx.z3_ctx, self.z3_sort)
+        }
+    }
 }
 
 impl<'ctx> fmt::Display for Sort<'ctx> {


### PR DESCRIPTION
This creates a way to construct and use Z3 datatypes, which are like Rust enums. There is no support yet for recursive datatypes. Also, accesses are by index and hence a bit unwieldy, but it works.
I don't see a way to emulate Python's nice API in Rust, maybe we can improve on this in the future.