### PR TITLE
implemented substitutions for Ast

### DIFF
--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -196,3 +196,20 @@ fn function_ref_count() {
 
     assert!(solver.check());
 }
+
+#[test]
+fn test_substitution() {
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+
+    let x = ast::Real::new_const(&ctx, "x");
+    let y = ast::Real::new_const(&ctx, "y");
+    let z = ast::Real::new_const(&ctx, "z");
+
+    let x_plus_y = x.add(&[&y]);
+    let x_plus_z = x.add(&[&z]);
+
+    let substitutions = &[(&y, &z)];
+
+    assert!(x_plus_y.substitute(substitutions) == x_plus_z);
+}


### PR DESCRIPTION
This PR adds a `substitute` method on the `Ast` trait with a default implementation. It just uses the `Z3_substitute` binding from `z3-sys` to do the actual substitution.

A unit test case was also added :) I will be happy to make additional changes based on maintainers' opinion.