### PR TITLE
Add a binding for Z3_simplify()

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -161,6 +161,15 @@ pub trait Ast<'ctx>: Sized {
             z3_sort: unsafe { Z3_get_sort(self.get_ctx().z3_ctx, self.get_z3_ast()) },
         }
     }
+
+    /// Simplify the `Ast`. Returns a new `Ast` which is equivalent,
+    /// but simplified using algebraic simplification rules, such as
+    /// constant propagation.
+    fn simplify(&self) -> Self {
+        Self::new(self.get_ctx(), unsafe {
+            Z3_simplify(self.get_ctx().z3_ctx, self.get_z3_ast())
+        })
+    }
 }
 
 macro_rules! impl_ast {


### PR DESCRIPTION
Add a binding for `Z3_simplify()`, which previously was exposed in `z3_sys` but not `z3`.  This operation applies to all `Ast`s.