### PR TITLE
Bugfix for Sort refcounting

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -156,10 +156,9 @@ pub trait Ast<'ctx>: Sized {
 
     /// Get the [`Sort`](../struct.Sort.html) of the `Ast`
     fn get_sort(&self) -> Sort<'ctx> {
-        Sort {
-            ctx: self.get_ctx(),
-            z3_sort: unsafe { Z3_get_sort(self.get_ctx().z3_ctx, self.get_z3_ast()) },
-        }
+        Sort::new(self.get_ctx(), unsafe {
+            Z3_get_sort(self.get_ctx().z3_ctx, self.get_z3_ast())
+        })
     }
 }
 

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -58,24 +58,36 @@ pub enum Symbol {
 }
 
 /// Sorts represent the various 'types' of [`Ast`s](trait.Ast.html).
+//
+// Note for in-crate users: Never construct a `Sort` directly; only use
+// `Sort::new()` which handles Z3 refcounting properly.
 pub struct Sort<'ctx> {
     ctx: &'ctx Context,
     z3_sort: Z3_sort,
 }
 
 /// (Incremental) solver, possibly specialized by a particular tactic or logic.
+//
+// Note for in-crate users: Never construct a `Solver` directly; only use
+// `Solver::new()` which handles Z3 refcounting properly.
 pub struct Solver<'ctx> {
     ctx: &'ctx Context,
     z3_slv: Z3_solver,
 }
 
 /// Model for the constraints inserted into the logical context.
+//
+// Note for in-crate users: Never construct a `Model` directly; only use
+// `Model::new()` which handles Z3 refcounting properly.
 pub struct Model<'ctx> {
     ctx: &'ctx Context,
     z3_mdl: Z3_model,
 }
 
 /// Context for solving optimization queries.
+//
+// Note for in-crate users: Never construct an `Optimize` directly; only use
+// `Optimize::new()` which handles Z3 refcounting properly.
 pub struct Optimize<'ctx> {
     ctx: &'ctx Context,
     z3_opt: Z3_optimize,
@@ -86,6 +98,9 @@ pub struct Optimize<'ctx> {
 /// The declaration assigns a name, a sort (i.e., type), and for function
 /// the sort (i.e., type) of each of its arguments. Note that, in Z3,
 /// a constant is a function with 0 arguments.
+//
+// Note for in-crate users: Never construct a `FuncDecl` directly; only use
+// `FuncDecl::new()` which handles Z3 refcounting properly.
 pub struct FuncDecl<'ctx> {
     ctx: &'ctx Context,
     z3_func_decl: Z3_func_decl,


### PR DESCRIPTION
Fixes #42.

The function `Ast::get_sort()` was constructing a `Sort` without doing `Z3_inc_ref` on the underlying Z3 sort object. Rather than just add the `Z3_inc_ref`, I refactored how `Sort` objects are constructed in order to hopefully avoid the problem in the future (and also reduce code duplication in sort.rs).  

While doing this, I discovered that `Sort::uninterpreted()` seemed to have a similar problem, so this PR makes sure that that function also properly performs `Z3_inc_ref` when constructing its `Sort`.

Finally, I added notes in `lib.rs` to hopefully help future developers avoid similar mistakes in the future. 