### PR TITLE
add more links to the top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-This repository contains high level and low level Rust bindings
+This repository contains [high level] and [low level] Rust bindings
 for the [Z3 solver](https://github.com/Z3Prover/z3).
+
+[high level]: https://github.com/prove-rs/z3.rs/tree/master/z3
+[low level]: https://github.com/prove-rs/z3.rs/tree/master/z3-sys


### PR DESCRIPTION
It seemed like a good idea to me to have links here to the `z3` and `z3-sys` readmes.

Unrelatedly - what remains on the todo list before we get the next crates.io release of `z3`?