### PR TITLE
Fixed get_proof deadlock

### DIFF
--- a/z3/src/solver.rs
+++ b/z3/src/solver.rs
@@ -267,14 +267,15 @@ impl<'ctx> Solver<'ctx> {
     // This seems to actually return an Ast with kind `SortKind::Unknown`, which we don't
     // have an Ast subtype for yet.
     pub fn get_proof(&self) -> Option<impl Ast<'ctx>> {
-        let guard = Z3_MUTEX.lock().unwrap();
-        Some(ast::Dynamic::new(self.ctx, unsafe {
-            let m = Z3_solver_get_proof(self.ctx.z3_ctx, self.z3_slv);
-            if m.is_null() {
-                return None;
-            }
-            m
-        }))
+        let m = unsafe {
+          let _guard = Z3_MUTEX.lock().unwrap();
+          Z3_solver_get_proof(self.ctx.z3_ctx, self.z3_slv)
+        };
+        if !m.is_null() {
+          return Some(ast::Dynamic::new(self.ctx, m));
+        } else {
+          return None;
+        }
     }
 
     /// Return a brief justification for an "unknown" result (i.e., `SatResult::Unknown`) for


### PR DESCRIPTION
I'm not sure exactly of the purpose of `Z3_MUTEX.lock().unwrap();` so I possibly am not locking properly, but there was a deadlock when calling this function (happened 100% of the time).