### PR TITLE
Remove Z3_MUTEX

### DIFF
--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -23,7 +23,6 @@ static-link-z3 = ["z3-sys/static-link-z3"]
 
 [dependencies]
 log = "0.4"
-lazy_static = "1"
 
 # optional dependencies
 num = { version = "0.2.0", optional=true }

--- a/z3/src/config.rs
+++ b/z3/src/config.rs
@@ -1,14 +1,12 @@
 use std::ffi::CString;
 use z3_sys::*;
 use Config;
-use Z3_MUTEX;
 
 impl Config {
     pub fn new() -> Config {
         Config {
             kvs: Vec::new(),
             z3_cfg: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_config();
                 debug!("new config {:p}", p);
                 p
@@ -19,7 +17,7 @@ impl Config {
         let ks = CString::new(k).unwrap();
         let vs = CString::new(v).unwrap();
         self.kvs.push((ks, vs));
-        let guard = Z3_MUTEX.lock().unwrap();
+
         unsafe {
             Z3_set_param_value(
                 self.z3_cfg,
@@ -59,7 +57,6 @@ impl Default for Config {
 
 impl Drop for Config {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_del_config(self.z3_cfg) };
     }
 }

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -2,13 +2,11 @@ use z3_sys::*;
 use Config;
 use Context;
 use ContextHandle;
-use Z3_MUTEX;
 
 impl Context {
     pub fn new(cfg: &Config) -> Context {
         Context {
             z3_ctx: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_context_rc(cfg.z3_cfg);
                 debug!("new context {:p}", p);
                 Z3_set_error_handler(p, None);
@@ -24,9 +22,7 @@ impl Context {
 
     /// Obtain a handle that can be used to interrupt computation from another thread.
     pub fn handle(&self) -> ContextHandle {
-        ContextHandle {
-            ctx: self
-        }
+        ContextHandle { ctx: self }
     }
 }
 

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -4,7 +4,7 @@ use std::convert::TryInto;
 use std::ffi::CStr;
 use std::fmt;
 use z3_sys::*;
-use {Context, FuncDecl, Sort, Symbol, Z3_MUTEX};
+use {Context, FuncDecl, Sort, Symbol};
 
 impl<'ctx> FuncDecl<'ctx> {
     pub fn new<S: Into<Symbol>>(
@@ -33,8 +33,6 @@ impl<'ctx> FuncDecl<'ctx> {
     }
 
     pub unsafe fn from_raw(ctx: &'ctx Context, z3_func_decl: Z3_func_decl) -> Self {
-        let guard = Z3_MUTEX.lock().unwrap();
-
         Z3_inc_ref(ctx.z3_ctx, Z3_func_decl_to_ast(ctx.z3_ctx, z3_func_decl));
 
         Self { ctx, z3_func_decl }
@@ -68,7 +66,6 @@ impl<'ctx> FuncDecl<'ctx> {
         let args: Vec<_> = args.iter().map(|a| a.get_z3_ast()).collect();
 
         ast::Dynamic::new(self.ctx, unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
             Z3_mk_app(
                 self.ctx.z3_ctx,
                 self.z3_func_decl,
@@ -80,10 +77,7 @@ impl<'ctx> FuncDecl<'ctx> {
 
     /// Return the `DeclKind` of this `FuncDecl`.
     pub fn kind(&self) -> DeclKind {
-        unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
-            Z3_get_decl_kind(self.ctx.z3_ctx, self.z3_func_decl)
-        }
+        unsafe { Z3_get_decl_kind(self.ctx.z3_ctx, self.z3_func_decl) }
     }
 
     /// Return the name of this `FuncDecl`.
@@ -92,7 +86,6 @@ impl<'ctx> FuncDecl<'ctx> {
     /// the `Symbol`.
     pub fn name(&self) -> String {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
             let z3_ctx = self.ctx.z3_ctx;
             let symbol = Z3_get_decl_name(z3_ctx, self.z3_func_decl);
             match Z3_get_symbol_kind(z3_ctx, symbol) {

--- a/z3/src/goal.rs
+++ b/z3/src/goal.rs
@@ -7,7 +7,6 @@ use crate::ast;
 use crate::ast::Ast;
 use Context;
 use Goal;
-use Z3_MUTEX;
 
 impl<'ctx> Clone for Goal<'ctx> {
     fn clone(&self) -> Self {
@@ -19,11 +18,14 @@ impl<'ctx> Clone for Goal<'ctx> {
 }
 
 impl<'ctx> Goal<'ctx> {
-    pub fn new_from_z3_type(ctx: &'ctx Context, z3_goal: Z3_goal, models: bool, unsat_cores: bool, proofs: bool) -> Goal<'ctx>{
-        Goal {
-            ctx,
-            z3_goal,
-        }
+    pub fn new_from_z3_type(
+        ctx: &'ctx Context,
+        z3_goal: Z3_goal,
+        models: bool,
+        unsat_cores: bool,
+        proofs: bool,
+    ) -> Goal<'ctx> {
+        Goal { ctx, z3_goal }
     }
 
     pub fn new(ctx: &'ctx Context, models: bool, unsat_cores: bool, proofs: bool) -> Goal<'ctx> {
@@ -31,75 +33,50 @@ impl<'ctx> Goal<'ctx> {
         Self {
             ctx,
             z3_goal: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let g = Z3_mk_goal(ctx.z3_ctx, models, unsat_cores, proofs);
                 Z3_goal_inc_ref(ctx.z3_ctx, g);
                 g
-            }
+            },
         }
     }
 
     /// Add a new formula `a` to the given goal.
     pub fn assert(&self, ast: &impl ast::Ast<'ctx>) {
-        unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_assert(self.ctx.z3_ctx, self.z3_goal, ast.get_z3_ast())
-        }
+        unsafe { Z3_goal_assert(self.ctx.z3_ctx, self.z3_goal, ast.get_z3_ast()) }
     }
 
     /// Return true if the given goal contains the formula `false`.
     pub fn is_inconsistent(&self) -> bool {
-        unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_inconsistent(self.ctx.z3_ctx, self.z3_goal)
-        }
+        unsafe { Z3_goal_inconsistent(self.ctx.z3_ctx, self.z3_goal) }
     }
 
     /// Return the depth of the given goal. It tracks how many transformations were applied to it.
     pub fn get_depth(&self) -> u32 {
-        unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_depth(self.ctx.z3_ctx, self.z3_goal)
-        }
+        unsafe { Z3_goal_depth(self.ctx.z3_ctx, self.z3_goal) }
     }
 
     /// Return the number of formulas in the given goal.
     pub fn get_size(&self) -> u32 {
-        unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_size(self.ctx.z3_ctx, self.z3_goal)
-        }
+        unsafe { Z3_goal_size(self.ctx.z3_ctx, self.z3_goal) }
     }
 
     /// Return the number of formulas, subformulas and terms in the given goal.
     pub fn get_num_expr(&self) -> u32 {
-        unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_num_exprs(self.ctx.z3_ctx, self.z3_goal)
-        }
+        unsafe { Z3_goal_num_exprs(self.ctx.z3_ctx, self.z3_goal) }
     }
 
     /// Return true if the goal is empty, and it is precise or the product of a under approximation.
     pub fn is_decided_sat(&self) -> bool {
-        unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_is_decided_sat(self.ctx.z3_ctx, self.z3_goal)
-        }
+        unsafe { Z3_goal_is_decided_sat(self.ctx.z3_ctx, self.z3_goal) }
     }
     /// Return true if the goal contains false, and it is precise or the product of an over approximation.
     pub fn is_decided_unsat(&self) -> bool {
-        unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_is_decided_unsat(self.ctx.z3_ctx, self.z3_goal)
-        }
+        unsafe { Z3_goal_is_decided_unsat(self.ctx.z3_ctx, self.z3_goal) }
     }
 
     /// Erase all formulas from the given goal.
     pub fn reset(&self) {
-        unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_reset(self.ctx.z3_ctx, self.z3_goal)
-        };
+        unsafe { Z3_goal_reset(self.ctx.z3_ctx, self.z3_goal) };
     }
 
     /// Copy a goal `g` from the context `source` to the context `target`.
@@ -107,47 +84,43 @@ impl<'ctx> Goal<'ctx> {
         Goal {
             ctx,
             z3_goal: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let g = Z3_goal_translate(self.ctx.z3_ctx, self.z3_goal, ctx.z3_ctx);
                 Z3_goal_inc_ref(ctx.z3_ctx, g);
                 g
-            }
+            },
         }
     }
 
     /// Return the "precision" of the given goal. Goals can be transformed using over and under approximations.
     pub fn get_precision(&self) -> GoalPrec {
-        let guard = Z3_MUTEX.lock().unwrap();
-        unsafe {
-            Z3_goal_precision(self.ctx.z3_ctx, self.z3_goal)
-        }
+        unsafe { Z3_goal_precision(self.ctx.z3_ctx, self.z3_goal) }
     }
 
-    pub fn iter_formulas<'a, T>(&'a self) -> impl Iterator<Item = T> + 'a where T: Ast<'a> {
+    pub fn iter_formulas<'a, T>(&'a self) -> impl Iterator<Item = T> + 'a
+    where
+        T: Ast<'a>,
+    {
         let goal_size = self.get_size() as usize;
         let z3_ctx = self.ctx.z3_ctx;
         let z3_goal = self.z3_goal.clone();
         (0..goal_size).into_iter().map(move |i| {
-            let formula = unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
-                Z3_goal_formula(z3_ctx, z3_goal, i as u32)
-            };
+            let formula = unsafe { Z3_goal_formula(z3_ctx, z3_goal, i as u32) };
             T::new(&self.ctx, formula)
         })
     }
 
     /// Return a vector of the formulas from the given goal.
-    pub fn get_formulas<T>(&self) -> Vec<T> where T: Ast<'ctx> {
+    pub fn get_formulas<T>(&self) -> Vec<T>
+    where
+        T: Ast<'ctx>,
+    {
         let goal_size = self.get_size() as usize;
         let mut formulas: Vec<T> = Vec::with_capacity(goal_size);
 
         for i in 0..goal_size {
-            let formula = unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
-                Z3_goal_formula(self.ctx.z3_ctx, self.z3_goal, i as u32)
-            };
+            let formula = unsafe { Z3_goal_formula(self.ctx.z3_ctx, self.z3_goal, i as u32) };
             formulas.push(T::new(&self.ctx, formula));
-        };
+        }
         formulas
     }
 }
@@ -173,7 +146,6 @@ impl<'ctx> fmt::Debug for Goal<'ctx> {
 
 impl<'ctx> Drop for Goal<'ctx> {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_goal_dec_ref(self.ctx.z3_ctx, self.z3_goal);
         };

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -6,16 +6,12 @@
 #[macro_use]
 extern crate log;
 
-#[macro_use]
-extern crate lazy_static;
-
 extern crate z3_sys;
 
 #[cfg(feature = "arbitrary-size-numeral")]
 extern crate num;
 
 use std::ffi::CString;
-use std::sync::Mutex;
 use z3_sys::*;
 pub use z3_sys::{AstKind, GoalPrec, SortKind};
 
@@ -35,12 +31,6 @@ mod solver;
 mod sort;
 mod symbol;
 mod tactic;
-
-// Z3 appears to be only mostly-threadsafe, a few initializers
-// and such race; so we mutex-guard all access to the library.
-lazy_static! {
-    static ref Z3_MUTEX: Mutex<()> = Mutex::new(());
-}
 
 /// Configuration used to initialize [logical contexts].
 ///

--- a/z3/src/model.rs
+++ b/z3/src/model.rs
@@ -6,14 +6,12 @@ use Context;
 use Model;
 use Optimize;
 use Solver;
-use Z3_MUTEX;
 
 impl<'ctx> Model<'ctx> {
     pub fn of_solver(slv: &Solver<'ctx>) -> Option<Model<'ctx>> {
         Some(Model {
             ctx: slv.ctx,
             z3_mdl: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let m = Z3_solver_get_model(slv.ctx.z3_ctx, slv.z3_slv);
                 if m.is_null() {
                     return None;
@@ -28,7 +26,6 @@ impl<'ctx> Model<'ctx> {
         Some(Model {
             ctx: opt.ctx,
             z3_mdl: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let m = Z3_optimize_get_model(opt.ctx.z3_ctx, opt.z3_opt);
                 if m.is_null() {
                     return None;
@@ -44,7 +41,6 @@ impl<'ctx> Model<'ctx> {
         Model {
             ctx: dest,
             z3_mdl: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let m = Z3_model_translate(self.ctx.z3_ctx, self.z3_mdl, dest.z3_ctx);
                 Z3_model_inc_ref(dest.z3_ctx, m);
                 m
@@ -58,7 +54,6 @@ impl<'ctx> Model<'ctx> {
     {
         let mut tmp: Z3_ast = ast.get_z3_ast();
         let res = {
-            let guard = Z3_MUTEX.lock().unwrap();
             unsafe {
                 Z3_model_eval(
                     self.ctx.z3_ctx,
@@ -98,7 +93,6 @@ impl<'ctx> fmt::Debug for Model<'ctx> {
 
 impl<'ctx> Drop for Model<'ctx> {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_model_dec_ref(self.ctx.z3_ctx, self.z3_mdl) };
     }
 }

--- a/z3/src/params.rs
+++ b/z3/src/params.rs
@@ -4,14 +4,12 @@ use z3_sys::*;
 use Context;
 use Params;
 use Symbol;
-use Z3_MUTEX;
 
 impl<'ctx> Params<'ctx> {
     pub fn new(ctx: &'ctx Context) -> Params<'ctx> {
         Params {
             ctx,
             z3_params: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_params(ctx.z3_ctx);
                 Z3_params_inc_ref(ctx.z3_ctx, p);
                 p
@@ -20,7 +18,6 @@ impl<'ctx> Params<'ctx> {
     }
 
     pub fn set_symbol<K: Into<Symbol>, V: Into<Symbol>>(&mut self, k: K, v: V) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_params_set_symbol(
                 self.ctx.z3_ctx,
@@ -32,7 +29,6 @@ impl<'ctx> Params<'ctx> {
     }
 
     pub fn set_bool<K: Into<Symbol>>(&mut self, k: K, v: bool) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_params_set_bool(
                 self.ctx.z3_ctx,
@@ -44,7 +40,6 @@ impl<'ctx> Params<'ctx> {
     }
 
     pub fn set_f64<K: Into<Symbol>>(&mut self, k: K, v: f64) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_params_set_double(
                 self.ctx.z3_ctx,
@@ -56,7 +51,6 @@ impl<'ctx> Params<'ctx> {
     }
 
     pub fn set_u32<K: Into<Symbol>>(&mut self, k: K, v: u32) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_params_set_uint(
                 self.ctx.z3_ctx,
@@ -89,7 +83,6 @@ impl<'ctx> fmt::Debug for Params<'ctx> {
 
 impl<'ctx> Drop for Params<'ctx> {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_params_dec_ref(self.ctx.z3_ctx, self.z3_params) };
     }
 }

--- a/z3/src/pattern.rs
+++ b/z3/src/pattern.rs
@@ -6,7 +6,6 @@ use std::fmt;
 use z3_sys::*;
 use Context;
 use Pattern;
-use Z3_MUTEX;
 
 impl<'ctx> Pattern<'ctx> {
     /// Create a pattern for quantifier instantiation.
@@ -36,7 +35,6 @@ impl<'ctx> Pattern<'ctx> {
         Pattern {
             ctx,
             z3_pattern: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_pattern(
                     ctx.z3_ctx,
                     terms.len().try_into().unwrap(),

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -7,11 +7,9 @@ use FuncDecl;
 use Sort;
 use SortDiffers;
 use Symbol;
-use Z3_MUTEX;
 
 impl<'ctx> Sort<'ctx> {
     pub(crate) fn new(ctx: &'ctx Context, z3_sort: Z3_sort) -> Sort<'ctx> {
-        let guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, z3_sort)) };
         Sort { ctx, z3_sort }
     }

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1007,10 +1007,7 @@ fn test_goal_get_formulas() {
     goal.assert(&a);
     goal.assert(&b);
     goal.assert(&c);
-    assert_eq!(
-        goal.get_formulas::<Bool>(),
-        vec![a, b, c],
-    );
+    assert_eq!(goal.get_formulas::<Bool>(), vec![a, b, c],);
 }
 
 #[test]
@@ -1030,10 +1027,7 @@ fn test_tactic_skip() {
     let apply_results = tactic.apply(&goal, Some(&params));
     let goal_results = apply_results.list_subgoals().collect::<Vec<Goal>>();
     let goal_result = goal_results.first().unwrap();
-    assert_eq!(
-        goal_result.get_formulas::<Bool>(),
-        vec![a.clone(), b, a],
-    );
+    assert_eq!(goal_result.get_formulas::<Bool>(), vec![a.clone(), b, a],);
 }
 
 #[test]
@@ -1079,13 +1073,17 @@ fn test_tactic_or_else() {
     assert_eq!(goal_result.get_formulas::<Bool>(), vec![a, b]);
 }
 
-
 #[test]
 fn test_goal_apply_tactic() {
     let cfg = Config::new();
     let ctx = Context::new(&cfg);
 
-    pub fn test_apply_tactic(ctx: &Context, goal: Goal, before_formulas: Vec<Bool>, after_formulas: Vec<Bool>) {
+    pub fn test_apply_tactic(
+        ctx: &Context,
+        goal: Goal,
+        before_formulas: Vec<Bool>,
+        after_formulas: Vec<Bool>,
+    ) {
         assert_eq!(goal.get_formulas::<Bool>(), before_formulas);
         let params = Params::new(&ctx);
 
@@ -1104,26 +1102,46 @@ fn test_goal_apply_tactic() {
     let a_and_b_and_a = Bool::and(&ctx, &bools);
     let goal = Goal::new(&ctx, false, false, false);
     goal.assert(&a_and_b_and_a);
-    test_apply_tactic(&ctx, goal, vec![a.clone(), b.clone(), a.clone()], vec![b.clone(), a.clone()]);
+    test_apply_tactic(
+        &ctx,
+        goal,
+        vec![a.clone(), b.clone(), a.clone()],
+        vec![b.clone(), a.clone()],
+    );
 
     let a_implies_b = ast::Bool::implies(&a, &b);
     let a_and_a_implies_b = Bool::and(&ctx, &[&a, &a_implies_b]);
 
     let goal = Goal::new(&ctx, false, false, false);
     goal.assert(&a_and_a_implies_b);
-    test_apply_tactic(&ctx, goal, vec![a.clone(), a_implies_b.clone()], vec![a.clone(), b.clone()]);
+    test_apply_tactic(
+        &ctx,
+        goal,
+        vec![a.clone(), a_implies_b.clone()],
+        vec![a.clone(), b.clone()],
+    );
 
     let goal = Goal::new(&ctx, false, false, false);
     goal.assert(&a);
     goal.assert(&a_implies_b.clone());
-    test_apply_tactic(&ctx, goal, vec![a.clone(), a_implies_b.clone()], vec![a.clone(), b.clone()]);
+    test_apply_tactic(
+        &ctx,
+        goal,
+        vec![a.clone(), a_implies_b.clone()],
+        vec![a.clone(), b.clone()],
+    );
 
     let true_bool = ast::Bool::from_bool(&ctx, true);
     let false_bool = ast::Bool::from_bool(&ctx, false);
     let goal = Goal::new(&ctx, false, false, false);
     let true_and_false_and_true = ast::Bool::and(&ctx, &[&true_bool, &false_bool, &true_bool]);
     goal.assert(&true_and_false_and_true);
-    test_apply_tactic(&ctx, goal, vec![false_bool.clone()], vec![false_bool.clone()]);
+    test_apply_tactic(
+        &ctx,
+        goal,
+        vec![false_bool.clone()],
+        vec![false_bool.clone()],
+    );
 }
 
 #[test]
@@ -1302,7 +1320,6 @@ fn test_issue_94() {
     ast::Int::add(&ctx0, &[&i0, &i1]);
 }
 
-
 #[test]
 fn test_ast_safe_eq() {
     let cfg = Config::new();
@@ -1334,16 +1351,89 @@ fn test_ast_safe_decl() {
     let f = FuncDecl::new(&ctx, "f", &[&Sort::int(&ctx)], &Sort::int(ctx));
     let x = ast::Int::new_const(&ctx, "x");
     let f_x: ast::Int = f.apply(&[&x.clone().into()]).try_into().unwrap();
-    let f_x_pattern: Pattern = Pattern::new(&ctx, &[ &f_x.clone().into() ]);
-    let forall = ast::forall_const(
-         &ctx,
-         &[&x.clone().into()],
-         &[&f_x_pattern],
-         &x._eq(&f_x)
-    );
+    let f_x_pattern: Pattern = Pattern::new(&ctx, &[&f_x.clone().into()]);
+    let forall = ast::forall_const(&ctx, &[&x.clone().into()], &[&f_x_pattern], &x._eq(&f_x));
     assert!(forall.safe_decl().is_err());
     assert_eq!(
         format!("{}", forall.safe_decl().err().unwrap()),
         "ast node is not a function application, has kind Quantifier"
     );
+}
+
+#[test]
+fn parallel() {
+    let mut handles = vec![];
+    for _ in 0..10 {
+        let t = std::thread::spawn(|| {
+            let begin = std::time::Instant::now();
+            loop {
+                let now = std::time::Instant::now();
+                let e = now - begin;
+                if e.as_secs() > 60 {
+                    break;
+                }
+                test_arbitrary_size_int();
+                test_arbitrary_size_real();
+                test_array_store_select();
+                test_ast_safe_eq();
+                test_ast_safe_decl();
+                test_ast_translate();
+                test_bitvectors();
+                test_cloning_ast();
+                test_config();
+                test_context();
+                test_datatype_builder();
+                test_dynamic_as_set();
+                test_float_add();
+                test_floating_point_bits();
+                test_format();
+                test_get_unsat_core();
+                test_goal_apply_tactic();
+                test_goal_depth();
+                test_goal_get_formulas();
+                test_goal_get_precision();
+                test_goal_is_sat();
+                test_goal_num_expr();
+                test_goal_reset();
+                test_goal_size();
+                //test_issue_94();
+                test_model_translate();
+                test_mutually_recursive_datatype();
+                test_optimize_unknown();
+                test_params();
+                test_pb_ops_model();
+                test_probe_debug();
+                test_probe_eq();
+                test_probe_gt();
+                test_probe_gte();
+                test_probe_le();
+                test_probe_lt();
+                test_probe_names();
+                test_probe_ne();
+                test_real_cmp();
+                test_recursive_datatype();
+                test_set_membership();
+                test_solver_translate();
+                test_solver_unknown();
+                test_solving();
+                test_solving_for_model();
+                test_sorts_and_symbols();
+                test_string_as_string();
+                test_string_concat();
+                test_string_eq();
+                test_string_prefix();
+                test_string_suffix();
+                test_substitution();
+                test_tactic_and_then();
+                test_tactic_cond();
+                test_tactic_conditions();
+                test_tactic_or_else();
+                test_tactic_skip();
+            }
+        });
+        handles.push(t);
+    }
+    for t in handles.into_iter() {
+        t.join().unwrap();
+    }
 }

--- a/z3/tests/objectives.rs
+++ b/z3/tests/objectives.rs
@@ -150,3 +150,25 @@ fn test_optimize_assert_soft_and_get_objectives() {
         );
     }
 }
+
+#[test]
+fn parallel() {
+    let mut handles = vec![];
+    for _ in 0..10 {
+        let t = std::thread::spawn(|| {
+            let begin = std::time::Instant::now();
+            loop {
+                let now = std::time::Instant::now();
+                let e = now - begin;
+                if e.as_secs() > 60 {
+                    break;
+                }
+                test_optimize_assert_soft_and_get_objectives();
+            }
+        });
+        handles.push(t);
+    }
+    for t in handles.into_iter() {
+        t.join().unwrap();
+    }
+}

--- a/z3/tests/ops.rs
+++ b/z3/tests/ops.rs
@@ -288,3 +288,32 @@ fn test_func_decl_attributes() {
     assert_eq!(binary_decl.name(), "binary");
     assert_eq!(binary_decl.arity(), 2);
 }
+
+#[test]
+fn parallel() {
+    let mut handles = vec![];
+    for _ in 0..10 {
+        let t = std::thread::spawn(|| {
+            let begin = std::time::Instant::now();
+            loop {
+                let now = std::time::Instant::now();
+                let e = now - begin;
+                if e.as_secs() > 60 {
+                    break;
+                }
+                test_ast_attributes();
+                test_ast_children();
+                test_double_ops();
+                test_float32_ops();
+                test_real_ops();
+                test_bool_ops();
+                test_int_ops();
+                test_func_decl_attributes();
+            }
+        });
+        handles.push(t);
+    }
+    for t in handles.into_iter() {
+        t.join().unwrap();
+    }
+}


### PR DESCRIPTION
#142

I removed the global mutex and wrote a simple stress test for it. The stress test spawns 10 threads and runs all the other unit tests for 60 seconds. There is no sign of crash or test failure in my machine(x86, Arch Linux / Ubuntu 20.04). And I think it's ok to remove the mutex now. :)