### PR TITLE
Stop ignoring `test_solver_unknown`

### DIFF
--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -598,7 +598,6 @@ fn test_rec_func_def_unsat() {
 }
 
 #[test]
-#[ignore = "See https://github.com/Z3Prover/z3/issues/5702"]
 fn test_solver_unknown() {
     let _ = env_logger::try_init();
     let mut cfg = Config::new();


### PR DESCRIPTION
Originally ignored in #180 due to https://github.com/Z3Prover/z3/issues/5702

This requires [z3-4.8.14](https://github.com/Z3Prover/z3/releases/tag/z3-4.8.14)