### PR TITLE
add std::ops implementations for BV, Int, Real and Bool

### DIFF
--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -24,6 +24,7 @@ mod context;
 mod datatype_builder;
 mod func_decl;
 mod model;
+mod ops;
 mod optimize;
 mod params;
 mod pattern;

--- a/z3/src/ops.rs
+++ b/z3/src/ops.rs
@@ -16,6 +16,12 @@ macro_rules! mk_const_int {
     };
 }
 
+macro_rules! mk_const_bool {
+    ($constant:expr, $function:ident, $val:expr, $other:expr) => {
+        $constant = Bool::from_bool($other.get_ctx(), $val);
+    };
+}
+
 macro_rules! impl_binary_op_raw {
     ($ty:ty, $rhs:ty, $output:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $function:ident) => {
         impl<'a, 'ctx> $base_trait<$rhs> for $ty {
@@ -134,6 +140,41 @@ macro_rules! impl_binary_op_without_numbers {
             $base_fn,
             $assign_fn,
             $function
+        );
+    };
+}
+
+macro_rules! impl_binary_op_bool {
+    ($ty:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $function:ident) => {
+        impl_binary_op_without_numbers!(
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function
+        );
+        impl_binary_op_assign_number_raw!(
+            $ty,
+            bool,
+            from_bool,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function,
+            mk_const_bool
+        );
+        impl_binary_op_number_raw!(
+            &'a $ty,
+            bool,
+            from_bool,
+            $ty,
+            $base_trait,
+            $base_fn,
+            $function,
+            mk_const_bool
         );
     };
 }
@@ -338,6 +379,40 @@ macro_rules! impl_binary_mult_op_without_numbers {
     };
 }
 
