### PR TITLE
array store: use reference for index and value

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1212,7 +1212,7 @@ impl<'ctx> Array<'ctx> {
     /// and the `value` _must be_ of the array's `range` sort.
     //
     // We avoid the trinop! macro because the arguments have non-Self types
-    pub fn store<A1, A2>(&self, index: A1, value: A2) -> Self
+    pub fn store<A1, A2>(&self, index: &A1, value: &A2) -> Self
     where
         A1: Ast<'ctx>,
         A2: Ast<'ctx>,

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -790,3 +790,18 @@ fn test_dynamic_as_set() {
         .as_set()
         .is_none());
 }
+
+#[test]
+fn test_array_store_select() {
+    let _ = env_logger::try_init();
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+    let solver = Solver::new(&ctx);
+    let zero = ast::Int::from_u64(&ctx, 0);
+    let one = ast::Int::from_u64(&ctx, 1);
+    let set = ast::Array::new_const(&ctx, "integer_array", &Sort::int(&ctx), &Sort::int(&ctx))
+        .store(&zero, &one);
+
+    solver.assert(&set.select(&zero)._eq(&one.into()).not());
+    assert_eq!(solver.check(), SatResult::Unsat);
+}


### PR DESCRIPTION
Realized I missed making these references in #110 

Hope you didn't publish 0.8.0 to crates.io yet, sorry about that.