### PR TITLE
[Fix] acquire mutex before translating Datatype

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1377,6 +1377,7 @@ impl<'ctx> Datatype<'ctx> {
     // When I try, it gives the error E0109 "lifetime arguments are not allowed for this type".
     pub fn translate<'dest_ctx>(&self, dest: &'dest_ctx Context) -> Datatype<'dest_ctx> {
         Datatype::new(dest, unsafe {
+            let guard = Z3_MUTEX.lock().unwrap();
             Z3_translate(self.ctx.z3_ctx, self.z3_ast, dest.z3_ctx)
         })
     }


### PR DESCRIPTION
`Datatype::translate()` is missing mutex acquisition before calling `Z3_translate()`