### PR TITLE
ergonomics: remove necessity of into() where possible

### DIFF
--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -298,7 +298,7 @@ fn test_real_cmp() {
     let x = ast::Real::new_const(&ctx, "x");
     let x_plus_1 = ast::Real::add(&ctx, &[&x, &ast::Real::from_real(&ctx, 1, 1)]);
     // forall x, x < x + 1
-    let forall = ast::forall_const(&ctx, &[&x.clone().into()], &[], &x.lt(&x_plus_1).into());
+    let forall = ast::forall_const(&ctx, &[&x.clone().into()], &[], &x.lt(&x_plus_1));
 
     solver.assert(&forall.try_into().unwrap());
     assert_eq!(solver.check(), SatResult::Sat);
@@ -689,7 +689,7 @@ fn test_mutually_recursive_datatype() {
         .apply(&[&leaf_ten])
         .as_int()
         .unwrap();
-    solver.assert(&leaf_ten_val_is_ten._eq(&ten.clone().into()));
+    solver.assert(&leaf_ten_val_is_ten._eq(&ten.clone()));
     assert_eq!(solver.check(), SatResult::Sat);
 
     let nil = tree_list_sort.variants[0].constructor.apply(&[]);
@@ -719,7 +719,7 @@ fn test_mutually_recursive_datatype() {
     solver.assert(
         &tree_list_sort.variants[1].accessors[0]
             .apply(&[&tree_sort.variants[1].accessors[0].apply(&[&n2])])
-            ._eq(&n1)
+            ._eq(&n1),
     );
     assert_eq!(solver.check(), SatResult::Sat);
 }


### PR DESCRIPTION
Adding type parameters to these methods makes it possible to pass non-dynamic ast nodes. It can't be done for slice-accepting methods since those arguments *do* need to be dynamic.

Unfortunately, this is a breaking change that would require a version upgrade -- previous calls to these methods with an into() will fail to compile:

```
type annotations needed

cannot infer type for type parameter `A` declared on the function `forall_const`

note: cannot satisfy `_: z3::ast::Ast<'_>`
help: consider specifying the type arguments in the function call: `::<'ctx, A>`rustc(E0283)
lib.rs(301, 18): cannot infer type for type parameter `A` declared on the function `forall_const`
lib.rs(301, 70): this method call resolves to `T`
ast.rs(1477, 8): required by this bound in `z3::ast::forall_const`
```

So some discussion is needed on whether there is a better way of doing this, or if it's even worth breaking existing behavior.
