### PR TITLE
Implement Clone for Sort

### DIFF
--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -259,6 +259,12 @@ impl<'ctx> Sort<'ctx> {
     }
 }
 
+impl<'ctx> Clone for Sort<'ctx> {
+    fn clone(&self) -> Self {
+        Sort::new(self.ctx, self.z3_sort)
+    }
+}
+
 impl<'ctx> fmt::Display for Sort<'ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let p = unsafe { Z3_sort_to_string(self.ctx.z3_ctx, self.z3_sort) };
@@ -299,10 +305,7 @@ impl<'ctx> Drop for Sort<'ctx> {
 
 impl<'ctx> SortDiffers<'ctx> {
     pub fn new(left: Sort<'ctx>, right: Sort<'ctx>) -> Self {
-        Self {
-            left,
-            right,
-        }
+        Self { left, right }
     }
 
     pub fn left(&self) -> &Sort {
@@ -316,6 +319,10 @@ impl<'ctx> SortDiffers<'ctx> {
 
 impl<'ctx> fmt::Display for SortDiffers<'ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "Can not compare nodes, Sort does not match.  Nodes contain types {} and {}", self.left, self.right)
+        write!(
+            f,
+            "Can not compare nodes, Sort does not match.  Nodes contain types {} and {}",
+            self.left, self.right
+        )
     }
 }


### PR DESCRIPTION
I was running into an issue in 0.9 where `DatatypeAccessor::Sort` required an owned `Sort` value. Unfortunately I only had a `&Sort` and it does not implement `Clone`, so I was stuck and decided to make this PR. In the process of making the PR I found #113 which did fix my issue (changed `DatatypeAccessor::Sort` to take a `&Sort`), but I don't like how that API requires extra borrowing. So I decided to continue on with the PR, and maybe the `DatatypeAccessor` API change will be reverted before the next release.

The issue with taking a reference to `Sort` is that a pattern like the following no longer works:
```rust
// Translating my own type system into Z3, specifically structs
let my_name: String = ...;
let my_fields: Vec<(String, IrType)> = ...;
let z3_types: HashMap<IrType, DatatypeSort> = ...;

let builder = DatatypeBuilder::new(context, "foo");
let variants = my_fields
    .iter()
    .map(|(name, field)| {
        let z3_ty = match field {
            IrType::Bool => DatatypeAccessor::Sort(Sort::bool(context)),
            // ... other simple types ...
            not_simple_type => {
                let z3_ty: &DatatypeSort = z3_types.get(not_simple_type).unwrap();
                DatatypeAccessor::Sort(z3_ty.sort.clone()) // My real issue: Sort doesn't impl Clone
            }
        };
        (name.as_str(), z3_ty)
    })
    .collect();

let new_ty: DatatypeSort<'ctx> = builder.variant("foo_variant", variants).finish();
z3_types.insert(my_name, new_ty);
```

`z3_ty` sometimes refers to a sort that lives on the stack (`Sort::bool(context)`), so it can't be returned from the map function. The fix is to make a single sort value outside of the loop (even if the sort will not be used by the variant) so it can be referred to in `variants`, but can this be avoided? Switching back to the owned `Sort` value and adding a `Clone` impl would do this.

Note 1: My use-case is somewhat fixed by #113, but it's not in a released version. It would be great if this PR is merged, but if not then a crates.io release would also fix my issue.
Note 2: rustfmt did edit the file slightly, hopefully that's OK with you.