### PR TITLE
Don't leak Z3 custom datatype sort constructors

### DIFF
--- a/z3/src/datatype_builder.rs
+++ b/z3/src/datatype_builder.rs
@@ -87,6 +87,10 @@ impl<'ctx> DatatypeBuilder<'ctx> {
                         accessors.as_mut_ptr(),
                     );
 
+                    // We don't need the raw constructor now that we have
+                    // converted it into a func decl.
+                    Z3_del_constructor(ctx.z3_ctx, constructor);
+
                     // convert to Rust types
                     let constructor = FuncDecl::from_raw(ctx, constructor_func);
                     let tester = FuncDecl::from_raw(ctx, tester);


### PR DESCRIPTION
We need to destroy the `Z3_constructor` after we've created the constructor function decl, tester function decl, and accessor function decls.