### PR TITLE
Removed unneeded bindgen features

### DIFF
--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -16,8 +16,8 @@ homepage = "https://github.com/prove-rs/z3.rs"
 repository = "https://github.com/prove-rs/z3.rs.git"
 
 [build-dependencies]
+bindgen = { version = "0.59", default-features = false, features = ["runtime"] }
 cmake = { version = "0.1", optional = true }
-bindgen = "0.58"
 
 [features]
 # Enable this feature to statically link our own build of Z3, rather than


### PR DESCRIPTION
Some features of bindgen are not needed when building the library and
lead to unused dependencies (mainly `clap`). This change deactivates all
`bindgen` features except for `runtime` which is required for build to
work.

See also https://github.com/rust-rocksdb/rust-rocksdb/pull/491