### PR TITLE
Add String::as_string() method

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1053,6 +1053,27 @@ impl<'ctx> String<'ctx> {
         }))
     }
 
+    /// Retrieves the underlying `std::string::String`
+    ///
+    /// If this is not a constant `z3::ast::String`, return `None`.
+    ///
+    /// Note that `to_string()` provided by `std::string::ToString` (which uses
+    /// `std::fmt::Display`) returns an escaped string. In contrast,
+    /// `z3::ast::String::from_str(&ctx, s).unwrap().as_string()` returns a
+    /// `String` equal to the original value.
+    pub fn as_string(&self) -> Option<std::string::String> {
+        let z3_ctx = self.get_ctx().z3_ctx;
+        unsafe {
+            let guard = Z3_MUTEX.lock().unwrap();
+            let bytes = Z3_get_string(z3_ctx, self.get_z3_ast());
+            if bytes.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(bytes).to_string_lossy().into_owned())
+            }
+        }
+    }
+
     varop! {
         /// Appends the argument strings to `Self`
         concat(Z3_mk_seq_concat, String<'ctx>);

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -442,6 +442,21 @@ fn test_string_suffix() {
     assert_eq!(solver.check(), SatResult::Sat)
 }
 
+fn assert_string_roundtrip(source: &str) {
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+    let expr = ast::String::from_str(&ctx, source).unwrap();
+    assert_eq!(&expr.as_string().unwrap(), source);
+}
+
+#[test]
+fn test_string_as_string() {
+    assert_string_roundtrip("x");
+    assert_string_roundtrip("'x'");
+    assert_string_roundtrip(r#""x""#);
+    assert_string_roundtrip(r#"\\"x\\""#);
+}
+
 #[test]
 fn test_solver_unknown() {
     let _ = env_logger::try_init();


### PR DESCRIPTION
Other literal types (Int, Bool, etc) have methods like
`as_bool() -> Option<bool>` or `as_i64() -> Option<i64>` allowing
a literal Ast node to be "unwrapped".  `ast::String` has no such
method, and `to_string` escapes quotes/etc, which makes it challenging
to extract the original stored value.

This introduces an analogous `ast::String::as_string` method, which
returns the original string, unchanged.  `String` constants return
None.