### PR TITLE
z3 optimize soft_assert weights can be negative

### DIFF
--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -236,21 +236,12 @@ macro_rules! impl_weight {
         $(
             impl Weight for $ty {
                 fn to_string(&self) -> String {
-                    #[allow(unused_comparisons)]
-                    let weight_valid: bool = *self >= 0;
-                    assert!(weight_valid, "Weight cannot be negative");
                     ToString::to_string(&self)
                 }
             }
 
             impl Weight for ($ty, $ty) {
                 fn to_string(&self) -> String {
-                    #[allow(unused_comparisons)]
-                    let num_valid: bool = self.0 >= 0;
-                    #[allow(unused_comparisons)]
-                    let denom_valid: bool = self.1 >= 0;
-                    assert!(num_valid, "Weight numerator cannot be negative");
-                    assert!(denom_valid, "Weight denominator cannot be negative");
                     format!("{} / {}", self.0, self.1)
                 }
             }


### PR DESCRIPTION
Closes https://github.com/prove-rs/z3.rs/issues/186

The docs have been updated to show that negative weights are rewards: https://github.com/Z3Prover/z3/blob/master/src/api/z3_optimization.h#L85