### PR TITLE
z3: add docstrings for all top-level items

### DIFF
--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -350,7 +350,7 @@ pub enum ParameterKind {
     FuncDecl = generated::Z3_parameter_kind::Z3_PARAMETER_FUNC_DECL as u32,
 }
 
-/// The different kinds of Z3 types (See [`Z3_get_sort_kind`](fn.Z3_get_sort_kind.html)).
+/// The different kinds of Z3 types.
 ///
 /// This corresponds to `Z3_sort_kind` in the C API.
 #[repr(u32)]
@@ -1531,9 +1531,7 @@ pub enum ErrorCode {
 pub type Z3_error_handler =
     ::std::option::Option<unsafe extern "C" fn(c: Z3_context, e: ErrorCode)>;
 
-/// A Goal is essentially a set of formulas.
-/// Z3 provide APIs for building strategies/tactics for solving and transforming Goals.
-/// Some of these transformations apply under/over approximations.
+/// Precision of a given goal. Some goals can be transformed using over/under approximations.
 ///
 /// This corresponds to `Z3_goal_prec` in the C API.
 #[repr(u32)]

--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1,3 +1,5 @@
+//! Abstract syntax tree (AST).
+
 use std::cmp::{Eq, PartialEq};
 use std::convert::{TryFrom, TryInto};
 use std::ffi::{CStr, CString};

--- a/z3/src/datatype_builder.rs
+++ b/z3/src/datatype_builder.rs
@@ -1,3 +1,5 @@
+//! Helpers for building custom [datatype sorts](struct.DatatypeSort.html).
+
 use std::{convert::TryInto, ptr::null_mut};
 use z3_sys::*;
 use Z3_MUTEX;

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -87,7 +87,7 @@ pub enum Symbol {
     String(String),
 }
 
-/// Sorts represent the various 'types' of [`Ast`s](trait.Ast.html).
+/// Sorts represent the various 'types' of [`Ast`s](ast/trait.Ast.html).
 //
 // Note for in-crate users: Never construct a `Sort` directly; only use
 // `Sort::new()` which handles Z3 refcounting properly.
@@ -96,14 +96,14 @@ pub struct Sort<'ctx> {
     z3_sort: Z3_sort,
 }
 
-/// a struct to represent when two sorts are of different types
+/// A struct to represent when two sorts are of different types.
 #[derive(Debug)]
 pub struct SortDiffers<'ctx> {
   left: Sort<'ctx>,
   right: Sort<'ctx>,
 }
 
-/// a struct to represent when an ast is not a function application
+/// A struct to represent when an ast is not a function application.
 #[derive(Debug)]
 pub struct IsNotApp {
     kind: AstKind,
@@ -151,7 +151,7 @@ pub struct FuncDecl<'ctx> {
 
 pub use z3_sys::DeclKind;
 
-/// Build a datatype sort.
+/// Build a custom [datatype sort](struct.DatatypeSort.html).
 ///
 /// Example:
 /// ```
@@ -191,12 +191,14 @@ pub struct DatatypeBuilder<'sort, 'ctx: 'sort> {
     constructors: Vec<(String, Vec<(String, DatatypeAccessor<'sort, 'ctx>)>)>,
 }
 
+/// Wrapper which can point to an existing sort (by reference) or to a custom datatype (by name).
 #[derive(Debug)]
 pub enum DatatypeAccessor<'sort, 'ctx: 'sort> {
     Sort(&'sort Sort<'ctx>),
     Datatype(Symbol),
 }
 
+/// Inner variant for a custom [datatype sort](struct.DatatypeSort.html).
 #[derive(Debug)]
 pub struct DatatypeVariant<'ctx> {
     pub constructor: FuncDecl<'ctx>,
@@ -204,6 +206,7 @@ pub struct DatatypeVariant<'ctx> {
     pub accessors: Vec<FuncDecl<'ctx>>,
 }
 
+/// A custom datatype sort.
 #[derive(Debug)]
 pub struct DatatypeSort<'ctx> {
     ctx: &'ctx Context,
@@ -211,6 +214,7 @@ pub struct DatatypeSort<'ctx> {
     pub variants: Vec<DatatypeVariant<'ctx>>,
 }
 
+/// Parameter set used to configure many components (simplifiers, tactics, solvers, etc).
 pub struct Params<'ctx> {
     ctx: &'ctx Context,
     z3_params: Z3_params,
@@ -233,22 +237,28 @@ pub struct Pattern<'ctx> {
     z3_pattern: Z3_pattern,
 }
 
+/// Collection of subgoals resulting from applying of a tactic to a goal.
 #[derive(Clone, Debug)]
 pub struct ApplyResult<'ctx> {
     ctx: &'ctx Context,
     z3_apply_result: Z3_apply_result,
 }
 
+/// Basic building block for creating custom solvers for specific problem domains.
 pub struct Tactic<'ctx> {
     ctx: &'ctx Context,
     z3_tactic: Z3_tactic,
 }
 
+/// Set of formulas that can be solved and/or transformed using tactics and solvers.
 pub struct Goal<'ctx> {
     ctx: &'ctx Context,
     z3_goal: Z3_goal,
 }
 
+/// Function/predicate used to inspect a goal and collect information
+/// that may be used to decide which solver and/or preprocessing step
+/// will be used.
 pub struct Probe<'ctx> {
     ctx: &'ctx Context,
     z3_probe: Z3_probe,


### PR DESCRIPTION
This updates crate documentation by adding docstring entries to all
top-level API items.