### PR TITLE
Removed Dynamic parameters, and refactored some code

### DIFF
--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -62,7 +62,7 @@ impl<'ctx> FuncDecl<'ctx> {
     /// Create a constant (if `args` has length 0) or function application (otherwise).
     ///
     /// Note that `args` should have the types corresponding to the `domain` of the `FuncDecl`.
-    pub fn apply(&self, args: &[&ast::Dynamic<'ctx>]) -> ast::Dynamic<'ctx> {
+    pub fn apply(&self, args: &[&dyn ast::Ast<'ctx>]) -> ast::Dynamic<'ctx> {
         assert!(args.iter().all(|s| s.get_ctx().z3_ctx == self.ctx.z3_ctx));
 
         let args: Vec<_> = args.iter().map(|a| a.get_z3_ast()).collect();

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -169,19 +169,19 @@ pub use z3_sys::DeclKind;
 ///
 /// // Assert x.is_none()
 /// let x = Datatype::new_const(&ctx, "x", &option_int.sort);
-/// solver.assert(&option_int.variants[0].tester.apply(&[&x.into()]).as_bool().unwrap());
+/// solver.assert(&option_int.variants[0].tester.apply(&[&x]).as_bool().unwrap());
 ///
 /// // Assert y == Some(3)
 /// let y = Datatype::new_const(&ctx, "y", &option_int.sort);
-/// let value = option_int.variants[1].constructor.apply(&[&Int::from_i64(&ctx, 3).into()]);
+/// let value = option_int.variants[1].constructor.apply(&[&Int::from_i64(&ctx, 3)]);
 /// solver.assert(&y._eq(&value.as_datatype().unwrap()));
 ///
 /// assert_eq!(solver.check(), SatResult::Sat);
 /// let model = solver.get_model().unwrap();;
 ///
 /// // Get the value out of Some(3)
-/// let ast = option_int.variants[1].accessors[0].apply(&[&y.into()]);
-/// assert_eq!(3, model.eval(&ast.as_int().unwrap()).unwrap().as_i64().unwrap());
+/// let ast = option_int.variants[1].accessors[0].apply(&[&y]);
+/// assert_eq!(3, model.eval(&ast.as_int().unwrap(), true).unwrap().as_i64().unwrap());
 /// ```
 #[derive(Debug)]
 pub struct DatatypeBuilder<'ctx> {

--- a/z3/src/model.rs
+++ b/z3/src/model.rs
@@ -52,7 +52,7 @@ impl<'ctx> Model<'ctx> {
         }
     }
 
-    pub fn eval<T>(&self, ast: &T) -> Option<T>
+    pub fn eval<T>(&self, ast: &T, model_completion: bool) -> Option<T>
     where
         T: Ast<'ctx>,
     {
@@ -64,7 +64,7 @@ impl<'ctx> Model<'ctx> {
                     self.ctx.z3_ctx,
                     self.z3_mdl,
                     ast.get_z3_ast(),
-                    true,
+                    model_completion,
                     &mut tmp,
                 )
             }

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -236,15 +236,22 @@ macro_rules! impl_weight {
         $(
             impl Weight for $ty {
                 fn to_string(&self) -> String {
-                    assert!(*self >= 0, "Weight cannot be negative");
+                    #[allow(unused_comparisons)]
+                    let weight_valid: bool = *self >= 0;
+                    assert!(weight_valid, "Weight cannot be negative");
                     ToString::to_string(&self)
                 }
             }
 
             impl Weight for ($ty, $ty) {
                 fn to_string(&self) -> String {
-                    assert!(self.0 >= 0, "Weight numerator cannot be negative");
-                    assert!(self.1 >= 0, "Weight denominator cannot be negative");
+                    #[allow(unused_comparisons)]
+                    let num_valid: bool = self.0 >= 0;
+                    #[allow(unused_comparisons)]
+                    let denom_valid: bool = self.1 >= 0;
+                    assert!(num_valid, "Weight numerator cannot be negative");
+                    #[allow(unused_comparisons)]
+                    assert!(denom_valid, "Weight denominator cannot be negative");
                     format!("{} / {}", self.0, self.1)
                 }
             }
@@ -287,6 +294,7 @@ impl Weight for BigRational {
 macro_rules! impl_sealed {
     ($($ty: ty),*) => {
         mod private {
+            #[allow(unused_imports)]
             use super::*;
             pub trait Sealed {}
             $(

--- a/z3/src/pattern.rs
+++ b/z3/src/pattern.rs
@@ -1,5 +1,4 @@
 use ast::Ast;
-use ast::Dynamic;
 use std::convert::TryInto;
 use std::ffi::CStr;
 use std::fmt;
@@ -27,7 +26,7 @@ impl<'ctx> Pattern<'ctx> {
     ///
     /// - `ast::forall_const()`
     /// - `ast::exists_const()`
-    pub fn new(ctx: &'ctx Context, terms: &[&Dynamic]) -> Pattern<'ctx> {
+    pub fn new(ctx: &'ctx Context, terms: &[&dyn Ast]) -> Pattern<'ctx> {
         assert!(!terms.is_empty());
         assert!(terms.iter().all(|t| t.get_ctx().z3_ctx == ctx.z3_ctx));
 

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -98,7 +98,7 @@ impl<'ctx> Sort<'ctx> {
     /// assert_eq!(solver.check(), SatResult::Sat);
     /// let model = solver.get_model().unwrap();;
     ///
-    /// assert!(model.eval(&eq).unwrap().as_bool().unwrap().as_bool().unwrap());
+    /// assert!(model.eval(&eq, true).unwrap().as_bool().unwrap().as_bool().unwrap());
     /// ```
     pub fn enumeration(
         ctx: &'ctx Context,

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -73,8 +73,8 @@ fn test_solving_for_model() {
     assert_eq!(solver.check(), SatResult::Sat);
 
     let model = solver.get_model().unwrap();
-    let xv = model.eval(&x).unwrap().as_i64().unwrap();
-    let yv = model.eval(&y).unwrap().as_i64().unwrap();
+    let xv = model.eval(&x, true).unwrap().as_i64().unwrap();
+    let yv = model.eval(&y, true).unwrap().as_i64().unwrap();
     info!("x: {}", xv);
     info!("y: {}", yv);
     assert!(xv > yv);
@@ -96,8 +96,8 @@ fn test_cloning_ast() {
     assert_eq!(solver.check(), SatResult::Sat);
 
     let model = solver.get_model().unwrap();
-    let xv = model.eval(&x).unwrap().as_i64().unwrap();
-    let yv = model.eval(&y).unwrap().as_i64().unwrap();
+    let xv = model.eval(&x, true).unwrap().as_i64().unwrap();
+    let yv = model.eval(&y, true).unwrap().as_i64().unwrap();
     assert_eq!(xv, 0);
     assert_eq!(yv, 0);
 }
@@ -129,8 +129,8 @@ fn test_bitvectors() {
     assert_eq!(solver.check(), SatResult::Sat);
 
     let model = solver.get_model().unwrap();
-    let av = model.eval(&a).unwrap().as_i64().unwrap();
-    let bv = model.eval(&b).unwrap().as_i64().unwrap();
+    let av = model.eval(&a, true).unwrap().as_i64().unwrap();
+    let bv = model.eval(&b, true).unwrap().as_i64().unwrap();
     assert!(av > bv);
     assert!(bv > 2);
     assert!(bv + 2 > av);
@@ -216,12 +216,12 @@ fn test_model_translate() {
     assert_eq!(slv.check(), SatResult::Sat);
 
     let model = slv.get_model().unwrap();
-    assert_eq!(2, model.eval(&a).unwrap().as_i64().unwrap());
+    assert_eq!(2, model.eval(&a, true).unwrap().as_i64().unwrap());
     let translated_model = model.translate(&destination);
     assert_eq!(
         2,
         translated_model
-            .eval(&translated_a)
+            .eval(&translated_a, true)
             .unwrap()
             .as_i64()
             .unwrap()
@@ -240,8 +240,8 @@ fn test_pb_ops_model() {
     solver.assert(&ast::Bool::pb_eq(&ctx, &[(&x, 1), (&y, 1)], 1));
     assert_eq!(solver.check(), SatResult::Sat);
     let model = solver.get_model().unwrap();
-    let xv = model.eval(&x).unwrap().as_bool().unwrap();
-    let yv = model.eval(&y).unwrap().as_bool().unwrap();
+    let xv = model.eval(&x, true).unwrap().as_bool().unwrap();
+    let yv = model.eval(&y, true).unwrap().as_bool().unwrap();
     info!("x: {}", xv);
     info!("y: {}", yv);
     assert!((xv && !yv) || (!xv && yv));
@@ -251,8 +251,8 @@ fn test_pb_ops_model() {
     solver.assert(&ast::Bool::pb_ge(&ctx, &[(&x, 1), (&y, 1)], 2));
     assert_eq!(solver.check(), SatResult::Sat);
     let model = solver.get_model().unwrap();
-    let xv = model.eval(&x).unwrap().as_bool().unwrap();
-    let yv = model.eval(&y).unwrap().as_bool().unwrap();
+    let xv = model.eval(&x, true).unwrap().as_bool().unwrap();
+    let yv = model.eval(&y, true).unwrap().as_bool().unwrap();
     info!("x: {}", xv);
     info!("y: {}", yv);
     assert!(xv && yv);
@@ -261,8 +261,8 @@ fn test_pb_ops_model() {
     solver.assert(&ast::Bool::pb_le(&ctx, &[(&x, 1), (&y, 1)], 0));
     assert_eq!(solver.check(), SatResult::Sat);
     let model = solver.get_model().unwrap();
-    let xv = model.eval(&x).unwrap().as_bool().unwrap();
-    let yv = model.eval(&y).unwrap().as_bool().unwrap();
+    let xv = model.eval(&x, true).unwrap().as_bool().unwrap();
+    let yv = model.eval(&y, true).unwrap().as_bool().unwrap();
     info!("x: {}", xv);
     info!("y: {}", yv);
     assert!(!xv && !yv);
@@ -327,9 +327,9 @@ fn test_real_cmp() {
     let x = ast::Real::new_const(&ctx, "x");
     let x_plus_1 = ast::Real::add(&ctx, &[&x, &ast::Real::from_real(&ctx, 1, 1)]);
     // forall x, x < x + 1
-    let forall = ast::forall_const(&ctx, &[&x.clone().into()], &[], &x.lt(&x_plus_1));
+    let forall = ast::forall_const(&ctx, &[&x], &[], &x.lt(&x_plus_1));
 
-    solver.assert(&forall.try_into().unwrap());
+    solver.assert(&forall);
     assert_eq!(solver.check(), SatResult::Sat);
 }
 
@@ -593,7 +593,7 @@ fn test_datatype_builder() {
     let five = ast::Int::from_i64(&ctx, 5);
     let just_five = maybe_int.variants[1]
         .constructor
-        .apply(&[&five.clone().into()]);
+        .apply(&[&five]);
 
     let nothing_is_nothing = maybe_int.variants[0]
         .tester
@@ -655,7 +655,7 @@ fn test_recursive_datatype() {
     let five = ast::Int::from_i64(&ctx, 5);
     let cons_five_nil = list_sort.variants[1]
         .constructor
-        .apply(&[&five.clone().into(), &nil]);
+        .apply(&[&five, &nil]);
 
     let nil_is_nil = list_sort.variants[0]
         .tester
@@ -742,7 +742,7 @@ fn test_mutually_recursive_datatype() {
     let ten = ast::Int::from_i64(&ctx, 10);
     let leaf_ten = tree_sort.variants[0]
         .constructor
-        .apply(&[&ten.clone().into()]);
+        .apply(&[&ten]);
     let leaf_ten_val_is_ten = tree_sort.variants[0].accessors[0]
         .apply(&[&leaf_ten])
         .as_int()
@@ -754,7 +754,7 @@ fn test_mutually_recursive_datatype() {
     let twenty = ast::Int::from_i64(&ctx, 20);
     let leaf_twenty = tree_sort.variants[0]
         .constructor
-        .apply(&[&twenty.clone().into()]);
+        .apply(&[&twenty]);
     let cons_leaf_twenty_nil = tree_list_sort.variants[1]
         .constructor
         .apply(&[&leaf_twenty, &nil]);
@@ -922,6 +922,7 @@ fn test_goal_reset() {
     assert_eq!(format!("{}", goal), "(goal)");
 }
 
+#[test]
 fn test_set_membership() {
     let _ = env_logger::try_init();
     let cfg = Config::new();
@@ -943,9 +944,7 @@ fn test_set_membership() {
     let x = ast::Int::new_const(&ctx, "x");
     // An empty set will always return false for member
     let forall: ast::Bool =
-        ast::forall_const(&ctx, &[&x.clone().into()], &[], &set.member(&x).not())
-            .try_into()
-            .unwrap();
+        ast::forall_const(&ctx, &[&x], &[], &set.member(&x).not());
     solver.assert(&forall);
     assert_eq!(solver.check(), SatResult::Sat);
     solver.pop(1);
@@ -1330,14 +1329,13 @@ fn test_ast_safe_decl() {
     let x_not = x.not();
     assert_eq!(x_not.safe_decl().unwrap().kind(), DeclKind::NOT);
 
-    let solver = Solver::new(&ctx);
     let f = FuncDecl::new(&ctx, "f", &[&Sort::int(&ctx)], &Sort::int(ctx));
     let x = ast::Int::new_const(&ctx, "x");
-    let f_x: ast::Int = f.apply(&[&x.clone().into()]).try_into().unwrap();
-    let f_x_pattern: Pattern = Pattern::new(&ctx, &[ &f_x.clone().into() ]);
+    let f_x: ast::Int = f.apply(&[&x]).try_into().unwrap();
+    let f_x_pattern: Pattern = Pattern::new(&ctx, &[ &f_x ]);
     let forall = ast::forall_const(
          &ctx,
-         &[&x.clone().into()],
+         &[&x],
          &[&f_x_pattern],
          &x._eq(&f_x)
     );

--- a/z3/tests/objectives.rs
+++ b/z3/tests/objectives.rs
@@ -1,5 +1,4 @@
 extern crate z3;
-use std::convert::TryInto;
 use z3::ast::Ast;
 use z3::*;
 
@@ -26,12 +25,12 @@ fn test_optimize_assert_soft_and_get_objectives() {
             &ctx,
             &[
                 &well_ordered_fn
-                    .apply(&[&ast::Int::from_u64(&ctx, i).into()])
+                    .apply(&[&ast::Int::from_u64(&ctx, i)])
                     .as_int()
                     .unwrap()
                     .lt(&ast::Int::from_u64(&ctx, COUNT)),
                 &well_ordered_fn
-                    .apply(&[&ast::Int::from_u64(&ctx, i).into()])
+                    .apply(&[&ast::Int::from_u64(&ctx, i)])
                     .as_int()
                     .unwrap()
                     .ge(&ast::Int::from_u64(&ctx, 0)),
@@ -40,11 +39,11 @@ fn test_optimize_assert_soft_and_get_objectives() {
         for j in 0..i {
             opt.assert_soft(
                 &well_ordered_fn
-                    .apply(&[&ast::Int::from_u64(&ctx, i).into()])
+                    .apply(&[&ast::Int::from_u64(&ctx, i)])
                     .as_int()
                     .unwrap()
                     .lt(&well_ordered_fn
-                        .apply(&[&ast::Int::from_u64(&ctx, j).into()])
+                        .apply(&[&ast::Int::from_u64(&ctx, j)])
                         .as_int()
                         .unwrap()),
                 1,
@@ -56,11 +55,11 @@ fn test_optimize_assert_soft_and_get_objectives() {
     // incorrect assertion: COUNT-1 > 0
     opt.assert_soft(
         &well_ordered_fn
-            .apply(&[&ast::Int::from_u64(&ctx, 0).into()])
+            .apply(&[&ast::Int::from_u64(&ctx, 0)])
             .as_int()
             .unwrap()
             .lt(&well_ordered_fn
-                .apply(&[&ast::Int::from_u64(&ctx, COUNT - 1).into()])
+                .apply(&[&ast::Int::from_u64(&ctx, COUNT - 1)])
                 .as_int()
                 .unwrap()),
         1,
@@ -73,7 +72,7 @@ fn test_optimize_assert_soft_and_get_objectives() {
 
     for i in 0..COUNT {
         let i_new_pos = model
-            .eval(&well_ordered_fn.apply(&[&ast::Int::from_u64(&ctx, i).into()]))
+            .eval(&well_ordered_fn.apply(&[&ast::Int::from_u64(&ctx, i)]), true)
             .unwrap()
             .as_int()
             .unwrap()
@@ -81,7 +80,7 @@ fn test_optimize_assert_soft_and_get_objectives() {
             .unwrap();
         for j in 0..i {
             let j_new_pos = model
-                .eval(&well_ordered_fn.apply(&[&ast::Int::from_u64(&ctx, j).into()]))
+                .eval(&well_ordered_fn.apply(&[&ast::Int::from_u64(&ctx, j)]), true)
                 .unwrap()
                 .as_int()
                 .unwrap()
@@ -95,14 +94,14 @@ fn test_optimize_assert_soft_and_get_objectives() {
     // the penalty of all other soft assertions
     assert!(
         model
-            .eval(&well_ordered_fn.apply(&[&ast::Int::from_u64(&ctx, 0).into()]))
+            .eval(&well_ordered_fn.apply(&[&ast::Int::from_u64(&ctx, 0)]), true)
             .unwrap()
             .as_int()
             .unwrap()
             .as_u64()
             .unwrap()
             > model
-                .eval(&well_ordered_fn.apply(&[&ast::Int::from_u64(&ctx, COUNT - 1).into()]))
+                .eval(&well_ordered_fn.apply(&[&ast::Int::from_u64(&ctx, COUNT - 1)]), true)
                 .unwrap()
                 .as_int()
                 .unwrap()

--- a/z3/tests/semver_tests.rs
+++ b/z3/tests/semver_tests.rs
@@ -274,7 +274,7 @@ fn test_solve_simple_semver_example() {
 
     for k in root.keys() {
         let ast = &asts[k];
-        let idx = model.eval(ast).unwrap().as_i64().unwrap();
+        let idx = model.eval(ast, true).unwrap().as_i64().unwrap();
         info!(
             "solved: {}: #{} = {}",
             k,
@@ -286,8 +286,8 @@ fn test_solve_simple_semver_example() {
     let pg_a = &asts["postgres"];
     let r2_a = &asts["r2d2-postgres"];
 
-    let pg_v = model.eval(pg_a).unwrap().as_i64().unwrap() as usize;
-    let r2_v = model.eval(r2_a).unwrap().as_i64().unwrap() as usize;
+    let pg_v = model.eval(pg_a, true).unwrap().as_i64().unwrap() as usize;
+    let r2_v = model.eval(r2_a, true).unwrap().as_i64().unwrap() as usize;
 
     assert_eq!(
         get_version(&smap, "postgres", pg_v).unwrap(),


### PR DESCRIPTION
I have removed `Dynamic` *parameters* (there are still `Dynamic` return types although I did consider changing them into a `Box<&dyn Ast>`) which added a great deal of unnecessary `into()`, and `from()`s in the user's code and Rust has better methods for dealing with this (mainly `&dyn` traits). Therefore I have modified `Ast` to be usable in a `&dyn` context by removing its `Size` trait which also required removing its `Into<Dynamic<'ctx>>`. This isn't an issue as I we have `from_ast` available in the `Dynamic` struct, and the macro `impl_from_try_into_dynamic`. I don't believe that it is possible to directly have a `From` trait that takes in `&dyn Ast` from my understanding, and testing of Rust although I think we have sufficiently covered the needed use cases anyway.

Minor points
- Fixed comment from double to triple slash
- Fixed tests to not use the `into`s
- Fixed `translate` to be on the Ast trait
- Changed `forall_const` to take, and return a `Bool` I searched extensively (in z3, and smtlib2 documentation) to find when it would return something other than `Bool` and I was unable to find information, and I didn't like the unneeded `into`, but if it turns out that it can return something other than `Bool` I will happily change it.
- Fixed `eval` to accept a `model_completion` parameter as some code I am writing needed it (and the C version has this parameter). I probably should have done this in a different pull request, but it seemed minor enough to include here with the other clean ups.
- Fixed some warnings
- Enabled test `test_set_membership`
- Added `where Self:Sized` when Rust complained on certain `Ast` trait functions. What it effectively means is that it requires a specific instance of `Ast` as opposed to any generic one. For example: this can require multiple elements in a slice to be of the same type.

I have a few quick questions:
- Does `simplify` always return the same type as the input? For example can a `Z3_func_decl` returning 1 in z3 be simplified to a `Z3_int` which would change its type?
- Can/should `substitute` allow multiple different types as currently it requires that each substitution pair be the same type. An example that currently isn't allowed is `(0, 1), ('a', 'b')` in psuedocode as they have different types, but each by themselves would be fine.
