### PR TITLE
Feat: Add method get_ctx() to Solver

### DIFF
--- a/z3/src/solver.rs
+++ b/z3/src/solver.rs
@@ -73,6 +73,11 @@ impl<'ctx> Solver<'ctx> {
         }
     }
 
+    /// Return the context of the solver.
+    pub fn get_ctx(&self) -> &'ctx Context {
+        self.ctx
+    }
+
     /// Assert a constraint into the solver.
     ///
     /// The functions [`Solver::check()`](#method.check) and


### PR DESCRIPTION
This might be useful when we need to `assert` and make `ast` objects at the same time, like when doing symbolic execution. With this method, we can pass down `solver` as a parameter only but not pass down `context` simultaneously, thus making interfaces cleaner. 