### PR TITLE
lib is not prepended on windows automatically, so to dynamically link…

### DIFF
--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -53,18 +53,6 @@ fn build_z3() {
 
     let lib = dst.join("lib");
 
-    // For some reason Z3 builds as `libz3.lib`, but on windows the "lib" prefix
-    // is not a convention.
-    if cfg!(target_os = "windows") {
-        let from = lib.join("libz3.lib");
-        let to = lib.join("z3.lib");
-        std::fs::rename(&from, &to).expect(&format!(
-            "failed to rename `{}` to `{}`",
-            from.display(),
-            to.display()
-        ));
-    }
-
     println!("cargo:rustc-link-search=native={}", lib.display());
     println!("cargo:rustc-link-lib=static=z3");
 }

--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -54,5 +54,9 @@ fn build_z3() {
     let lib = dst.join("lib");
 
     println!("cargo:rustc-link-search=native={}", lib.display());
-    println!("cargo:rustc-link-lib=static=z3");
+    if cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=static=libz3");
+    } else {
+        println!("cargo:rustc-link-lib=static=z3");
+    }
 }

--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -1559,7 +1559,6 @@ pub enum GoalPrec {
     UnderOver = generated::Z3_goal_prec::Z3_GOAL_UNDER_OVER as u32,
 }
 
-#[link(name = "z3")]
 extern "C" {
     /// Set a global (or module) parameter.
     /// This setting is shared by all Z3 contexts.
@@ -7482,3 +7481,11 @@ extern "C" {
     /// Best-effort quantifier elimination
     pub fn Z3_qe_lite(c: Z3_context, vars: Z3_ast_vector, body: Z3_ast) -> Z3_ast;
 }
+
+#[cfg(not(windows))]
+#[link(name = "z3")]
+extern "C" {}
+
+#[cfg(windows)]
+#[link(name = "libz3")]
+extern "C" {}


### PR DESCRIPTION
… a z3 install we must have an explicit libz3 link

Should fix #96, I tested it locally with a dynamically linked, self built z3