### PR TITLE
Expose Ast::decl() method to return FuncDecl

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use z3_sys::*;
 use Context;
+use FuncDecl;
 use Pattern;
 use Sort;
 use Symbol;
@@ -299,6 +300,23 @@ pub trait Ast<'ctx>: Sized + fmt::Debug + Into<Dynamic<'ctx>> {
     /// Note that constants are function applications with 0 arguments.
     fn is_const(&self) -> bool {
         self.is_app() && self.num_children() == 0
+    }
+
+    /// Return the `FuncDecl` of the `Ast`.
+    ///
+    /// This will panic if the `Ast` is not an app, i.e. if AstKind is not App
+    /// or Numeral.
+    fn decl(&self) -> FuncDecl<'ctx> {
+        let ctx = self.get_ctx();
+        let func_decl = unsafe {
+            let guard = Z3_MUTEX.lock().unwrap();
+            let app = Z3_to_app(ctx.z3_ctx, self.get_z3_ast());
+            assert!(!app.is_null(), "Ast has a null Z3_app.");
+            let func_decl = Z3_get_app_decl(ctx.z3_ctx, app);
+            assert!(!func_decl.is_null(), "Ast has a null Z3_func_decl.");
+            func_decl
+        };
+        unsafe { FuncDecl::from_raw(ctx, func_decl) }
     }
 }
 

--- a/z3/tests/ops.rs
+++ b/z3/tests/ops.rs
@@ -208,11 +208,17 @@ fn test_ast_attributes() {
 
     let a = Bool::new_const(&ctx, "a");
     let b = Bool::from_bool(&ctx, false);
+    let not_a = a.not();
+    let a_or_b = &Bool::or(&ctx, &[&a, &b]);
+    assert_eq!(b.decl().kind(), DeclKind::FALSE);
+    assert_eq!(not_a.decl().kind(), DeclKind::NOT);
+    assert_eq!(a_or_b.decl().kind(), DeclKind::OR);
+
     assert_ast_attributes(&a, true);
     assert_ast_attributes(&b, true);
     assert_ast_attributes(&Dynamic::from_ast(&a), true);
-    assert_ast_attributes(&a.not(), false);
-    assert_ast_attributes(&Bool::or(&ctx, &[&a, &b]), false);
+    assert_ast_attributes(&not_a, false);
+    assert_ast_attributes(a_or_b, false);
 
     assert_ast_attributes(
         &Array::new_const(&ctx, "arr", &Sort::int(&ctx), &Sort::bool(&ctx)),


### PR DESCRIPTION
In the C API, Ast nodes that are `expr` expose the underlyling `FuncDecl`, which allows introspection of the type and name of the node.

One question is about the check whether the `Ast` is an `app` or not.  It seems like by construction they are, but I don't have full confidence in this, and would love a second opinion!