### PR TITLE
Remove #[allow(dead code)] and #[allow(unused variables)]

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -201,8 +201,8 @@ pub trait Ast<'ctx>: fmt::Debug {
     /// Compare this `Ast` with another `Ast`, and get a Result.  Errors if the sort does not
     /// match for the two values.
     fn _safe_eq(&self, other: &Self) -> Result<Bool<'ctx>, SortDiffers<'ctx>> where Self: Sized {
-        let ctx = self.get_ctx().z3_ctx;
-        let other_ctx = other.get_ctx().z3_ctx;
+        assert_eq!(self.get_ctx(), other.get_ctx());
+
         let left_sort = self.get_sort();
         let right_sort = other.get_sort();
         match left_sort == right_sort {
@@ -937,7 +937,7 @@ impl<'ctx> Float<'ctx> {
     }
 
     pub fn fresh_const(ctx: &'ctx Context, prefix: &str, ebits: u32, sbits: u32) -> Float<'ctx> {
-        let sort = Sort::float32(ctx);
+        let sort = Sort::float(ctx, ebits, sbits);
         Self::new(ctx, unsafe {
             let pp = CString::new(prefix).unwrap();
             let p = pp.as_ptr();
@@ -1465,11 +1465,10 @@ impl<'ctx> Set<'ctx> {
     }
 
     /// Creates a set that maps the domain to false by default
-    pub fn empty(ctx: &'ctx Context, eltype: &Sort<'ctx>) -> Set<'ctx> {
-        let sort = Sort::set(ctx, eltype);
+    pub fn empty(ctx: &'ctx Context, domain: &Sort<'ctx>) -> Set<'ctx> {
         Self::new(ctx, unsafe {
             let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_mk_const_array(ctx.z3_ctx, eltype.z3_sort, Z3_mk_false(ctx.z3_ctx))
+            Z3_mk_empty_set(ctx.z3_ctx, domain.z3_sort)
         })
     }
 

--- a/z3/src/config.rs
+++ b/z3/src/config.rs
@@ -8,7 +8,7 @@ impl Config {
         Config {
             kvs: Vec::new(),
             z3_cfg: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_config();
                 debug!("new config {:p}", p);
                 p
@@ -19,7 +19,7 @@ impl Config {
         let ks = CString::new(k).unwrap();
         let vs = CString::new(v).unwrap();
         self.kvs.push((ks, vs));
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_set_param_value(
                 self.z3_cfg,
@@ -59,7 +59,7 @@ impl Default for Config {
 
 impl Drop for Config {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_del_config(self.z3_cfg) };
     }
 }

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -8,7 +8,7 @@ impl Context {
     pub fn new(cfg: &Config) -> Context {
         Context {
             z3_ctx: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_context_rc(cfg.z3_cfg);
                 debug!("new context {:p}", p);
                 Z3_set_error_handler(p, None);

--- a/z3/src/datatype_builder.rs
+++ b/z3/src/datatype_builder.rs
@@ -77,7 +77,7 @@ pub fn create_datatypes<'ctx>(
                         let matching_names: Vec<_> = datatype_builders
                             .iter()
                             .enumerate()
-                            .filter(|&(i, x)| &x.name == dtype_name)
+                            .filter(|&(_, x)| &x.name == dtype_name)
                             .collect();
 
                         assert_eq!(

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -33,7 +33,7 @@ impl<'ctx> FuncDecl<'ctx> {
     }
 
     pub unsafe fn from_raw(ctx: &'ctx Context, z3_func_decl: Z3_func_decl) -> Self {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
 
         Z3_inc_ref(ctx.z3_ctx, Z3_func_decl_to_ast(ctx.z3_ctx, z3_func_decl));
 
@@ -68,7 +68,7 @@ impl<'ctx> FuncDecl<'ctx> {
         let args: Vec<_> = args.iter().map(|a| a.get_z3_ast()).collect();
 
         ast::Dynamic::new(self.ctx, unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             Z3_mk_app(
                 self.ctx.z3_ctx,
                 self.z3_func_decl,
@@ -81,7 +81,7 @@ impl<'ctx> FuncDecl<'ctx> {
     /// Return the `DeclKind` of this `FuncDecl`.
     pub fn kind(&self) -> DeclKind {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             Z3_get_decl_kind(self.ctx.z3_ctx, self.z3_func_decl)
         }
     }
@@ -92,7 +92,7 @@ impl<'ctx> FuncDecl<'ctx> {
     /// the `Symbol`.
     pub fn name(&self) -> String {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_ctx = self.ctx.z3_ctx;
             let symbol = Z3_get_decl_name(z3_ctx, self.z3_func_decl);
             match Z3_get_symbol_kind(z3_ctx, symbol) {

--- a/z3/src/goal.rs
+++ b/z3/src/goal.rs
@@ -31,7 +31,7 @@ impl<'ctx> Goal<'ctx> {
         Self {
             ctx,
             z3_goal: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 let g = Z3_mk_goal(ctx.z3_ctx, models, unsat_cores, proofs);
                 Z3_goal_inc_ref(ctx.z3_ctx, g);
                 g
@@ -42,7 +42,7 @@ impl<'ctx> Goal<'ctx> {
     /// Add a new formula `a` to the given goal.
     pub fn assert(&self, ast: &impl ast::Ast<'ctx>) {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             Z3_goal_assert(self.ctx.z3_ctx, self.z3_goal, ast.get_z3_ast())
         }
     }
@@ -50,7 +50,7 @@ impl<'ctx> Goal<'ctx> {
     /// Return true if the given goal contains the formula `false`.
     pub fn is_inconsistent(&self) -> bool {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             Z3_goal_inconsistent(self.ctx.z3_ctx, self.z3_goal)
         }
     }
@@ -58,7 +58,7 @@ impl<'ctx> Goal<'ctx> {
     /// Return the depth of the given goal. It tracks how many transformations were applied to it.
     pub fn get_depth(&self) -> u32 {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             Z3_goal_depth(self.ctx.z3_ctx, self.z3_goal)
         }
     }
@@ -66,7 +66,7 @@ impl<'ctx> Goal<'ctx> {
     /// Return the number of formulas in the given goal.
     pub fn get_size(&self) -> u32 {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             Z3_goal_size(self.ctx.z3_ctx, self.z3_goal)
         }
     }
@@ -74,7 +74,7 @@ impl<'ctx> Goal<'ctx> {
     /// Return the number of formulas, subformulas and terms in the given goal.
     pub fn get_num_expr(&self) -> u32 {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             Z3_goal_num_exprs(self.ctx.z3_ctx, self.z3_goal)
         }
     }
@@ -82,14 +82,14 @@ impl<'ctx> Goal<'ctx> {
     /// Return true if the goal is empty, and it is precise or the product of a under approximation.
     pub fn is_decided_sat(&self) -> bool {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             Z3_goal_is_decided_sat(self.ctx.z3_ctx, self.z3_goal)
         }
     }
     /// Return true if the goal contains false, and it is precise or the product of an over approximation.
     pub fn is_decided_unsat(&self) -> bool {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             Z3_goal_is_decided_unsat(self.ctx.z3_ctx, self.z3_goal)
         }
     }
@@ -97,7 +97,7 @@ impl<'ctx> Goal<'ctx> {
     /// Erase all formulas from the given goal.
     pub fn reset(&self) {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             Z3_goal_reset(self.ctx.z3_ctx, self.z3_goal)
         };
     }
@@ -107,7 +107,7 @@ impl<'ctx> Goal<'ctx> {
         Goal {
             ctx,
             z3_goal: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 let g = Z3_goal_translate(self.ctx.z3_ctx, self.z3_goal, ctx.z3_ctx);
                 Z3_goal_inc_ref(ctx.z3_ctx, g);
                 g
@@ -117,7 +117,7 @@ impl<'ctx> Goal<'ctx> {
 
     /// Return the "precision" of the given goal. Goals can be transformed using over and under approximations.
     pub fn get_precision(&self) -> GoalPrec {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_goal_precision(self.ctx.z3_ctx, self.z3_goal)
         }
@@ -129,7 +129,7 @@ impl<'ctx> Goal<'ctx> {
         let z3_goal = self.z3_goal.clone();
         (0..goal_size).into_iter().map(move |i| {
             let formula = unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 Z3_goal_formula(z3_ctx, z3_goal, i as u32)
             };
             T::new(&self.ctx, formula)
@@ -143,7 +143,7 @@ impl<'ctx> Goal<'ctx> {
 
         for i in 0..goal_size {
             let formula = unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 Z3_goal_formula(self.ctx.z3_ctx, self.z3_goal, i as u32)
             };
             formulas.push(T::new(&self.ctx, formula));
@@ -173,7 +173,7 @@ impl<'ctx> fmt::Debug for Goal<'ctx> {
 
 impl<'ctx> Drop for Goal<'ctx> {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_goal_dec_ref(self.ctx.z3_ctx, self.z3_goal);
         };

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-#![allow(unused_variables)]
 #![allow(clippy::unreadable_literal)]
 #![deny(missing_debug_implementations)]
 

--- a/z3/src/model.rs
+++ b/z3/src/model.rs
@@ -13,7 +13,7 @@ impl<'ctx> Model<'ctx> {
         Some(Model {
             ctx: slv.ctx,
             z3_mdl: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 let m = Z3_solver_get_model(slv.ctx.z3_ctx, slv.z3_slv);
                 if m.is_null() {
                     return None;
@@ -28,7 +28,7 @@ impl<'ctx> Model<'ctx> {
         Some(Model {
             ctx: opt.ctx,
             z3_mdl: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 let m = Z3_optimize_get_model(opt.ctx.z3_ctx, opt.z3_opt);
                 if m.is_null() {
                     return None;
@@ -44,7 +44,7 @@ impl<'ctx> Model<'ctx> {
         Model {
             ctx: dest,
             z3_mdl: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 let m = Z3_model_translate(self.ctx.z3_ctx, self.z3_mdl, dest.z3_ctx);
                 Z3_model_inc_ref(dest.z3_ctx, m);
                 m
@@ -58,7 +58,7 @@ impl<'ctx> Model<'ctx> {
     {
         let mut tmp: Z3_ast = ast.get_z3_ast();
         let res = {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             unsafe {
                 Z3_model_eval(
                     self.ctx.z3_ctx,
@@ -98,7 +98,7 @@ impl<'ctx> fmt::Debug for Model<'ctx> {
 
 impl<'ctx> Drop for Model<'ctx> {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_model_dec_ref(self.ctx.z3_ctx, self.z3_mdl) };
     }
 }

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -22,7 +22,7 @@ impl<'ctx> Optimize<'ctx> {
         Optimize {
             ctx,
             z3_opt: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 let opt = Z3_mk_optimize(ctx.z3_ctx);
                 Z3_optimize_inc_ref(ctx.z3_ctx, opt);
                 opt
@@ -38,7 +38,7 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::maximize()`](#method.maximize)
     /// - [`Optimize::minimize()`](#method.minimize)
     pub fn assert(&self, ast: &impl Ast<'ctx>) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_optimize_assert(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
     }
 
@@ -57,7 +57,7 @@ impl<'ctx> Optimize<'ctx> {
         let group = group
             .map(|g| g.as_z3_symbol(self.ctx))
             .unwrap_or_else(|| std::ptr::null_mut());
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_optimize_assert_soft(
                 self.ctx.z3_ctx,
@@ -76,7 +76,7 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::assert()`](#method.assert)
     /// - [`Optimize::minimize()`](#method.minimize)
     pub fn maximize(&self, ast: &impl Ast<'ctx>) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_optimize_maximize(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
     }
 
@@ -87,7 +87,7 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::assert()`](#method.assert)
     /// - [`Optimize::maximize()`](#method.maximize)
     pub fn minimize(&self, ast: &impl Ast<'ctx>) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_optimize_minimize(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
     }
 
@@ -101,7 +101,7 @@ impl<'ctx> Optimize<'ctx> {
     ///
     /// - [`Optimize::pop()`](#method.pop)
     pub fn push(&self) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_optimize_push(self.ctx.z3_ctx, self.z3_opt) };
     }
 
@@ -116,7 +116,7 @@ impl<'ctx> Optimize<'ctx> {
     ///
     /// - [`Optimize::push()`](#method.push)
     pub fn pop(&self) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_optimize_pop(self.ctx.z3_ctx, self.z3_opt) };
     }
 
@@ -126,7 +126,7 @@ impl<'ctx> Optimize<'ctx> {
     ///
     /// - [`Optimize::get_model()`](#method.get_model)
     pub fn check(&self, assumptions: &[Bool<'ctx>]) -> SatResult {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         let assumptions: Vec<Z3_ast> = assumptions.iter().map(|a| a.z3_ast).collect();
         match unsafe {
             Z3_optimize_check(
@@ -213,7 +213,7 @@ impl<'ctx> fmt::Debug for Optimize<'ctx> {
 
 impl<'ctx> Drop for Optimize<'ctx> {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_optimize_dec_ref(self.ctx.z3_ctx, self.z3_opt) };
     }
 }

--- a/z3/src/params.rs
+++ b/z3/src/params.rs
@@ -11,7 +11,7 @@ impl<'ctx> Params<'ctx> {
         Params {
             ctx,
             z3_params: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_params(ctx.z3_ctx);
                 Z3_params_inc_ref(ctx.z3_ctx, p);
                 p
@@ -20,7 +20,7 @@ impl<'ctx> Params<'ctx> {
     }
 
     pub fn set_symbol<K: Into<Symbol>, V: Into<Symbol>>(&mut self, k: K, v: V) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_params_set_symbol(
                 self.ctx.z3_ctx,
@@ -32,7 +32,7 @@ impl<'ctx> Params<'ctx> {
     }
 
     pub fn set_bool<K: Into<Symbol>>(&mut self, k: K, v: bool) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_params_set_bool(
                 self.ctx.z3_ctx,
@@ -44,7 +44,7 @@ impl<'ctx> Params<'ctx> {
     }
 
     pub fn set_f64<K: Into<Symbol>>(&mut self, k: K, v: f64) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_params_set_double(
                 self.ctx.z3_ctx,
@@ -56,7 +56,7 @@ impl<'ctx> Params<'ctx> {
     }
 
     pub fn set_u32<K: Into<Symbol>>(&mut self, k: K, v: u32) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_params_set_uint(
                 self.ctx.z3_ctx,
@@ -89,7 +89,7 @@ impl<'ctx> fmt::Debug for Params<'ctx> {
 
 impl<'ctx> Drop for Params<'ctx> {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_params_dec_ref(self.ctx.z3_ctx, self.z3_params) };
     }
 }

--- a/z3/src/pattern.rs
+++ b/z3/src/pattern.rs
@@ -35,7 +35,7 @@ impl<'ctx> Pattern<'ctx> {
         Pattern {
             ctx,
             z3_pattern: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_pattern(
                     ctx.z3_ctx,
                     terms.len().try_into().unwrap(),

--- a/z3/src/probe.rs
+++ b/z3/src/probe.rs
@@ -34,7 +34,7 @@ impl<'ctx> Probe<'ctx> {
         Probe {
             ctx: c,
             z3_probe: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_probe(c.z3_ctx, probe_name.as_ptr());
                 Z3_probe_inc_ref(c.z3_ctx, p);
                 p
@@ -51,7 +51,7 @@ impl<'ctx> Probe<'ctx> {
     /// Return a probe that always evaluates to val.
     pub fn constant(ctx: &'ctx Context, val: f64) -> Probe<'ctx> {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_probe = Z3_probe_const(ctx.z3_ctx, val);
             Z3_probe_inc_ref(ctx.z3_ctx, z3_probe);
             Probe {
@@ -66,7 +66,7 @@ impl<'ctx> Probe<'ctx> {
     /// NOTE: For probes, "true" is any value different from 0.0.
     pub fn lt(&self, p: Probe) -> Probe<'ctx> {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_probe = Z3_probe_lt(self.ctx.z3_ctx, self.z3_probe, p.z3_probe);
             Z3_probe_inc_ref(self.ctx.z3_ctx, z3_probe);
             Probe {
@@ -79,7 +79,7 @@ impl<'ctx> Probe<'ctx> {
     /// Return a probe that evaluates to "true" when the value returned by `self` is greater than the value returned by `p`.
     pub fn gt(&self, p: &Probe) -> Probe<'ctx> {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_probe = Z3_probe_gt(self.ctx.z3_ctx, self.z3_probe, p.z3_probe);
             Z3_probe_inc_ref(self.ctx.z3_ctx, z3_probe);
             Probe {
@@ -92,7 +92,7 @@ impl<'ctx> Probe<'ctx> {
     /// Return a probe that evaluates to "true" when the value returned by `self` is less than or equal to the value returned by `p`.
     pub fn le(&self, p: &Probe) -> Probe<'ctx> {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_probe = Z3_probe_le(self.ctx.z3_ctx, self.z3_probe, p.z3_probe);
             Z3_probe_inc_ref(self.ctx.z3_ctx, z3_probe);
             Probe {
@@ -105,7 +105,7 @@ impl<'ctx> Probe<'ctx> {
     /// Return a probe that evaluates to "true" when the value returned by `self` is greater than or equal to the value returned by `p`.
     pub fn ge(&self, p: &Probe) -> Probe<'ctx> {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_probe = Z3_probe_ge(self.ctx.z3_ctx, self.z3_probe, p.z3_probe);
             Z3_probe_inc_ref(self.ctx.z3_ctx, z3_probe);
             Probe {
@@ -118,7 +118,7 @@ impl<'ctx> Probe<'ctx> {
     /// Return a probe that evaluates to "true" when the value returned by `self` is equal to the value returned by `p`.
     pub fn eq(&self, p: &Probe) -> Probe<'ctx> {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_probe = Z3_probe_eq(self.ctx.z3_ctx, self.z3_probe, p.z3_probe);
             Z3_probe_inc_ref(self.ctx.z3_ctx, z3_probe);
             Probe {
@@ -131,7 +131,7 @@ impl<'ctx> Probe<'ctx> {
     /// Return a probe that evaluates to "true" when `self` and `p` evaluates to true.
     pub fn and(&self, p: &Probe) -> Probe<'ctx> {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_probe = Z3_probe_and(self.ctx.z3_ctx, self.z3_probe, p.z3_probe);
             Z3_probe_inc_ref(self.ctx.z3_ctx, z3_probe);
             Probe {
@@ -144,7 +144,7 @@ impl<'ctx> Probe<'ctx> {
     /// Return a probe that evaluates to "true" when `p1` or `p2` evaluates to true.
     pub fn or(&self, p: &Probe) -> Probe<'ctx> {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_probe = Z3_probe_or(self.ctx.z3_ctx, self.z3_probe, p.z3_probe);
             Z3_probe_inc_ref(self.ctx.z3_ctx, z3_probe);
             Probe {
@@ -157,7 +157,7 @@ impl<'ctx> Probe<'ctx> {
     /// Return a probe that evaluates to "true" when `p` does not evaluate to true.
     pub fn not(&self) -> Probe<'ctx> {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_probe = Z3_probe_not(self.ctx.z3_ctx, self.z3_probe);
             Z3_probe_inc_ref(self.ctx.z3_ctx, z3_probe);
             Probe {
@@ -170,7 +170,7 @@ impl<'ctx> Probe<'ctx> {
     /// Return a probe that evaluates to "true" when the value returned by `self` is not equal to the value returned by `p`.
     pub fn ne(&self, p: &Probe) -> Probe<'ctx> {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_probe = Z3_probe_eq(self.ctx.z3_ctx, self.z3_probe, p.z3_probe);
             Z3_probe_inc_ref(self.ctx.z3_ctx, z3_probe);
             let z3_probe_not = Z3_probe_not(self.ctx.z3_ctx, z3_probe);
@@ -188,7 +188,7 @@ impl<'ctx> Clone for Probe<'ctx> {
         Probe {
             ctx: self.ctx,
             z3_probe: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 Z3_probe_inc_ref(self.ctx.z3_ctx, self.z3_probe);
                 self.z3_probe
             },
@@ -210,7 +210,7 @@ impl<'ctx> fmt::Debug for Probe<'ctx> {
 
 impl<'ctx> Drop for Probe<'ctx> {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_probe_dec_ref(self.ctx.z3_ctx, self.z3_probe);
         }

--- a/z3/src/rec_func_decl.rs
+++ b/z3/src/rec_func_decl.rs
@@ -33,7 +33,7 @@ impl<'ctx> RecFuncDecl<'ctx> {
     }
 
     pub unsafe fn from_raw(ctx: &'ctx Context, z3_func_decl: Z3_func_decl) -> Self {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
 
         Z3_inc_ref(ctx.z3_ctx, Z3_func_decl_to_ast(ctx.z3_ctx, z3_func_decl));
 
@@ -118,7 +118,7 @@ impl<'ctx> RecFuncDecl<'ctx> {
         let args: Vec<_> = args.iter().map(|a| a.get_z3_ast()).collect();
 
         ast::Dynamic::new(self.ctx, unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             Z3_mk_app(
                 self.ctx.z3_ctx,
                 self.z3_func_decl,
@@ -131,7 +131,7 @@ impl<'ctx> RecFuncDecl<'ctx> {
     /// Return the `DeclKind` of this `RecFuncDecl`.
     pub fn kind(&self) -> DeclKind {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             Z3_get_decl_kind(self.ctx.z3_ctx, self.z3_func_decl)
         }
     }
@@ -142,7 +142,7 @@ impl<'ctx> RecFuncDecl<'ctx> {
     /// the `Symbol`.
     pub fn name(&self) -> String {
         unsafe {
-            let guard = Z3_MUTEX.lock().unwrap();
+            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_ctx = self.ctx.z3_ctx;
             let symbol = Z3_get_decl_name(z3_ctx, self.z3_func_decl);
             match Z3_get_symbol_kind(z3_ctx, symbol) {

--- a/z3/src/solver.rs
+++ b/z3/src/solver.rs
@@ -53,7 +53,7 @@ impl<'ctx> Solver<'ctx> {
         Solver {
             ctx,
             z3_slv: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 let s = Z3_mk_solver(ctx.z3_ctx);
                 Z3_solver_inc_ref(ctx.z3_ctx, s);
                 s
@@ -65,7 +65,7 @@ impl<'ctx> Solver<'ctx> {
         Solver {
             ctx: dest,
             z3_slv: unsafe {
-                let guard = Z3_MUTEX.lock().unwrap();
+                let _guard = Z3_MUTEX.lock().unwrap();
                 let s = Z3_solver_translate(self.ctx.z3_ctx, self.z3_slv, dest.z3_ctx);
                 Z3_solver_inc_ref(dest.z3_ctx, s);
                 s
@@ -89,7 +89,7 @@ impl<'ctx> Solver<'ctx> {
     /// - [`Solver::assert_and_track()`](#method.assert_and_track)
     pub fn assert(&self, ast: &ast::Bool<'ctx>) {
         debug!("assert: {:?}", ast);
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_assert(self.ctx.z3_ctx, self.z3_slv, ast.z3_ast) };
     }
 
@@ -109,13 +109,13 @@ impl<'ctx> Solver<'ctx> {
     /// - [`Solver::assert()`](#method.assert)
     pub fn assert_and_track(&self, ast: &ast::Bool<'ctx>, p: &ast::Bool<'ctx>) {
         debug!("assert_and_track: {:?}", ast);
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_assert_and_track(self.ctx.z3_ctx, self.z3_slv, ast.z3_ast, p.z3_ast) };
     }
 
     /// Remove all assertions from the solver.
     pub fn reset(&self) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_reset(self.ctx.z3_ctx, self.z3_slv) };
     }
 
@@ -143,7 +143,7 @@ impl<'ctx> Solver<'ctx> {
     /// [model construction is enabled]: struct.Config.html#method.set_model_generation
     /// [proof generation was enabled]: struct.Config.html#method.set_proof_generation
     pub fn check(&self) -> SatResult {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         match unsafe { Z3_solver_check(self.ctx.z3_ctx, self.z3_slv) } {
             Z3_L_FALSE => SatResult::Unsat,
             Z3_L_UNDEF => SatResult::Unknown,
@@ -164,7 +164,7 @@ impl<'ctx> Solver<'ctx> {
     ///
     /// - [`Solver::check()`](#method.check)
     pub fn check_assumptions(&self, assumptions: &[ast::Bool<'ctx>]) -> SatResult {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         let a: Vec<Z3_ast> = assumptions.iter().map(|a| a.z3_ast).collect();
         match unsafe {
             Z3_solver_check_assumptions(self.ctx.z3_ctx, self.z3_slv, a.len() as u32, a.as_ptr())
@@ -227,7 +227,7 @@ impl<'ctx> Solver<'ctx> {
     ///
     /// - [`Solver::pop()`](#method.pop)
     pub fn push(&self) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_push(self.ctx.z3_ctx, self.z3_slv) };
     }
 
@@ -237,7 +237,7 @@ impl<'ctx> Solver<'ctx> {
     ///
     /// - [`Solver::push()`](#method.push)
     pub fn pop(&self, n: u32) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_pop(self.ctx.z3_ctx, self.z3_slv, n) };
     }
 
@@ -294,7 +294,7 @@ impl<'ctx> Solver<'ctx> {
 
     /// Set the current solver using the given parameters.
     pub fn set_params(&self, params: &Params<'ctx>) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_set_params(self.ctx.z3_ctx, self.z3_slv, params.z3_params) };
     }
 }
@@ -320,7 +320,7 @@ impl<'ctx> fmt::Debug for Solver<'ctx> {
 
 impl<'ctx> Drop for Solver<'ctx> {
     fn drop(&mut self) {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_dec_ref(self.ctx.z3_ctx, self.z3_slv) };
     }
 }

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -11,7 +11,7 @@ use Z3_MUTEX;
 
 impl<'ctx> Sort<'ctx> {
     pub(crate) fn new(ctx: &'ctx Context, z3_sort: Z3_sort) -> Sort<'ctx> {
-        let guard = Z3_MUTEX.lock().unwrap();
+        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, z3_sort)) };
         Sort { ctx, z3_sort }
     }

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -495,7 +495,7 @@ fn test_rec_func_def() {
 
     let ctx = Context::new(&cfg);
 
-    let mut fac = RecFuncDecl::new(&ctx, "fac", &[&Sort::int(&ctx)], &Sort::int(&ctx));
+    let fac = RecFuncDecl::new(&ctx, "fac", &[&Sort::int(&ctx)], &Sort::int(&ctx));
     let n = ast::Int::new_const(&ctx, "n");
     let n_minus_1 = ast::Int::sub(&ctx, &[&n, &ast::Int::from_i64(&ctx, 1)]);
     let fac_of_n_minus_1 = fac.apply(&[&n_minus_1.into()]);
@@ -539,7 +539,7 @@ fn test_rec_func_def_unsat() {
 
     let ctx = Context::new(&cfg);
 
-    let mut fac = RecFuncDecl::new(&ctx, "fac", &[&Sort::int(&ctx)], &Sort::int(&ctx));
+    let fac = RecFuncDecl::new(&ctx, "fac", &[&Sort::int(&ctx)], &Sort::int(&ctx));
     let n = ast::Int::new_const(&ctx, "n");
     let n_minus_1 = ast::Int::sub(&ctx, &[&n, &ast::Int::from_i64(&ctx, 1)]);
     let fac_of_n_minus_1 = fac.apply(&[&n_minus_1.into()]);

--- a/z3/tests/semver_tests.rs
+++ b/z3/tests/semver_tests.rs
@@ -1,6 +1,3 @@
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
 extern crate env_logger;
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
This also fixes an error in _safe_eq