### PR TITLE
Add option to choose z3.h location for bindgen

### DIFF
--- a/z3-sys/README.md
+++ b/z3-sys/README.md
@@ -24,6 +24,19 @@ Add it to your `Cargo.toml` like so:
 z3-sys = "0.7.1"
 ```
 
+**Note:** This crate requires a `z3.h` during build time.
+
+* By default, the crate will look for a `z3.h` in standard/system include paths.
+* If the feature `static-link-z3` is enabled, the `z3.h` of the built Z3 will be used.
+* Alternatively, the path to the desired `z3.h` can be specified via the environment variable
+`Z3_SYS_Z3_HEADER`. I.e., running:
+
+```console
+$ Z3_SYS_Z3_HEADER="/path/to/my/z3.h" cargo build
+```
+
+in your project will use `/path/to/my/z3.h` instead.
+
 ## Support and Maintenance
 
 I am developing this library largely on my own so far. I am able

--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -1,3 +1,5 @@
+const Z3_HEADER_VAR: &str = "Z3_SYS_Z3_HEADER";
+
 fn main() {
     #[cfg(feature = "static-link-z3")]
     build_z3();
@@ -5,10 +7,13 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let header = if cfg!(feature = "static-link-z3") {
-        "z3/src/api/z3.h"
+        "z3/src/api/z3.h".to_string()
+    } else if let Ok(header_path) = std::env::var(Z3_HEADER_VAR) {
+        header_path
     } else {
-        "wrapper.h"
+        "wrapper.h".to_string()
     };
+    println!("cargo:rerun-if-env-changed={}", Z3_HEADER_VAR);
     println!("cargo:rerun-if-changed={}", header);
     let out_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
 
@@ -24,7 +29,7 @@ fn main() {
         "symbol_kind",
     ] {
         let enum_bindings = bindgen::Builder::default()
-            .header(header)
+            .header(&header)
             .parse_callbacks(Box::new(bindgen::CargoCallbacks))
             .generate_comments(false)
             .rustified_enum(format!("Z3_{}", x))


### PR DESCRIPTION
This enables the user to choose the path to their z3.h, and doesn't force usage of the system header through wrapper.h.

I.e., by setting the environment variable `Z3_SYS_Z3_HEADER`, the user can determine which z3.h will be used.

Needed this in a project where we did not want to just use the system z3.