### PR TITLE
Correcting operations used for Floating-Point sorts ge and le operations

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1016,9 +1016,9 @@ impl<'ctx> Float<'ctx> {
     }
     binop! {
         lt(Z3_mk_fpa_lt, Bool<'ctx>);
-        le(Z3_mk_fpa_lt, Bool<'ctx>);
+        le(Z3_mk_fpa_leq, Bool<'ctx>);
         gt(Z3_mk_fpa_gt, Bool<'ctx>);
-        ge(Z3_mk_fpa_gt, Bool<'ctx>);
+        ge(Z3_mk_fpa_geq, Bool<'ctx>);
     }
     trinop! {
         add(Z3_mk_fpa_add, Self);


### PR DESCRIPTION
Floating point sorts using incorrect operations for "greater than or equal" and "less than or equal" operations. 