### PR TITLE
Factor out SafeAstPtr and allow Ast trait objects

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -122,7 +122,7 @@ pub struct Datatype<'ctx>(SafeAstPtr<'ctx>);
 #[derive(Hash, Debug, PartialEq, Eq, Clone)]
 pub struct Dynamic<'ctx>(SafeAstPtr<'ctx>);
 
-macro_rules! for_each_static_typed_ast {
+macro_rules! for_each_ast {
     ($m:ident) => {
         $m!(Bool);
         $m!(Int);
@@ -131,12 +131,6 @@ macro_rules! for_each_static_typed_ast {
         $m!(Array);
         $m!(Set);
         $m!(Datatype);
-    };
-}
-
-macro_rules! for_each_ast {
-    ($m:ident) => {
-        for_each_static_typed_ast!($m);
         $m!(Dynamic);
     };
 }

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -31,7 +31,7 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::minimize()`](#method.minimize)
     pub fn assert(&self, ast: &impl Ast<'ctx>) {
         let guard = Z3_MUTEX.lock().unwrap();
-        unsafe { Z3_optimize_assert(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
+        unsafe { Z3_optimize_assert(self.ctx.z3_ctx, self.z3_opt, ast.get_ast_ptr().z3_ast) };
     }
 
     /// Add a maximization constraint.
@@ -42,7 +42,7 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::minimize()`](#method.minimize)
     pub fn maximize(&self, ast: &impl Ast<'ctx>) {
         let guard = Z3_MUTEX.lock().unwrap();
-        unsafe { Z3_optimize_maximize(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
+        unsafe { Z3_optimize_maximize(self.ctx.z3_ctx, self.z3_opt, ast.get_ast_ptr().z3_ast) };
     }
 
     /// Add a minimization constraint.
@@ -53,7 +53,7 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::maximize()`](#method.maximize)
     pub fn minimize(&self, ast: &impl Ast<'ctx>) {
         let guard = Z3_MUTEX.lock().unwrap();
-        unsafe { Z3_optimize_minimize(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
+        unsafe { Z3_optimize_minimize(self.ctx.z3_ctx, self.z3_opt, ast.get_ast_ptr().z3_ast) };
     }
 
     /// Create a backtracking point.
@@ -92,7 +92,7 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::get_model()`](#method.get_model)
     pub fn check(&self, assumptions: &[Bool<'ctx>]) -> SatResult {
         let guard = Z3_MUTEX.lock().unwrap();
-        let assumptions: Vec<Z3_ast> = assumptions.iter().map(|a| a.z3_ast).collect();
+        let assumptions: Vec<Z3_ast> = assumptions.iter().map(|a| a.get_ast_ptr().z3_ast).collect();
         match unsafe {
             Z3_optimize_check(
                 self.ctx.z3_ctx,

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -235,7 +235,6 @@ fn test_substitution() {
 
     let x_plus_y = x.add(&[&y]);
     let x_plus_z = x.add(&[&z]);
-
     let substitutions = &[(&y, &z)];
 
     assert!(x_plus_y.substitute(substitutions) == x_plus_z);


### PR DESCRIPTION
This commit is largely a refactor that centralizes the logic for Ast pointers into a `SafeAstPtr` type, rather than duplicating it across every AST struct (`Bool`, `Int`, etc.).

This allows us to rely on more Rust machinery (auto-derives) and makes safe vs. unsafe access to the z3 internals more explicit. It also removes the raw `Z3_ast` ptr from the public interface of `Ast` by allowing `Ast::new` to accept a `SafeAstPtr` rather than a raw `Z3_ast` ptr.

While I was at it, I moved the `Sized` restrictions onto the trait methods that required it, allowing trait objects a la `&dyn Ast` to exist. These could replace the methods where we have `& impl Ast` but I figured that's a task for another day.

If people think this new ptr is worthwhile I think there's a way to unify all of the various pointer types so they are automatically safe, but again I think that's best left to a future commit.