+macro_rules! impl_binary_mult_op_bool {
+    ($base_ty:ident, $ty:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $function:ident) => {
+        impl_binary_mult_op_without_numbers!(
+            $base_ty,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function
+        );
+        impl_binary_mult_op_assign_number_raw!(
+            $ty,
+            bool,
+            from_bool,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            mk_const_bool
+        );
+        impl_binary_mult_op_number_raw!(
+            &'a $ty,
+            bool,
+            from_bool,
+            $ty,
+            $base_trait,
+            $base_fn,
+            mk_const_bool
+        );
+    };
+}
+
 macro_rules! impl_binary_mult_op {
     ($base_ty:ident, $ty:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $construct_constant:ident) => {
         impl_binary_mult_op_without_numbers!(
@@ -514,7 +589,7 @@ impl_binary_op_without_numbers!(Real<'ctx>, Div, DivAssign, div, div_assign, div
 impl_unary_op!(Real<'ctx>, Neg, neg, unary_minus);
 
 // implementations for Bool
-impl_binary_mult_op_without_numbers!(
+impl_binary_mult_op_bool!(
     Bool,
     Bool<'ctx>,
     BitAnd,
@@ -523,7 +598,7 @@ impl_binary_mult_op_without_numbers!(
     bitand_assign,
     and
 );
-impl_binary_mult_op_without_numbers!(
+impl_binary_mult_op_bool!(
     Bool,
     Bool<'ctx>,
     BitOr,
@@ -532,5 +607,5 @@ impl_binary_mult_op_without_numbers!(
     bitor_assign,
     or
 );
-impl_binary_op_without_numbers!(Bool<'ctx>, BitXor, BitXorAssign, bitxor, bitxor_assign, xor);
+impl_binary_op_bool!(Bool<'ctx>, BitXor, BitXorAssign, bitxor, bitxor_assign, xor);
 impl_unary_op!(Bool<'ctx>, Not, not, not);

--- a/z3/src/ops.rs
+++ b/z3/src/ops.rs
@@ -1,0 +1,536 @@
+use crate::ast::{Ast, Bool, Int, Real, BV};
+use std::ops::{
+    Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
+    Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Sub, SubAssign,
+};
+
+macro_rules! mk_const_bv {
+    ($constant:expr, $function:ident, $val:expr, $other:expr) => {
+        $constant = BV::$function($other.get_ctx(), $val, $other.get_size());
+    };
+}
+
+macro_rules! mk_const_int {
+    ($constant:expr, $function:ident, $val:expr, $other:expr) => {
+        $constant = Int::$function($other.get_ctx(), $val);
+    };
+}
+
+macro_rules! impl_binary_op_raw {
+    ($ty:ty, $rhs:ty, $output:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $function:ident) => {
+        impl<'a, 'ctx> $base_trait<$rhs> for $ty {
+            type Output = $output;
+
+            fn $base_fn(self, rhs: $rhs) -> Self::Output {
+                (&self as &$output).$function(&rhs as &$output)
+            }
+        }
+    };
+}
+
+macro_rules! impl_binary_assign_op_raw {
+    ($ty:ty, $rhs:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $function:ident) => {
+        impl_binary_op_raw!(
+            $ty,
+            $rhs,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function
+        );
+        impl<'a, 'ctx> $assign_trait<$rhs> for $ty {
+            fn $assign_fn(&mut self, rhs: $rhs) {
+                *self = (self as &$ty).$function(&rhs as &$ty);
+            }
+        }
+    };
+}
+
+macro_rules! impl_binary_op_number_raw {
+    ($ty:ty, $other:ty, $other_fn:ident, $output:ty, $base_trait:ident, $base_fn:ident, $function:ident, $construct_constant:ident) => {
+        impl<'a, 'ctx> $base_trait<$other> for $ty {
+            type Output = $output;
+
+            fn $base_fn(self, rhs: $other) -> Self::Output {
+                let c;
+                $construct_constant!(c, $other_fn, rhs, self);
+                $base_trait::$base_fn(self, c)
+            }
+        }
+
+        impl<'a, 'ctx> $base_trait<$ty> for $other {
+            type Output = $output;
+
+            fn $base_fn(self, rhs: $ty) -> Self::Output {
+                let c;
+                $construct_constant!(c, $other_fn, self, rhs);
+                $base_trait::$base_fn(rhs, c)
+            }
+        }
+    };
+}
+
+macro_rules! impl_binary_op_assign_number_raw {
+    ($ty:ty, $other:ty, $other_fn:ident, $output:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $function:ident, $construct_constant:ident) => {
+        impl_binary_op_number_raw!(
+            $ty,
+            $other,
+            $other_fn,
+            $output,
+            $base_trait,
+            $base_fn,
+            $function,
+            $construct_constant
+        );
+
+        impl<'a, 'ctx> $assign_trait<$other> for $ty {
+            fn $assign_fn(&mut self, rhs: $other) {
+                let c;
+                $construct_constant!(c, $other_fn, rhs, self);
+                self.$assign_fn(c);
+            }
+        }
+    };
+}
+
+macro_rules! impl_binary_op_without_numbers {
+    ($ty:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $function:ident) => {
+        impl_binary_assign_op_raw!(
+            $ty,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function
+        );
+        impl_binary_assign_op_raw!(
+            $ty,
+            &'a $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function
+        );
+        impl_binary_op_raw!(
+            &'a $ty,
+            $ty,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function
+        );
+        impl_binary_op_raw!(
+            &'a $ty,
+            &'a $ty,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function
+        );
+    };
+}
+
+macro_rules! impl_binary_op {
+    ($ty:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $function:ident, $construct_constant:ident) => {
+        impl_binary_op_without_numbers!(
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function
+        );
+        impl_binary_op_assign_number_raw!(
+            $ty,
+            u64,
+            from_u64,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function,
+            $construct_constant
+        );
+        impl_binary_op_number_raw!(
+            &'a $ty,
+            u64,
+            from_u64,
+            $ty,
+            $base_trait,
+            $base_fn,
+            $function,
+            $construct_constant
+        );
+        impl_binary_op_assign_number_raw!(
+            $ty,
+            i64,
+            from_i64,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function,
+            $construct_constant
+        );
+        impl_binary_op_number_raw!(
+            &'a $ty,
+            i64,
+            from_i64,
+            $ty,
+            $base_trait,
+            $base_fn,
+            $function,
+            $construct_constant
+        );
+    };
+}
+
+macro_rules! impl_unary_op_raw {
+    ($ty:ty, $output:ty, $base_trait:ident, $base_fn:ident, $function:ident) => {
+        impl<'a, 'ctx> $base_trait for $ty {
+            type Output = $output;
+
+            fn $base_fn(self) -> Self::Output {
+                (&self as &$output).$function()
+            }
+        }
+    };
+}
+
+macro_rules! impl_unary_op {
+    ($ty:ty, $base_trait:ident, $base_fn:ident, $function:ident) => {
+        impl_unary_op_raw!($ty, $ty, $base_trait, $base_fn, $function);
+        impl_unary_op_raw!(&'a $ty, $ty, $base_trait, $base_fn, $function);
+    };
+}
+
+macro_rules! impl_binary_mult_op_raw {
+    ($base_ty:ident, $ty:ty, $rhs:ty, $output:ty, $base_trait:ident, $base_fn:ident, $function:ident) => {
+        impl<'a, 'ctx> $base_trait<$rhs> for $ty {
+            type Output = $output;
+
+            fn $base_fn(self, other: $rhs) -> Self::Output {
+                $base_ty::$function(self.get_ctx(), &[&self as &$output, &other as &$output])
+            }
+        }
+    };
+}
+
+macro_rules! impl_binary_mult_op_assign_raw {
+    ($base_ty:ident, $ty:ty, $rhs:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $function:ident) => {
+        impl_binary_mult_op_raw!($base_ty, $ty, $rhs, $ty, $base_trait, $base_fn, $function);
+
+        impl<'a, 'ctx> $assign_trait<$rhs> for $ty {
+            fn $assign_fn(&mut self, other: $rhs) {
+                *self = $base_ty::$function(self.get_ctx(), &[&self as &$ty, &other as &$ty])
+            }
+        }
+    };
+}
+
+macro_rules! impl_binary_mult_op_number_raw {
+    ($ty:ty, $other:ty, $other_fn:ident, $output:ty, $base_trait:ident, $base_fn:ident, $construct_constant:ident) => {
+        impl<'a, 'ctx> $base_trait<$other> for $ty {
+            type Output = $output;
+
+            fn $base_fn(self, rhs: $other) -> Self::Output {
+                let c;
+                $construct_constant!(c, $other_fn, rhs, self);
+                $base_trait::$base_fn(self, c)
+            }
+        }
+
+        impl<'a, 'ctx> $base_trait<$ty> for $other {
+            type Output = $output;
+
+            fn $base_fn(self, rhs: $ty) -> Self::Output {
+                let c;
+                $construct_constant!(c, $other_fn, self, rhs);
+                $base_trait::$base_fn(rhs, c)
+            }
+        }
+    };
+}
+
+macro_rules! impl_binary_mult_op_assign_number_raw {
+    ($ty:ty, $other:ty, $other_fn:ident, $output:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $construct_constant:ident) => {
+        impl_binary_mult_op_number_raw!(
+            $ty,
+            $other,
+            $other_fn,
+            $output,
+            $base_trait,
+            $base_fn,
+            $construct_constant
+        );
+
+        impl<'a, 'ctx> $assign_trait<$other> for $ty {
+            fn $assign_fn(&mut self, rhs: $other) {
+                let c;
+                $construct_constant!(c, $other_fn, rhs, self);
+                *self = (&self as &$ty).$base_fn(&c as &$ty)
+            }
+        }
+    };
+}
+
+macro_rules! impl_binary_mult_op_without_numbers {
+    ($base_ty:ident, $ty:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $function:ident) => {
+        impl_binary_mult_op_assign_raw!(
+            $base_ty,
+            $ty,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function
+        );
+        impl_binary_mult_op_assign_raw!(
+            $base_ty,
+            $ty,
+            &'a $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function
+        );
+        impl_binary_mult_op_raw!(
+            $base_ty,
+            &'a $ty,
+            $ty,
+            $ty,
+            $base_trait,
+            $base_fn,
+            $function
+        );
+        impl_binary_mult_op_raw!(
+            $base_ty,
+            &'a $ty,
+            &'a $ty,
+            $ty,
+            $base_trait,
+            $base_fn,
+            $function
+        );
+    };
+    ($base_ty:ident, $ty:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident) => {
+        impl_binary_mult_op_without_numbers!(
+            $base_ty,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $base_fn
+        );
+    };
+}
+
+macro_rules! impl_binary_mult_op {
+    ($base_ty:ident, $ty:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $construct_constant:ident) => {
+        impl_binary_mult_op_without_numbers!(
+            $base_ty,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn
+        );
+        impl_binary_mult_op_assign_number_raw!(
+            $ty,
+            u64,
+            from_u64,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $construct_constant
+        );
+        impl_binary_mult_op_number_raw!(
+            &'a $ty,
+            u64,
+            from_u64,
+            $ty,
+            $base_trait,
+            $base_fn,
+            $construct_constant
+        );
+        impl_binary_mult_op_assign_number_raw!(
+            $ty,
+            i64,
+            from_i64,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $construct_constant
+        );
+        impl_binary_mult_op_number_raw!(
+            &'a $ty,
+            i64,
+            from_i64,
+            $ty,
+            $base_trait,
+            $base_fn,
+            $construct_constant
+        );
+    };
+}
+
+// implementations for BV
+impl_binary_op!(
+    BV<'ctx>,
+    Add,
+    AddAssign,
+    add,
+    add_assign,
+    bvadd,
+    mk_const_bv
+);
+impl_binary_op!(
+    BV<'ctx>,
+    Sub,
+    SubAssign,
+    sub,
+    sub_assign,
+    bvsub,
+    mk_const_bv
+);
+impl_binary_op!(
+    BV<'ctx>,
+    Mul,
+    MulAssign,
+    mul,
+    mul_assign,
+    bvmul,
+    mk_const_bv
+);
+impl_binary_op!(
+    BV<'ctx>,
+    BitAnd,
+    BitAndAssign,
+    bitand,
+    bitand_assign,
+    bvand,
+    mk_const_bv
+);
+impl_binary_op!(
+    BV<'ctx>,
+    BitOr,
+    BitOrAssign,
+    bitor,
+    bitor_assign,
+    bvor,
+    mk_const_bv
+);
+impl_binary_op!(
+    BV<'ctx>,
+    BitXor,
+    BitXorAssign,
+    bitxor,
+    bitxor_assign,
+    bvxor,
+    mk_const_bv
+);
+impl_binary_op!(
+    BV<'ctx>,
+    Shl,
+    ShlAssign,
+    shl,
+    shl_assign,
+    bvshl,
+    mk_const_bv
+);
+impl_unary_op!(BV<'ctx>, Not, not, bvnot);
+impl_unary_op!(BV<'ctx>, Neg, neg, bvneg);
+
+// implementations for Int
+impl_binary_mult_op!(
+    Int,
+    Int<'ctx>,
+    Add,
+    AddAssign,
+    add,
+    add_assign,
+    mk_const_int
+);
+impl_binary_mult_op!(
+    Int,
+    Int<'ctx>,
+    Sub,
+    SubAssign,
+    sub,
+    sub_assign,
+    mk_const_int
+);
+impl_binary_mult_op!(
+    Int,
+    Int<'ctx>,
+    Mul,
+    MulAssign,
+    mul,
+    mul_assign,
+    mk_const_int
+);
+impl_binary_op!(
+    Int<'ctx>,
+    Div,
+    DivAssign,
+    div,
+    div_assign,
+    div,
+    mk_const_int
+);
+impl_binary_op!(
+    Int<'ctx>,
+    Rem,
+    RemAssign,
+    rem,
+    rem_assign,
+    rem,
+    mk_const_int
+);
+impl_unary_op!(Int<'ctx>, Neg, neg, unary_minus);
+
+// implementations for Real
+impl_binary_mult_op_without_numbers!(Real, Real<'ctx>, Add, AddAssign, add, add_assign);
+impl_binary_mult_op_without_numbers!(Real, Real<'ctx>, Sub, SubAssign, sub, sub_assign);
+impl_binary_mult_op_without_numbers!(Real, Real<'ctx>, Mul, MulAssign, mul, mul_assign);
+impl_binary_op_without_numbers!(Real<'ctx>, Div, DivAssign, div, div_assign, div);
+impl_unary_op!(Real<'ctx>, Neg, neg, unary_minus);
+
+// implementations for Bool
+impl_binary_mult_op_without_numbers!(
+    Bool,
+    Bool<'ctx>,
+    BitAnd,
+    BitAndAssign,
+    bitand,
+    bitand_assign,
+    and
+);
+impl_binary_mult_op_without_numbers!(
+    Bool,
+    Bool<'ctx>,
+    BitOr,
+    BitOrAssign,
+    bitor,
+    bitor_assign,
+    or
+);
+impl_binary_op_without_numbers!(Bool<'ctx>, BitXor, BitXorAssign, bitxor, bitxor_assign, xor);
+impl_unary_op!(Bool<'ctx>, Not, not, not);

--- a/z3/tests/ops.rs
+++ b/z3/tests/ops.rs
@@ -1,0 +1,152 @@
+extern crate z3;
+
+use z3::{
+    ast::{Bool, Int, Real, BV},
+    Config, Context,
+};
+
+#[test]
+fn test_bv_ops() {
+    let cfg = Config::default();
+    let ctx = Context::new(&cfg);
+
+    macro_rules! test_binary_op {
+        ($op:tt) => {
+            let a = BV::new_const(&ctx, "a", 5);
+            let b = BV::new_const(&ctx, "b", 5);
+            let _ = a $op b $op 2u64 $op 2i64;
+        };
+    }
+    macro_rules! test_op_assign {
+        ($op:tt, $assign:tt) => {
+            test_binary_op!($op);
+            let mut a = BV::new_const(&ctx, "a", 5);
+            let b = BV::new_const(&ctx, "b", 5);
+            a $assign b;
+            a $assign 2u64;
+            a $assign 2i64;
+        };
+    }
+    macro_rules! test_unary_op {
+        ($op:tt) => {
+            let a = BV::new_const(&ctx, "a", 5);
+            let _ = $op a;
+        };
+    }
+
+    test_op_assign!(+, +=);
+    test_op_assign!(-, -=);
+    test_op_assign!(*, *=);
+    test_op_assign!(&, &=);
+    test_op_assign!(|, |=);
+    test_op_assign!(^, ^=);
+    test_op_assign!(<<, <<=);
+    test_unary_op!(-);
+    test_unary_op!(!);
+}
+
+#[test]
+fn test_int_ops() {
+    let cfg = Config::default();
+    let ctx = Context::new(&cfg);
+
+    macro_rules! test_binary_op {
+        ($op:tt) => {
+            let a = Int::new_const(&ctx, "a");
+            let b = Int::new_const(&ctx, "b");
+            let _ = a $op b $op 2u64 $op 2i64;
+        };
+    }
+    macro_rules! test_op_assign {
+        ($op:tt, $assign:tt) => {
+            test_binary_op!($op);
+            let mut a = Int::new_const(&ctx, "a");
+            let b = Int::new_const(&ctx, "b");
+            a $assign b;
+            a $assign 2u64;
+            a $assign 2i64;
+        };
+    }
+    macro_rules! test_unary_op {
+        ($op:tt) => {
+            let a = Int::new_const(&ctx, "a");
+            let _ = $op a;
+        };
+    }
+
+    test_op_assign!(+, +=);
+    test_op_assign!(-, -=);
+    test_op_assign!(*, *=);
+    test_op_assign!(/, /=);
+    test_op_assign!(%, %=);
+    test_unary_op!(-);
+}
+
+#[test]
+fn test_real_ops() {
+    let cfg = Config::default();
+    let ctx = Context::new(&cfg);
+
+    macro_rules! test_binary_op {
+        ($op:tt) => {
+            let a = Real::new_const(&ctx, "a");
+            let b = Real::new_const(&ctx, "b");
+            let _ = a $op b;
+        };
+    }
+    macro_rules! test_op_assign {
+        ($op:tt, $assign:tt) => {
+            test_binary_op!($op);
+            let mut a = Real::new_const(&ctx, "a");
+            let b = Real::new_const(&ctx, "b");
+            a $assign b;
+        };
+    }
+    macro_rules! test_unary_op {
+        ($op:tt) => {
+            let a = Real::new_const(&ctx, "a");
+            let _ = $op a;
+        };
+    }
+
+    test_op_assign!(+, +=);
+    test_op_assign!(-, -=);
+    test_op_assign!(*, *=);
+    test_op_assign!(/, /=);
+    test_unary_op!(-);
+}
+
+#[test]
+fn test_bool_ops() {
+    let cfg = Config::default();
+    let ctx = Context::new(&cfg);
+
+    macro_rules! test_binary_op {
+        ($op:tt) => {
+            let a = Bool::new_const(&ctx, "a");
+            let b = Bool::new_const(&ctx, "b");
+            let _ = a $op b $op true $op false;
+        };
+    }
+    macro_rules! test_op_assign {
+        ($op:tt, $assign:tt) => {
+            test_binary_op!($op);
+            let mut a = Bool::new_const(&ctx, "a");
+            let b = Bool::new_const(&ctx, "b");
+            a $assign b;
+            a $assign true;
+            a $assign false;
+        };
+    }
+    macro_rules! test_unary_op {
+        ($op:tt) => {
+            let a = Bool::new_const(&ctx, "a");
+            let _ = $op a;
+        };
+    }
+
+    test_op_assign!(&, &=);
+    test_op_assign!(|, |=);
+    test_op_assign!(^, ^=);
+    test_unary_op!(!);
+}


### PR DESCRIPTION
this pr adds a lot of macros to implement various traits for datatypes

1. `BV`: Add, Sub, Mul, BitAnd, BitOr, BitXor, Shl, Not, Neg
implementations:
```rust
impl<'a, 'ctx> Add<&'a BV<'ctx>> for BV<'ctx> {}
impl<'a, 'ctx> Add<&'a BV<'ctx>> for &'a BV<'ctx> {}
impl<'a, 'ctx> Add<&'a BV<'ctx>> for u64 {}
impl<'a, 'ctx> Add<&'a BV<'ctx>> for i64 {}
impl<'a, 'ctx> Add<BV<'ctx>> for BV<'ctx> {}
impl<'a, 'ctx> Add<BV<'ctx>> for &'a BV<'ctx> {}
impl<'a, 'ctx> Add<BV<'ctx>> for u64 {}
impl<'a, 'ctx> Add<BV<'ctx>> for i64 {}
impl<'a, 'ctx> Add<i64> for BV<'ctx> {}
impl<'a, 'ctx> Add<i64> for &'a BV<'ctx> {}
impl<'a, 'ctx> Add<u64> for BV<'ctx> {}
impl<'a, 'ctx> Add<u64> for &'a BV<'ctx> {}
impl<'a, 'ctx> AddAssign<&'a BV<'ctx>> for BV<'ctx> {}
impl<'a, 'ctx> AddAssign<BV<'ctx>> for BV<'ctx> {}
impl<'a, 'ctx> AddAssign<i64> for BV<'ctx> {}
impl<'a, 'ctx> AddAssign<u64> for BV<'ctx> {}
impl<'a, 'ctx> BitAnd<&'a BV<'ctx>> for BV<'ctx> {}
// etc...
```
2. `Int`: Add, Sub, Mul, Div, Rem, Neg
implementations:
```rust
impl<'a, 'ctx> Add<&'a Int<'ctx>> for Int<'ctx> {}
impl<'a, 'ctx> Add<&'a Int<'ctx>> for &'a Int<'ctx> {}
impl<'a, 'ctx> Add<&'a Int<'ctx>> for u64 {}
impl<'a, 'ctx> Add<&'a Int<'ctx>> for i64 {}
impl<'a, 'ctx> Add<Int<'ctx>> for Int<'ctx> {}
impl<'a, 'ctx> Add<Int<'ctx>> for &'a Int<'ctx> {}
impl<'a, 'ctx> Add<Int<'ctx>> for u64 {}
impl<'a, 'ctx> Add<Int<'ctx>> for i64 {}
impl<'a, 'ctx> Add<i64> for Int<'ctx> {}
impl<'a, 'ctx> Add<i64> for &'a Int<'ctx> {}
impl<'a, 'ctx> Add<u64> for Int<'ctx> {}
impl<'a, 'ctx> Add<u64> for &'a Int<'ctx> {}
impl<'a, 'ctx> AddAssign<&'a Int<'ctx>> for Int<'ctx> {}
impl<'a, 'ctx> AddAssign<Int<'ctx>> for Int<'ctx> {}
impl<'a, 'ctx> AddAssign<i64> for Int<'ctx> {}
impl<'a, 'ctx> AddAssign<u64> for Int<'ctx> {}
impl<'a, 'ctx> Div<&'a Int<'ctx>> for Int<'ctx>
// etc...
```
3. `Real`: Add, Sub, Mul, Div, Neg
implementations:
```rust
impl<'a, 'ctx> Add<&'a Real<'ctx>> for Real<'ctx> {}
impl<'a, 'ctx> Add<&'a Real<'ctx>> for &'a Real<'ctx> {}
impl<'a, 'ctx> Add<Real<'ctx>> for Real<'ctx> {}
impl<'a, 'ctx> Add<Real<'ctx>> for &'a Real<'ctx> {}
impl<'a, 'ctx> AddAssign<&'a Real<'ctx>> for Real<'ctx> {}
impl<'a, 'ctx> AddAssign<Real<'ctx>> for Real<'ctx> {}
impl<'a, 'ctx> Div<&'a Real<'ctx>> for Real<'ctx> {}
// etc...
```
4. `Bool`: BitAnd, BitOr, BitXor, Not
implementations:
```rust
impl<'a, 'ctx> BitAnd<&'a Bool<'ctx>> for Bool<'ctx> {}
impl<'a, 'ctx> BitAnd<&'a Bool<'ctx>> for &'a Bool<'ctx> {}
impl<'a, 'ctx> BitAnd<Bool<'ctx>> for Bool<'ctx> {}
impl<'a, 'ctx> BitAnd<Bool<'ctx>> for &'a Bool<'ctx> {}
impl<'a, 'ctx> BitAndAssign<&'a Bool<'ctx>> for Bool<'ctx> {}
impl<'a, 'ctx> BitAndAssign<Bool<'ctx>> for Bool<'ctx> {}
impl<'a, 'ctx> BitOr<&'a Bool<'ctx>> for Bool<'ctx> {}
// etc...
```

some operations cannot be directly mapped to the traits because they need to know whether the values are signed eg. Shr for `BV`