### PR TITLE
Silence warnings from unused enums

### DIFF
--- a/z3-sys/src/generated.rs
+++ b/z3-sys/src/generated.rs
@@ -2,6 +2,7 @@ macro_rules! declare_generated_mods {
     ($($mod_name: ident),*) => {
         $(
             mod $mod_name {
+                #![allow(dead_code)]
                 include!(concat!(env!("OUT_DIR"), "/", stringify!($mod_name), ".rs"));
             }
         )*


### PR DESCRIPTION
Some of the generated enum variants are not reexported, this silences the warning

(this hides the unsoundness in z3-sys/lib.rs though)