### PR TITLE
Include a note about static-link-z3

### DIFF
--- a/z3/README.md
+++ b/z3/README.md
@@ -21,7 +21,16 @@ Add it to your `Cargo.toml` like so:
 
 ```toml
 [dependencies]
-z3 = "0.4.0"
+z3 = "0.5.0"
+```
+
+**Note:** This library has a dependency on Z3. You will either need to
+have the Z3 dependency already installed, or you can statically link
+to our build of Z3 like so:
+
+```toml
+[dependencies]
+z3 = {version="0.5.0", features = ["static-link-z3"]}
 ```
 
 ## Support and Maintenance


### PR DESCRIPTION
First, I just want to say thanks for this crate 🎉🎉🎉

After adding the `z3 = "0.5.0"` dep to my `cargo.toml` file I was getting the following error on `cargo build`:

>linking with `cc` failed: exit code: 1
>... note: ld: library not found for -lz3

It wasn't immediately apparent to me that having to install the underlying Z3 library is a requirement for this crate.

This PR updates the readme to clarify that dependency, and help get folks up and running.