### PR TITLE
z3-sys/build: fix link order for static lib

### DIFF
--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -47,10 +47,6 @@ fn build_z3() {
         }
     };
 
-    if let Some(cxx) = cxx {
-        println!("cargo:rustc-link-lib={}", cxx);
-    }
-
     let mut found_lib_dir = false;
     for lib_dir in &[
         "lib",
@@ -80,5 +76,9 @@ fn build_z3() {
         println!("cargo:rustc-link-lib=static=libz3");
     } else {
         println!("cargo:rustc-link-lib=static=z3");
+    }
+
+    if let Some(cxx) = cxx {
+        println!("cargo:rustc-link-lib={}", cxx);
     }
 }


### PR DESCRIPTION
This tweaks link order when building a static libz3, so that
dangling C++ stdlib symbols can be resolved by the library appearing
aftwerward in linking order.
It fixes a linking failure when trying to use latest Z3 from git,
as it would otherwise fail to resolve C++ stdlib symbols used
by the library.