### PR TITLE
Rename static lib instead of copy

### DIFF
--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -53,8 +53,8 @@ fn build_z3() {
     if cfg!(target_os = "windows") {
         let from = lib.join("libz3.lib");
         let to = lib.join("z3.lib");
-        std::fs::copy(&from, &to).expect(&format!(
-            "failed to copy `{}` to `{}`",
+        std::fs::rename(&from, &to).expect(&format!(
+            "failed to rename `{}` to `{}`",
             from.display(),
             to.display()
         ));


### PR DESCRIPTION
The static library is quite large, ~250mb in my debug build.

This will help our CI a little bit where we cache build artifacts for faster incremental builds.