### PR TITLE
feat: add from_str() for BV

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1112,6 +1112,21 @@ macro_rules! bv_overflow_check_signed {
 }
 
 impl<'ctx> BV<'ctx> {
+    pub fn from_str(ctx: &'ctx Context, sz: u32, value: &str) -> Option<BV<'ctx>> {
+        let sort = Sort::bitvector(ctx, sz);
+        let ast = unsafe {
+            let _guard = Z3_MUTEX.lock().unwrap();
+            let bv_cstring = CString::new(value).unwrap();
+            let numeral_ptr = Z3_mk_numeral(ctx.z3_ctx, bv_cstring.as_ptr(), sort.z3_sort);
+            if numeral_ptr.is_null() {
+                return None;
+            }
+
+            numeral_ptr
+        };
+        Some(Self::new(ctx, ast))
+    }
+
     pub fn new_const<S: Into<Symbol>>(ctx: &'ctx Context, name: S, sz: u32) -> BV<'ctx> {
         let sort = Sort::bitvector(ctx, sz);
         Self::new(ctx, unsafe {

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -139,6 +139,24 @@ fn test_bitvectors() {
 }
 
 #[test]
+fn test_bitvector_from_str() {
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+
+    let a = ast::BV::new_const(&ctx, "a", 129);
+    // 2 ** 128
+    let b = ast::BV::from_str(&ctx, 129, "340282366920938463463374607431768211456").unwrap();
+
+    let solver = Solver::new(&ctx);
+    solver.assert(&a._eq(&b));
+    assert_eq!(solver.check(), SatResult::Sat);
+
+    let model = solver.get_model().unwrap();
+    let av = model.eval(&a, true).unwrap().to_string();
+    assert_eq!(av, "#b100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".to_string());
+}
+
+#[test]
 fn test_floating_point_bits() {
     let cfg = Config::new();
     let ctx = Context::new(&cfg);


### PR DESCRIPTION
The value for bitvector could be larger than 64 bits, thus the current interface doesn't allow us to create one.