### PR TITLE
z3-sys: Add Fedora's `lib64` path to rustc's lib search path

### DIFF
--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -54,14 +54,21 @@ fn build_z3() {
     let mut found_lib_dir = false;
     for lib_dir in &[
         "lib",
-        // Fedora builds seem to use `lib64` rather than `lib` in some
-        // circumstances.
+        // Fedora builds seem to use `lib64` rather than `lib` for 64-bit
+        // builds.
         "lib64",
     ] {
-        let lib_dir = dst.join(lib_dir);
-        if lib_dir.exists() {
+        let full_lib_dir = dst.join(lib_dir);
+        if full_lib_dir.exists() {
+            if *lib_dir == "lib64" {
+                assert_eq!(
+                    std::env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap(),
+                    "64"
+                );
+            }
+            println!("cargo:rustc-link-search=native={}", full_lib_dir.display());
             found_lib_dir = true;
-            println!("cargo:rustc-link-search=native={}", lib_dir.display(),);
+            break;
         }
     }
     assert!(

--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -51,9 +51,24 @@ fn build_z3() {
         println!("cargo:rustc-link-lib={}", cxx);
     }
 
-    let lib = dst.join("lib");
+    let mut found_lib_dir = false;
+    for lib_dir in &[
+        "lib",
+        // Fedora builds seem to use `lib64` rather than `lib` in some
+        // circumstances.
+        "lib64",
+    ] {
+        let lib_dir = dst.join(lib_dir);
+        if lib_dir.exists() {
+            found_lib_dir = true;
+            println!("cargo:rustc-link-search=native={}", lib_dir.display(),);
+        }
+    }
+    assert!(
+        found_lib_dir,
+        "Should have found the lib directory for our built Z3"
+    );
 
-    println!("cargo:rustc-link-search=native={}", lib.display());
     if cfg!(target_os = "windows") {
         println!("cargo:rustc-link-lib=static=libz3");
     } else {


### PR DESCRIPTION
Apparently Fedora will use `lib64` instead of `lib` in some circumstances. This commit should fix the `static-link-z3` build for Fedora.

@julian-seward1, could you try pulling this branch and verifying that it fixes the build issues you are seeing? I'd add a CI job, but github only supports ubuntu. Thanks!

Fixes #98