### PR TITLE
Revert #113 (DatatypeAccessor::Sort reference)

### DIFF
--- a/z3/src/datatype_builder.rs
+++ b/z3/src/datatype_builder.rs
@@ -8,7 +8,7 @@ use {
     Symbol,
 };
 
-impl<'sort, 'ctx: 'sort> DatatypeBuilder<'sort, 'ctx> {
+impl<'ctx> DatatypeBuilder<'ctx> {
     pub fn new<S: Into<Symbol>>(ctx: &'ctx Context, name: S) -> Self {
         Self {
             ctx,
@@ -17,12 +17,8 @@ impl<'sort, 'ctx: 'sort> DatatypeBuilder<'sort, 'ctx> {
         }
     }
 
-    pub fn variant(
-        mut self,
-        name: &str,
-        fields: Vec<(&str, DatatypeAccessor<'sort, 'ctx>)>,
-    ) -> Self {
-        let mut accessor_vec: Vec<(String, DatatypeAccessor<'sort, 'ctx>)> = Vec::new();
+    pub fn variant(mut self, name: &str, fields: Vec<(&str, DatatypeAccessor<'ctx>)>) -> Self {
+        let mut accessor_vec: Vec<(String, DatatypeAccessor<'ctx>)> = Vec::new();
         for (accessor_name, accessor) in fields {
             accessor_vec.push((accessor_name.to_string(), accessor));
         }
@@ -38,8 +34,8 @@ impl<'sort, 'ctx: 'sort> DatatypeBuilder<'sort, 'ctx> {
     }
 }
 
-pub fn create_datatypes<'sort, 'ctx: 'sort>(
-    datatype_builders: Vec<DatatypeBuilder<'sort, 'ctx>>,
+pub fn create_datatypes<'ctx>(
+    datatype_builders: Vec<DatatypeBuilder<'ctx>>,
 ) -> Vec<DatatypeSort<'ctx>> {
     let num = datatype_builders.len();
     assert!(num > 0, "At least one DatatypeBuilder must be specified");

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -164,7 +164,7 @@ pub use z3_sys::DeclKind;
 /// .variant("None", vec![])
 /// .variant(
 ///     "Some",
-///     vec![("value", DatatypeAccessor::Sort(&Sort::int(&ctx)))],
+///     vec![("value", DatatypeAccessor::Sort(Sort::int(&ctx)))],
 /// )
 /// .finish();
 ///
@@ -185,16 +185,16 @@ pub use z3_sys::DeclKind;
 /// assert_eq!(3, model.eval(&ast.as_int().unwrap()).unwrap().as_i64().unwrap());
 /// ```
 #[derive(Debug)]
-pub struct DatatypeBuilder<'sort, 'ctx: 'sort> {
+pub struct DatatypeBuilder<'ctx> {
     ctx: &'ctx Context,
     name: Symbol,
-    constructors: Vec<(String, Vec<(String, DatatypeAccessor<'sort, 'ctx>)>)>,
+    constructors: Vec<(String, Vec<(String, DatatypeAccessor<'ctx>)>)>,
 }
 
 /// Wrapper which can point to an existing sort (by reference) or to a custom datatype (by name).
 #[derive(Debug)]
-pub enum DatatypeAccessor<'sort, 'ctx: 'sort> {
-    Sort(&'sort Sort<'ctx>),
+pub enum DatatypeAccessor<'ctx> {
+    Sort(Sort<'ctx>),
     Datatype(Symbol),
 }
 

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -36,7 +36,6 @@ mod sort;
 mod symbol;
 mod tactic;
 
-
 // Z3 appears to be only mostly-threadsafe, a few initializers
 // and such race; so we mutex-guard all access to the library.
 lazy_static! {
@@ -99,8 +98,8 @@ pub struct Sort<'ctx> {
 /// A struct to represent when two sorts are of different types.
 #[derive(Debug)]
 pub struct SortDiffers<'ctx> {
-  left: Sort<'ctx>,
-  right: Sort<'ctx>,
+    left: Sort<'ctx>,
+    right: Sort<'ctx>,
 }
 
 /// A struct to represent when an ast is not a function application.
@@ -191,7 +190,7 @@ pub struct DatatypeBuilder<'ctx> {
     constructors: Vec<(String, Vec<(String, DatatypeAccessor<'ctx>)>)>,
 }
 
-/// Wrapper which can point to an existing sort (by reference) or to a custom datatype (by name).
+/// Wrapper which can point to a sort (by value) or to a custom datatype (by name).
 #[derive(Debug)]
 pub enum DatatypeAccessor<'ctx> {
     Sort(Sort<'ctx>),

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -585,7 +585,7 @@ fn test_datatype_builder() {
         .variant("Nothing", vec![])
         .variant(
             "Just",
-            vec![("int", DatatypeAccessor::Sort(&Sort::int(&ctx)))],
+            vec![("int", DatatypeAccessor::Sort(Sort::int(&ctx)))],
         )
         .finish();
 
@@ -644,7 +644,7 @@ fn test_recursive_datatype() {
         .variant(
             "cons",
             vec![
-                ("car", DatatypeAccessor::Sort(&Sort::int(&ctx))),
+                ("car", DatatypeAccessor::Sort(Sort::int(&ctx))),
                 ("cdr", DatatypeAccessor::Datatype("List".into())),
             ],
         )
@@ -707,10 +707,11 @@ fn test_mutually_recursive_datatype() {
     let ctx = Context::new(&cfg);
     let solver = Solver::new(&ctx);
 
-    let int_sort = Sort::int(&ctx);
-
     let tree_builder = DatatypeBuilder::new(&ctx, "Tree")
-        .variant("leaf", vec![("val", DatatypeAccessor::Sort(&int_sort))])
+        .variant(
+            "leaf",
+            vec![("val", DatatypeAccessor::Sort(Sort::int(&ctx)))],
+        )
         .variant(
             "node",
             vec![("children", DatatypeAccessor::Datatype("TreeList".into()))],


### PR DESCRIPTION
Reverts the behavior of `DatatypeAccessor::Sort` from holding a `Sort` reference to holding a `Sort` value.

Closes #138 