### PR TITLE
Add accessors for Ast and FuncDecl

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -239,8 +239,9 @@ pub trait Ast<'ctx>: Sized + fmt::Debug + Into<Dynamic<'ctx>> {
         })
     }
 
-    /// Return the number of children of this AST node.
-    /// Leaf nodes (eg Bool consts) will return 0.
+    /// Return the number of children of this `Ast`.
+    ///
+    /// Leaf nodes (eg `Bool` consts) will return 0.
     fn num_children(&self) -> usize {
         let this_ctx = self.get_ctx().z3_ctx;
         unsafe {
@@ -250,8 +251,9 @@ pub trait Ast<'ctx>: Sized + fmt::Debug + Into<Dynamic<'ctx>> {
         }
     }
 
-    /// Return the nth child of this AST node.  Out-of-bound indices will
-    /// return none.
+    /// Return the `n`th child of this `Ast`.
+    ///
+    /// Out-of-bound indices will return `None`.
     fn nth_child(&self, idx: usize) -> Option<Dynamic<'ctx>> {
         if idx >= self.num_children() {
             None

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -77,6 +77,32 @@ impl<'ctx> FuncDecl<'ctx> {
             )
         })
     }
+
+    /// Return the `DeclKind` of this `FuncDecl`.
+    pub fn kind(&self) -> DeclKind {
+        unsafe {
+            let guard = Z3_MUTEX.lock().unwrap();
+            Z3_get_decl_kind(self.ctx.z3_ctx, self.z3_func_decl)
+        }
+    }
+
+    /// Return the name of this `FuncDecl`.
+    ///
+    /// Strings will return the `Symbol`.  Ints will have a `"k!"` prepended to
+    /// the `Symbol`.
+    pub fn name(&self) -> String {
+        unsafe {
+            let guard = Z3_MUTEX.lock().unwrap();
+            let z3_ctx = self.ctx.z3_ctx;
+            let symbol = Z3_get_decl_name(z3_ctx, self.z3_func_decl);
+            match Z3_get_symbol_kind(z3_ctx, symbol) {
+                SymbolKind::String => CStr::from_ptr(Z3_get_symbol_string(z3_ctx, symbol))
+                    .to_string_lossy()
+                    .into_owned(),
+                SymbolKind::Int => format!("k!{}", Z3_get_symbol_int(z3_ctx, symbol)),
+            }
+        }
+    }
 }
 
 impl<'ctx> fmt::Display for FuncDecl<'ctx> {

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -127,6 +127,8 @@ pub struct FuncDecl<'ctx> {
     z3_func_decl: Z3_func_decl,
 }
 
+pub use z3_sys::DeclKind;
+
 /// Build a datatype sort.
 ///
 /// Example:


### PR DESCRIPTION
These are some of the accessors found in the Python and C++ APIs.

Also included is a commit that standardizes some documentation formats.