### PR TITLE
Add solver parameters

### DIFF
--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -24,6 +24,7 @@ mod optimize;
 mod solver;
 mod sort;
 mod symbol;
+mod params;
 
 // Z3 appears to be only mostly-threadsafe, a few initializers
 // and such race; so we mutex-guard all access to the library.
@@ -163,4 +164,9 @@ pub struct DatatypeSort<'ctx> {
     ctx: &'ctx Context,
     pub sort: Sort<'ctx>,
     pub variants: Vec<DatatypeVariant<'ctx>>,
+}
+
+pub struct Params<'ctx> {
+    ctx: &'ctx Context,
+    z3_params: Z3_params,
 }

--- a/z3/src/params.rs
+++ b/z3/src/params.rs
@@ -1,0 +1,66 @@
+use std::ffi::CStr;
+use std::fmt;
+use z3_sys::*;
+use Context;
+use Params;
+use Symbol;
+use Z3_MUTEX;
+
+impl<'ctx> Params<'ctx> {
+    pub fn new(ctx: &'ctx Context) -> Params<'ctx> {
+        Params {
+            ctx,
+            z3_params: unsafe {
+                let guard = Z3_MUTEX.lock().unwrap();
+                let p = Z3_mk_params(ctx.z3_ctx);
+                Z3_params_inc_ref(ctx.z3_ctx, p);
+                p
+            },
+        }
+    }
+
+    pub fn set_symbol<K: Into<Symbol>, V: Into<Symbol>>(&mut self, k: K, v: V) {
+        let guard = Z3_MUTEX.lock().unwrap();
+        unsafe {
+            Z3_params_set_symbol(
+                self.ctx.z3_ctx,
+                self.z3_params,
+                k.into().as_z3_symbol(self.ctx),
+                v.into().as_z3_symbol(self.ctx),
+            )
+        };
+    }
+
+    pub fn set_bool<K: Into<Symbol>>(&mut self, k: K, v: bool) {
+        let guard = Z3_MUTEX.lock().unwrap();
+        unsafe {
+            Z3_params_set_bool(
+                self.ctx.z3_ctx,
+                self.z3_params,
+                k.into().as_z3_symbol(self.ctx),
+                v,
+            )
+        };
+    }
+}
+
+impl<'ctx> fmt::Display for Params<'ctx> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let p =
+            unsafe { CStr::from_ptr(Z3_params_to_string(self.ctx.z3_ctx, self.z3_params) as *mut i8) };
+        if p.as_ptr().is_null() {
+            return Result::Err(fmt::Error);
+        }
+        match p.to_str() {
+            Ok(s) => write!(f, "{}", s),
+            Err(_) => Result::Err(fmt::Error),
+        }
+    }
+}
+
+impl<'ctx> Drop for Params<'ctx> {
+    fn drop(&mut self) {
+        let guard = Z3_MUTEX.lock().unwrap();
+        unsafe { Z3_params_dec_ref(self.ctx.z3_ctx, self.z3_params) };
+    }
+}

--- a/z3/src/solver.rs
+++ b/z3/src/solver.rs
@@ -6,6 +6,7 @@ use z3_sys::*;
 use Context;
 use Model;
 use Solver;
+use Params;
 use Z3_MUTEX;
 
 impl<'ctx> Solver<'ctx> {
@@ -210,6 +211,12 @@ impl<'ctx> Solver<'ctx> {
         ast::Dynamic::new(self.ctx, unsafe {
             Z3_solver_get_proof(self.ctx.z3_ctx, self.z3_slv)
         })
+    }
+
+    /// Set the current solver using the given parameters.
+    pub fn set_params(&self, params: &Params<'ctx>) {
+        let guard = Z3_MUTEX.lock().unwrap();
+        unsafe { Z3_solver_set_params(self.ctx.z3_ctx, self.z3_slv, params.z3_params) };
     }
 }
 

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -196,3 +196,20 @@ fn function_ref_count() {
 
     assert!(solver.check());
 }
+
+#[test]
+fn test_params() {
+    let _ = env_logger::try_init();
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+    let x = ast::Int::new_const(&ctx, "x");
+    let y = ast::Int::new_const(&ctx, "y");
+
+    let mut params = Params::new(&ctx);
+    params.set_bool("smt.mbqi", false);
+
+    let solver = Solver::new(&ctx);
+    solver.set_params(&params);
+    solver.assert(&x.gt(&y));
+    assert!(solver.check());
+}


### PR DESCRIPTION
I needed to set a parameter of the solver, so I added the `Params` structure and a `set_params` method to `Solver`.

Please double check the mutex and `unsafe` blocks before merging, because it's the first time that I use `z3_sys`.