### PR TITLE
accept refs for the sort datatype accessor

### DIFF
--- a/z3/src/datatype_builder.rs
+++ b/z3/src/datatype_builder.rs
@@ -6,7 +6,7 @@ use {
     Symbol,
 };
 
-impl<'ctx> DatatypeBuilder<'ctx> {
+impl<'sort, 'ctx: 'sort> DatatypeBuilder<'sort, 'ctx> {
     pub fn new<S: Into<Symbol>>(ctx: &'ctx Context, name: S) -> Self {
         Self {
             ctx,
@@ -15,8 +15,12 @@ impl<'ctx> DatatypeBuilder<'ctx> {
         }
     }
 
-    pub fn variant(mut self, name: &str, fields: Vec<(&str, DatatypeAccessor<'ctx>)>) -> Self {
-        let mut accessor_vec: Vec<(String, DatatypeAccessor<'ctx>)> = Vec::new();
+    pub fn variant(
+        mut self,
+        name: &str,
+        fields: Vec<(&str, DatatypeAccessor<'sort, 'ctx>)>,
+    ) -> Self {
+        let mut accessor_vec: Vec<(String, DatatypeAccessor<'sort, 'ctx>)> = Vec::new();
         for (accessor_name, accessor) in fields {
             accessor_vec.push((accessor_name.to_string(), accessor));
         }
@@ -32,8 +36,8 @@ impl<'ctx> DatatypeBuilder<'ctx> {
     }
 }
 
-pub fn create_datatypes<'ctx>(
-    datatype_builders: Vec<DatatypeBuilder<'ctx>>,
+pub fn create_datatypes<'sort, 'ctx: 'sort>(
+    datatype_builders: Vec<DatatypeBuilder<'sort, 'ctx>>,
 ) -> Vec<DatatypeSort<'ctx>> {
     let num = datatype_builders.len();
     assert!(num > 0, "At least one DatatypeBuilder must be specified");

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -140,7 +140,7 @@ pub struct FuncDecl<'ctx> {
 /// .variant("None", vec![])
 /// .variant(
 ///     "Some",
-///     vec![("value", DatatypeAccessor::Sort(Sort::int(&ctx)))],
+///     vec![("value", DatatypeAccessor::Sort(&Sort::int(&ctx)))],
 /// )
 /// .finish();
 ///
@@ -161,15 +161,15 @@ pub struct FuncDecl<'ctx> {
 /// assert_eq!(3, model.eval(&ast.as_int().unwrap()).unwrap().as_i64().unwrap());
 /// ```
 #[derive(Debug)]
-pub struct DatatypeBuilder<'ctx> {
+pub struct DatatypeBuilder<'sort, 'ctx: 'sort> {
     ctx: &'ctx Context,
     name: Symbol,
-    constructors: Vec<(String, Vec<(String, DatatypeAccessor<'ctx>)>)>,
+    constructors: Vec<(String, Vec<(String, DatatypeAccessor<'sort, 'ctx>)>)>,
 }
 
 #[derive(Debug)]
-pub enum DatatypeAccessor<'ctx> {
-    Sort(Sort<'ctx>),
+pub enum DatatypeAccessor<'sort, 'ctx: 'sort> {
+    Sort(&'sort Sort<'ctx>),
     Datatype(Symbol),
 }
 

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -527,7 +527,7 @@ fn test_datatype_builder() {
         .variant("Nothing", vec![])
         .variant(
             "Just",
-            vec![("int", DatatypeAccessor::Sort(Sort::int(&ctx)))],
+            vec![("int", DatatypeAccessor::Sort(&Sort::int(&ctx)))],
         )
         .finish();
 
@@ -586,7 +586,7 @@ fn test_recursive_datatype() {
         .variant(
             "cons",
             vec![
-                ("car", DatatypeAccessor::Sort(Sort::int(&ctx))),
+                ("car", DatatypeAccessor::Sort(&Sort::int(&ctx))),
                 ("cdr", DatatypeAccessor::Datatype("List".into())),
             ],
         )
@@ -649,11 +649,10 @@ fn test_mutually_recursive_datatype() {
     let ctx = Context::new(&cfg);
     let solver = Solver::new(&ctx);
 
+    let int_sort = Sort::int(&ctx);
+
     let tree_builder = DatatypeBuilder::new(&ctx, "Tree")
-        .variant(
-            "leaf",
-            vec![("val", DatatypeAccessor::Sort(Sort::int(&ctx)))],
-        )
+        .variant("leaf", vec![("val", DatatypeAccessor::Sort(&int_sort))])
         .variant(
             "node",
             vec![("children", DatatypeAccessor::Datatype("TreeList".into()))],


### PR DESCRIPTION
this makes re-using a particular sort with accessors easier, since it
can just be referenced in the builder:

(psuedocode)
```rust
let some_complex_sort = Sort::set(&ctx, &Sort::set(...));
let datatype_using_that_sort = DatatypeBuilder::new(&ctx, "foo")
.variant("first", vec![("bar", &some_complex_sort)])
.variant("second", vec![("bar", &some_complex_sort), ("count", &Sort::int(&ctx))])
.finish();
```

It is backwards incompatible -- users of the builder would need to add a reference. Also, if the builder is not `finish`-ed immediately, the sort needs a let binding.
