### PR TITLE
Remove Z3_MUTEX.

### DIFF
--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -23,7 +23,6 @@ static-link-z3 = ["z3-sys/static-link-z3"]
 
 [dependencies]
 log = "0.4"
-lazy_static = "1"
 
 # optional dependencies
 num = { version = "0.4.0", optional=true }

--- a/z3/src/config.rs
+++ b/z3/src/config.rs
@@ -1,14 +1,12 @@
 use std::ffi::CString;
 use z3_sys::*;
 use Config;
-use Z3_MUTEX;
 
 impl Config {
     pub fn new() -> Config {
         Config {
             kvs: Vec::new(),
             z3_cfg: unsafe {
-                let _guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_config();
                 debug!("new config {:p}", p);
                 p
@@ -19,7 +17,6 @@ impl Config {
         let ks = CString::new(k).unwrap();
         let vs = CString::new(v).unwrap();
         self.kvs.push((ks, vs));
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_set_param_value(
                 self.z3_cfg,
@@ -59,7 +56,6 @@ impl Default for Config {
 
 impl Drop for Config {
     fn drop(&mut self) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_del_config(self.z3_cfg) };
     }
 }

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -2,13 +2,11 @@ use z3_sys::*;
 use Config;
 use Context;
 use ContextHandle;
-use Z3_MUTEX;
 
 impl Context {
     pub fn new(cfg: &Config) -> Context {
         Context {
             z3_ctx: unsafe {
-                let _guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_context_rc(cfg.z3_cfg);
                 debug!("new context {:p}", p);
                 Z3_set_error_handler(p, None);

--- a/z3/src/datatype_builder.rs
+++ b/z3/src/datatype_builder.rs
@@ -2,7 +2,6 @@
 
 use std::{convert::TryInto, ptr::null_mut};
 use z3_sys::*;
-use Z3_MUTEX;
 use {
     Context, DatatypeAccessor, DatatypeBuilder, DatatypeSort, DatatypeVariant, FuncDecl, Sort,
     Symbol,
@@ -97,7 +96,6 @@ pub fn create_datatypes<'ctx>(
             }
 
             let constructor = unsafe {
-                let _guard = Z3_MUTEX.lock().unwrap();
                 Z3_mk_constructor(
                     ctx.z3_ctx,
                     cname_symbol,
@@ -113,7 +111,6 @@ pub fn create_datatypes<'ctx>(
         assert!(!cs.is_empty());
 
         let clist = unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
             Z3_mk_constructor_list(ctx.z3_ctx, num_cs.try_into().unwrap(), cs.as_mut_ptr())
         };
         clists.push(clist);
@@ -124,7 +121,6 @@ pub fn create_datatypes<'ctx>(
     assert_eq!(num, clists.len());
 
     unsafe {
-        let _guard = Z3_MUTEX.lock().unwrap();
         Z3_mk_datatypes(
             ctx.z3_ctx,
             num.try_into().unwrap(),
@@ -139,10 +135,7 @@ pub fn create_datatypes<'ctx>(
     for (z3_sort, datatype_builder) in raw_sorts.into_iter().zip(&datatype_builders) {
         let num_cs = datatype_builder.constructors.len();
 
-        unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, z3_sort))
-        };
+        unsafe { Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, z3_sort)) };
         let sort = Sort { ctx, z3_sort };
 
         let mut variants: Vec<DatatypeVariant<'ctx>> = Vec::with_capacity(num_cs as usize);
@@ -151,13 +144,11 @@ pub fn create_datatypes<'ctx>(
             let num_fs = fs.len();
 
             let raw_constructor: Z3_func_decl = unsafe {
-                let _guard = Z3_MUTEX.lock().unwrap();
                 Z3_get_datatype_sort_constructor(ctx.z3_ctx, z3_sort, j.try_into().unwrap())
             };
             let constructor: FuncDecl<'ctx> = unsafe { FuncDecl::from_raw(ctx, raw_constructor) };
 
             let tester_func: Z3_func_decl = unsafe {
-                let _guard = Z3_MUTEX.lock().unwrap();
                 Z3_get_datatype_sort_recognizer(ctx.z3_ctx, z3_sort, j.try_into().unwrap())
             };
             let tester = unsafe { FuncDecl::from_raw(ctx, tester_func) };
@@ -165,7 +156,6 @@ pub fn create_datatypes<'ctx>(
             let mut accessors: Vec<FuncDecl<'ctx>> = Vec::new();
             for k in 0..num_fs {
                 let accessor_func: Z3_func_decl = unsafe {
-                    let _guard = Z3_MUTEX.lock().unwrap();
                     Z3_get_datatype_sort_constructor_accessor(
                         ctx.z3_ctx,
                         z3_sort,

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -4,7 +4,7 @@ use std::convert::TryInto;
 use std::ffi::CStr;
 use std::fmt;
 use z3_sys::*;
-use {Context, FuncDecl, Sort, Symbol, Z3_MUTEX};
+use {Context, FuncDecl, Sort, Symbol};
 
 impl<'ctx> FuncDecl<'ctx> {
     pub fn new<S: Into<Symbol>>(
@@ -33,8 +33,6 @@ impl<'ctx> FuncDecl<'ctx> {
     }
 
     pub unsafe fn from_raw(ctx: &'ctx Context, z3_func_decl: Z3_func_decl) -> Self {
-        let _guard = Z3_MUTEX.lock().unwrap();
-
         Z3_inc_ref(ctx.z3_ctx, Z3_func_decl_to_ast(ctx.z3_ctx, z3_func_decl));
 
         Self { ctx, z3_func_decl }
@@ -69,7 +67,6 @@ impl<'ctx> FuncDecl<'ctx> {
 
         unsafe {
             ast::Dynamic::new(self.ctx, {
-                let _guard = Z3_MUTEX.lock().unwrap();
                 Z3_mk_app(
                     self.ctx.z3_ctx,
                     self.z3_func_decl,
@@ -82,10 +79,7 @@ impl<'ctx> FuncDecl<'ctx> {
 
     /// Return the `DeclKind` of this `FuncDecl`.
     pub fn kind(&self) -> DeclKind {
-        unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_get_decl_kind(self.ctx.z3_ctx, self.z3_func_decl)
-        }
+        unsafe { Z3_get_decl_kind(self.ctx.z3_ctx, self.z3_func_decl) }
     }
 
     /// Return the name of this `FuncDecl`.
@@ -94,7 +88,6 @@ impl<'ctx> FuncDecl<'ctx> {
     /// the `Symbol`.
     pub fn name(&self) -> String {
         unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_ctx = self.ctx.z3_ctx;
             let symbol = Z3_get_decl_name(z3_ctx, self.z3_func_decl);
             match Z3_get_symbol_kind(z3_ctx, symbol) {

--- a/z3/src/goal.rs
+++ b/z3/src/goal.rs
@@ -7,7 +7,6 @@ use crate::ast;
 use crate::ast::Ast;
 use Context;
 use Goal;
-use Z3_MUTEX;
 
 impl<'ctx> Clone for Goal<'ctx> {
     fn clone(&self) -> Self {
@@ -26,76 +25,50 @@ impl<'ctx> Goal<'ctx> {
 
     pub fn new(ctx: &'ctx Context, models: bool, unsat_cores: bool, proofs: bool) -> Goal<'ctx> {
         // NOTE: The Z3 context ctx must have been created with proof generation support.
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_mk_goal(ctx.z3_ctx, models, unsat_cores, proofs)) }
     }
 
     /// Add a new formula `a` to the given goal.
     pub fn assert(&self, ast: &impl ast::Ast<'ctx>) {
-        unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_assert(self.ctx.z3_ctx, self.z3_goal, ast.get_z3_ast())
-        }
+        unsafe { Z3_goal_assert(self.ctx.z3_ctx, self.z3_goal, ast.get_z3_ast()) }
     }
 
     /// Return true if the given goal contains the formula `false`.
     pub fn is_inconsistent(&self) -> bool {
-        unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_inconsistent(self.ctx.z3_ctx, self.z3_goal)
-        }
+        unsafe { Z3_goal_inconsistent(self.ctx.z3_ctx, self.z3_goal) }
     }
 
     /// Return the depth of the given goal. It tracks how many transformations were applied to it.
     pub fn get_depth(&self) -> u32 {
-        unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_depth(self.ctx.z3_ctx, self.z3_goal)
-        }
+        unsafe { Z3_goal_depth(self.ctx.z3_ctx, self.z3_goal) }
     }
 
     /// Return the number of formulas in the given goal.
     pub fn get_size(&self) -> u32 {
-        unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_size(self.ctx.z3_ctx, self.z3_goal)
-        }
+        unsafe { Z3_goal_size(self.ctx.z3_ctx, self.z3_goal) }
     }
 
     /// Return the number of formulas, subformulas and terms in the given goal.
     pub fn get_num_expr(&self) -> u32 {
-        unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_num_exprs(self.ctx.z3_ctx, self.z3_goal)
-        }
+        unsafe { Z3_goal_num_exprs(self.ctx.z3_ctx, self.z3_goal) }
     }
 
     /// Return true if the goal is empty, and it is precise or the product of a under approximation.
     pub fn is_decided_sat(&self) -> bool {
-        unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_is_decided_sat(self.ctx.z3_ctx, self.z3_goal)
-        }
+        unsafe { Z3_goal_is_decided_sat(self.ctx.z3_ctx, self.z3_goal) }
     }
     /// Return true if the goal contains false, and it is precise or the product of an over approximation.
     pub fn is_decided_unsat(&self) -> bool {
-        unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_is_decided_unsat(self.ctx.z3_ctx, self.z3_goal)
-        }
+        unsafe { Z3_goal_is_decided_unsat(self.ctx.z3_ctx, self.z3_goal) }
     }
 
     /// Erase all formulas from the given goal.
     pub fn reset(&self) {
-        unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_goal_reset(self.ctx.z3_ctx, self.z3_goal)
-        };
+        unsafe { Z3_goal_reset(self.ctx.z3_ctx, self.z3_goal) };
     }
 
     /// Copy a goal `g` from the context `source` to the context `target`.
     pub fn translate<'dest_ctx>(self, ctx: &'dest_ctx Context) -> Goal<'dest_ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Goal::wrap(
                 ctx,
@@ -106,7 +79,6 @@ impl<'ctx> Goal<'ctx> {
 
     /// Return the "precision" of the given goal. Goals can be transformed using over and under approximations.
     pub fn get_precision(&self) -> GoalPrec {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_goal_precision(self.ctx.z3_ctx, self.z3_goal) }
     }
 
@@ -118,10 +90,7 @@ impl<'ctx> Goal<'ctx> {
         let z3_ctx = self.ctx.z3_ctx;
         let z3_goal = self.z3_goal;
         (0..goal_size).into_iter().map(move |i| {
-            let formula = unsafe {
-                let _guard = Z3_MUTEX.lock().unwrap();
-                Z3_goal_formula(z3_ctx, z3_goal, i as u32)
-            };
+            let formula = unsafe { Z3_goal_formula(z3_ctx, z3_goal, i as u32) };
             unsafe { T::new(self.ctx, formula) }
         })
     }
@@ -135,10 +104,7 @@ impl<'ctx> Goal<'ctx> {
         let mut formulas: Vec<T> = Vec::with_capacity(goal_size);
 
         for i in 0..goal_size {
-            let formula = unsafe {
-                let _guard = Z3_MUTEX.lock().unwrap();
-                Z3_goal_formula(self.ctx.z3_ctx, self.z3_goal, i as u32)
-            };
+            let formula = unsafe { Z3_goal_formula(self.ctx.z3_ctx, self.z3_goal, i as u32) };
             formulas.push(unsafe { T::new(self.ctx, formula) });
         }
         formulas
@@ -166,7 +132,6 @@ impl<'ctx> fmt::Debug for Goal<'ctx> {
 
 impl<'ctx> Drop for Goal<'ctx> {
     fn drop(&mut self) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_goal_dec_ref(self.ctx.z3_ctx, self.z3_goal);
         };

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -4,16 +4,12 @@
 #[macro_use]
 extern crate log;
 
-#[macro_use]
-extern crate lazy_static;
-
 extern crate z3_sys;
 
 #[cfg(feature = "arbitrary-size-numeral")]
 extern crate num;
 
 use std::ffi::CString;
-use std::sync::Mutex;
 use z3_sys::*;
 pub use z3_sys::{AstKind, GoalPrec, SortKind};
 
@@ -37,12 +33,6 @@ mod symbol;
 mod tactic;
 
 pub use statistics::{StatisticsEntry, StatisticsValue};
-
-// Z3 appears to be only mostly-threadsafe, a few initializers
-// and such race; so we mutex-guard all access to the library.
-lazy_static! {
-    static ref Z3_MUTEX: Mutex<()> = Mutex::new(());
-}
 
 /// Configuration used to initialize [logical contexts].
 ///

--- a/z3/src/model.rs
+++ b/z3/src/model.rs
@@ -6,7 +6,6 @@ use Context;
 use Model;
 use Optimize;
 use Solver;
-use Z3_MUTEX;
 
 impl<'ctx> Model<'ctx> {
     unsafe fn wrap(ctx: &'ctx Context, z3_mdl: Z3_model) -> Model<'ctx> {
@@ -15,7 +14,6 @@ impl<'ctx> Model<'ctx> {
     }
 
     pub fn of_solver(slv: &Solver<'ctx>) -> Option<Model<'ctx>> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             let m = Z3_solver_get_model(slv.ctx.z3_ctx, slv.z3_slv);
             if m.is_null() {
@@ -27,7 +25,6 @@ impl<'ctx> Model<'ctx> {
     }
 
     pub fn of_optimize(opt: &Optimize<'ctx>) -> Option<Model<'ctx>> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             let m = Z3_optimize_get_model(opt.ctx.z3_ctx, opt.z3_opt);
             if m.is_null() {
@@ -40,7 +37,6 @@ impl<'ctx> Model<'ctx> {
 
     /// Translate model to context `dest`
     pub fn translate<'dest_ctx>(&self, dest: &'dest_ctx Context) -> Model<'dest_ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Model::wrap(
                 dest,
@@ -55,7 +51,6 @@ impl<'ctx> Model<'ctx> {
     {
         let mut tmp: Z3_ast = ast.get_z3_ast();
         let res = {
-            let _guard = Z3_MUTEX.lock().unwrap();
             unsafe {
                 Z3_model_eval(
                     self.ctx.z3_ctx,
@@ -95,7 +90,6 @@ impl<'ctx> fmt::Debug for Model<'ctx> {
 
 impl<'ctx> Drop for Model<'ctx> {
     fn drop(&mut self) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_model_dec_ref(self.ctx.z3_ctx, self.z3_mdl) };
     }
 }

--- a/z3/src/params.rs
+++ b/z3/src/params.rs
@@ -4,7 +4,6 @@ use z3_sys::*;
 use Context;
 use Params;
 use Symbol;
-use Z3_MUTEX;
 
 impl<'ctx> Params<'ctx> {
     unsafe fn wrap(ctx: &'ctx Context, z3_params: Z3_params) -> Params<'ctx> {
@@ -13,12 +12,10 @@ impl<'ctx> Params<'ctx> {
     }
 
     pub fn new(ctx: &'ctx Context) -> Params<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_mk_params(ctx.z3_ctx)) }
     }
 
     pub fn set_symbol<K: Into<Symbol>, V: Into<Symbol>>(&mut self, k: K, v: V) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_params_set_symbol(
                 self.ctx.z3_ctx,
@@ -30,7 +27,6 @@ impl<'ctx> Params<'ctx> {
     }
 
     pub fn set_bool<K: Into<Symbol>>(&mut self, k: K, v: bool) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_params_set_bool(
                 self.ctx.z3_ctx,
@@ -42,7 +38,6 @@ impl<'ctx> Params<'ctx> {
     }
 
     pub fn set_f64<K: Into<Symbol>>(&mut self, k: K, v: f64) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_params_set_double(
                 self.ctx.z3_ctx,
@@ -54,7 +49,6 @@ impl<'ctx> Params<'ctx> {
     }
 
     pub fn set_u32<K: Into<Symbol>>(&mut self, k: K, v: u32) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_params_set_uint(
                 self.ctx.z3_ctx,
@@ -87,7 +81,6 @@ impl<'ctx> fmt::Debug for Params<'ctx> {
 
 impl<'ctx> Drop for Params<'ctx> {
     fn drop(&mut self) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_params_dec_ref(self.ctx.z3_ctx, self.z3_params) };
     }
 }

--- a/z3/src/pattern.rs
+++ b/z3/src/pattern.rs
@@ -5,7 +5,6 @@ use std::fmt;
 use z3_sys::*;
 use Context;
 use Pattern;
-use Z3_MUTEX;
 
 impl<'ctx> Pattern<'ctx> {
     /// Create a pattern for quantifier instantiation.
@@ -35,7 +34,6 @@ impl<'ctx> Pattern<'ctx> {
         Pattern {
             ctx,
             z3_pattern: unsafe {
-                let _guard = Z3_MUTEX.lock().unwrap();
                 let p = Z3_mk_pattern(
                     ctx.z3_ctx,
                     terms.len().try_into().unwrap(),

--- a/z3/src/probe.rs
+++ b/z3/src/probe.rs
@@ -7,7 +7,6 @@ use z3_sys::*;
 use Context;
 use Goal;
 use Probe;
-use Z3_MUTEX;
 
 impl<'ctx> Probe<'ctx> {
     unsafe fn wrap(ctx: &'ctx Context, z3_probe: Z3_probe) -> Probe<'ctx> {
@@ -32,7 +31,6 @@ impl<'ctx> Probe<'ctx> {
 
     pub fn new(ctx: &'ctx Context, name: &str) -> Probe<'ctx> {
         let probe_name = CString::new(name).unwrap();
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_mk_probe(ctx.z3_ctx, probe_name.as_ptr())) }
     }
 
@@ -42,7 +40,6 @@ impl<'ctx> Probe<'ctx> {
 
     /// Return a probe that always evaluates to val.
     pub fn constant(ctx: &'ctx Context, val: f64) -> Probe<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_probe_const(ctx.z3_ctx, val)) }
     }
 
@@ -50,7 +47,6 @@ impl<'ctx> Probe<'ctx> {
     ///
     /// NOTE: For probes, "true" is any value different from 0.0.
     pub fn lt(&self, p: Probe) -> Probe<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Self::wrap(
                 self.ctx,
@@ -61,7 +57,6 @@ impl<'ctx> Probe<'ctx> {
 
     /// Return a probe that evaluates to "true" when the value returned by `self` is greater than the value returned by `p`.
     pub fn gt(&self, p: &Probe) -> Probe<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Self::wrap(
                 self.ctx,
@@ -72,7 +67,6 @@ impl<'ctx> Probe<'ctx> {
 
     /// Return a probe that evaluates to "true" when the value returned by `self` is less than or equal to the value returned by `p`.
     pub fn le(&self, p: &Probe) -> Probe<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Self::wrap(
                 self.ctx,
@@ -83,7 +77,6 @@ impl<'ctx> Probe<'ctx> {
 
     /// Return a probe that evaluates to "true" when the value returned by `self` is greater than or equal to the value returned by `p`.
     pub fn ge(&self, p: &Probe) -> Probe<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Self::wrap(
                 self.ctx,
@@ -94,7 +87,6 @@ impl<'ctx> Probe<'ctx> {
 
     /// Return a probe that evaluates to "true" when the value returned by `self` is equal to the value returned by `p`.
     pub fn eq(&self, p: &Probe) -> Probe<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Self::wrap(
                 self.ctx,
@@ -105,7 +97,6 @@ impl<'ctx> Probe<'ctx> {
 
     /// Return a probe that evaluates to "true" when `self` and `p` evaluates to true.
     pub fn and(&self, p: &Probe) -> Probe<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Self::wrap(
                 self.ctx,
@@ -116,7 +107,6 @@ impl<'ctx> Probe<'ctx> {
 
     /// Return a probe that evaluates to "true" when `p1` or `p2` evaluates to true.
     pub fn or(&self, p: &Probe) -> Probe<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Self::wrap(
                 self.ctx,
@@ -127,7 +117,6 @@ impl<'ctx> Probe<'ctx> {
 
     /// Return a probe that evaluates to "true" when `p` does not evaluate to true.
     pub fn not(&self) -> Probe<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(self.ctx, Z3_probe_not(self.ctx.z3_ctx, self.z3_probe)) }
     }
 
@@ -139,7 +128,6 @@ impl<'ctx> Probe<'ctx> {
 
 impl<'ctx> Clone for Probe<'ctx> {
     fn clone(&self) -> Self {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(self.ctx, self.z3_probe) }
     }
 }
@@ -158,7 +146,6 @@ impl<'ctx> fmt::Debug for Probe<'ctx> {
 
 impl<'ctx> Drop for Probe<'ctx> {
     fn drop(&mut self) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_probe_dec_ref(self.ctx.z3_ctx, self.z3_probe);
         }

--- a/z3/src/rec_func_decl.rs
+++ b/z3/src/rec_func_decl.rs
@@ -4,7 +4,7 @@ use std::convert::TryInto;
 use std::ffi::CStr;
 use std::fmt;
 use z3_sys::*;
-use {Context, RecFuncDecl, Sort, Symbol, Z3_MUTEX};
+use {Context, RecFuncDecl, Sort, Symbol};
 
 impl<'ctx> RecFuncDecl<'ctx> {
     pub fn new<S: Into<Symbol>>(
@@ -33,8 +33,6 @@ impl<'ctx> RecFuncDecl<'ctx> {
     }
 
     pub unsafe fn from_raw(ctx: &'ctx Context, z3_func_decl: Z3_func_decl) -> Self {
-        let _guard = Z3_MUTEX.lock().unwrap();
-
         Z3_inc_ref(ctx.z3_ctx, Z3_func_decl_to_ast(ctx.z3_ctx, z3_func_decl));
 
         Self { ctx, z3_func_decl }
@@ -124,7 +122,6 @@ impl<'ctx> RecFuncDecl<'ctx> {
 
         unsafe {
             ast::Dynamic::new(self.ctx, {
-                let _guard = Z3_MUTEX.lock().unwrap();
                 Z3_mk_app(
                     self.ctx.z3_ctx,
                     self.z3_func_decl,
@@ -137,10 +134,7 @@ impl<'ctx> RecFuncDecl<'ctx> {
 
     /// Return the `DeclKind` of this `RecFuncDecl`.
     pub fn kind(&self) -> DeclKind {
-        unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_get_decl_kind(self.ctx.z3_ctx, self.z3_func_decl)
-        }
+        unsafe { Z3_get_decl_kind(self.ctx.z3_ctx, self.z3_func_decl) }
     }
 
     /// Return the name of this `RecFuncDecl`.
@@ -149,7 +143,6 @@ impl<'ctx> RecFuncDecl<'ctx> {
     /// the `Symbol`.
     pub fn name(&self) -> String {
         unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
             let z3_ctx = self.ctx.z3_ctx;
             let symbol = Z3_get_decl_name(z3_ctx, self.z3_func_decl);
             match Z3_get_symbol_kind(z3_ctx, symbol) {

--- a/z3/src/solver.rs
+++ b/z3/src/solver.rs
@@ -10,7 +10,6 @@ use SatResult;
 use Solver;
 use Statistics;
 use Symbol;
-use Z3_MUTEX;
 
 impl<'ctx> Solver<'ctx> {
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_slv: Z3_solver) -> Solver<'ctx> {
@@ -57,14 +56,12 @@ impl<'ctx> Solver<'ctx> {
     /// [`Solver::reset()`]: #method.reset
     ///
     pub fn new(ctx: &'ctx Context) -> Solver<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_mk_solver(ctx.z3_ctx)) }
     }
 
     /// Create a new solver customized for the given logic.
     /// It returns `None` if the logic is unknown or unsupported.
     pub fn new_for_logic<S: Into<Symbol>>(ctx: &'ctx Context, logic: S) -> Option<Solver<'ctx>> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             let s = Z3_mk_solver_for_logic(ctx.z3_ctx, logic.into().as_z3_symbol(ctx));
             if s.is_null() {
@@ -76,7 +73,6 @@ impl<'ctx> Solver<'ctx> {
     }
 
     pub fn translate<'dest_ctx>(&self, dest: &'dest_ctx Context) -> Solver<'dest_ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Solver::wrap(
                 dest,
@@ -101,7 +97,6 @@ impl<'ctx> Solver<'ctx> {
     /// - [`Solver::assert_and_track()`](#method.assert_and_track)
     pub fn assert(&self, ast: &ast::Bool<'ctx>) {
         debug!("assert: {:?}", ast);
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_assert(self.ctx.z3_ctx, self.z3_slv, ast.z3_ast) };
     }
 
@@ -121,13 +116,11 @@ impl<'ctx> Solver<'ctx> {
     /// - [`Solver::assert()`](#method.assert)
     pub fn assert_and_track(&self, ast: &ast::Bool<'ctx>, p: &ast::Bool<'ctx>) {
         debug!("assert_and_track: {:?}", ast);
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_assert_and_track(self.ctx.z3_ctx, self.z3_slv, ast.z3_ast, p.z3_ast) };
     }
 
     /// Remove all assertions from the solver.
     pub fn reset(&self) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_reset(self.ctx.z3_ctx, self.z3_slv) };
     }
 
@@ -155,7 +148,6 @@ impl<'ctx> Solver<'ctx> {
     /// [model construction is enabled]: struct.Config.html#method.set_model_generation
     /// [proof generation was enabled]: struct.Config.html#method.set_proof_generation
     pub fn check(&self) -> SatResult {
-        let _guard = Z3_MUTEX.lock().unwrap();
         match unsafe { Z3_solver_check(self.ctx.z3_ctx, self.z3_slv) } {
             Z3_L_FALSE => SatResult::Unsat,
             Z3_L_UNDEF => SatResult::Unknown,
@@ -176,7 +168,6 @@ impl<'ctx> Solver<'ctx> {
     ///
     /// - [`Solver::check()`](#method.check)
     pub fn check_assumptions(&self, assumptions: &[ast::Bool<'ctx>]) -> SatResult {
-        let _guard = Z3_MUTEX.lock().unwrap();
         let a: Vec<Z3_ast> = assumptions.iter().map(|a| a.z3_ast).collect();
         match unsafe {
             Z3_solver_check_assumptions(self.ctx.z3_ctx, self.z3_slv, a.len() as u32, a.as_ptr())
@@ -204,26 +195,17 @@ impl<'ctx> Solver<'ctx> {
     /// - [`Solver::check_assumptions`](#method.check_assumptions)
     /// - [`Solver::assert_and_track`](#method.assert_and_track)
     pub fn get_unsat_core(&self) -> Vec<ast::Bool<'ctx>> {
-        let z3_unsat_core = unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_solver_get_unsat_core(self.ctx.z3_ctx, self.z3_slv)
-        };
+        let z3_unsat_core = unsafe { Z3_solver_get_unsat_core(self.ctx.z3_ctx, self.z3_slv) };
         if z3_unsat_core.is_null() {
             return vec![];
         }
 
-        let len = unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_ast_vector_size(self.ctx.z3_ctx, z3_unsat_core)
-        };
+        let len = unsafe { Z3_ast_vector_size(self.ctx.z3_ctx, z3_unsat_core) };
 
         let mut unsat_core = Vec::with_capacity(len as usize);
 
         for i in 0..len {
-            let elem = unsafe {
-                let _guard = Z3_MUTEX.lock().unwrap();
-                Z3_ast_vector_get(self.ctx.z3_ctx, z3_unsat_core, i)
-            };
+            let elem = unsafe { Z3_ast_vector_get(self.ctx.z3_ctx, z3_unsat_core, i) };
             let elem = unsafe { ast::Bool::new(self.ctx, elem) };
             unsat_core.push(elem);
         }
@@ -239,7 +221,6 @@ impl<'ctx> Solver<'ctx> {
     ///
     /// - [`Solver::pop()`](#method.pop)
     pub fn push(&self) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_push(self.ctx.z3_ctx, self.z3_slv) };
     }
 
@@ -249,7 +230,6 @@ impl<'ctx> Solver<'ctx> {
     ///
     /// - [`Solver::push()`](#method.push)
     pub fn pop(&self, n: u32) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_pop(self.ctx.z3_ctx, self.z3_slv, n) };
     }
 
@@ -279,10 +259,7 @@ impl<'ctx> Solver<'ctx> {
     // This seems to actually return an Ast with kind `SortKind::Unknown`, which we don't
     // have an Ast subtype for yet.
     pub fn get_proof(&self) -> Option<impl Ast<'ctx>> {
-        let m = unsafe {
-            let _guard = Z3_MUTEX.lock().unwrap();
-            Z3_solver_get_proof(self.ctx.z3_ctx, self.z3_slv)
-        };
+        let m = unsafe { Z3_solver_get_proof(self.ctx.z3_ctx, self.z3_slv) };
         if !m.is_null() {
             Some(unsafe { ast::Dynamic::new(self.ctx, m) })
         } else {
@@ -306,13 +283,11 @@ impl<'ctx> Solver<'ctx> {
 
     /// Set the current solver using the given parameters.
     pub fn set_params(&self, params: &Params<'ctx>) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_set_params(self.ctx.z3_ctx, self.z3_slv, params.z3_params) };
     }
 
     /// Retrieve the statistics for the last [`Solver::check()`].
     pub fn get_statistics(&self) -> Statistics<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Statistics::wrap(
                 self.ctx,
@@ -343,7 +318,6 @@ impl<'ctx> fmt::Debug for Solver<'ctx> {
 
 impl<'ctx> Drop for Solver<'ctx> {
     fn drop(&mut self) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Z3_solver_dec_ref(self.ctx.z3_ctx, self.z3_slv) };
     }
 }

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -7,7 +7,6 @@ use FuncDecl;
 use Sort;
 use SortDiffers;
 use Symbol;
-use Z3_MUTEX;
 
 impl<'ctx> Sort<'ctx> {
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_sort: Z3_sort) -> Sort<'ctx> {
@@ -16,7 +15,6 @@ impl<'ctx> Sort<'ctx> {
     }
 
     pub fn uninterpreted(ctx: &'ctx Context, name: Symbol) -> Sort<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Self::wrap(
                 ctx,
@@ -26,47 +24,38 @@ impl<'ctx> Sort<'ctx> {
     }
 
     pub fn bool(ctx: &'ctx Context) -> Sort<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_mk_bool_sort(ctx.z3_ctx)) }
     }
 
     pub fn int(ctx: &'ctx Context) -> Sort<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_mk_int_sort(ctx.z3_ctx)) }
     }
 
     pub fn real(ctx: &'ctx Context) -> Sort<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_mk_real_sort(ctx.z3_ctx)) }
     }
 
     pub fn float(ctx: &'ctx Context, ebits: u32, sbits: u32) -> Sort<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx, ebits, sbits)) }
     }
 
     pub fn float32(ctx: &'ctx Context) -> Sort<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx, 8, 24)) }
     }
 
     pub fn double(ctx: &'ctx Context) -> Sort<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx, 11, 53)) }
     }
 
     pub fn string(ctx: &'ctx Context) -> Sort<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_mk_string_sort(ctx.z3_ctx)) }
     }
 
     pub fn bitvector(ctx: &'ctx Context, sz: u32) -> Sort<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_mk_bv_sort(ctx.z3_ctx, sz as ::std::os::raw::c_uint)) }
     }
 
     pub fn array(ctx: &'ctx Context, domain: &Sort<'ctx>, range: &Sort<'ctx>) -> Sort<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Self::wrap(
                 ctx,
@@ -76,7 +65,6 @@ impl<'ctx> Sort<'ctx> {
     }
 
     pub fn set(ctx: &'ctx Context, elt: &Sort<'ctx>) -> Sort<'ctx> {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(ctx, Z3_mk_set_sort(ctx.z3_ctx, elt.z3_sort)) }
     }
 
@@ -119,8 +107,6 @@ impl<'ctx> Sort<'ctx> {
         name: Symbol,
         enum_names: &[Symbol],
     ) -> (Sort<'ctx>, Vec<FuncDecl<'ctx>>, Vec<FuncDecl<'ctx>>) {
-        let _guard = Z3_MUTEX.lock().unwrap();
-
         let enum_names: Vec<_> = enum_names.iter().map(|s| s.as_z3_symbol(ctx)).collect();
         let mut enum_consts = vec![std::ptr::null_mut(); enum_names.len()];
         let mut enum_testers = vec![std::ptr::null_mut(); enum_names.len()];
@@ -284,7 +270,6 @@ impl<'ctx> Sort<'ctx> {
 
 impl<'ctx> Clone for Sort<'ctx> {
     fn clone(&self) -> Self {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(self.ctx, self.z3_sort) }
     }
 }

--- a/z3/src/statistics.rs
+++ b/z3/src/statistics.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use z3_sys::*;
 use Context;
 use Statistics;
-use Z3_MUTEX;
 
 /// The value for a key in [`Statistics`].
 ///
@@ -82,7 +81,6 @@ impl<'ctx> Statistics<'ctx> {
 
 impl<'ctx> Clone for Statistics<'ctx> {
     fn clone(&self) -> Self {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe { Self::wrap(self.ctx, self.z3_stats) }
     }
 }
@@ -108,7 +106,6 @@ impl<'ctx> fmt::Debug for Statistics<'ctx> {
 
 impl<'ctx> Drop for Statistics<'ctx> {
     fn drop(&mut self) {
-        let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             Z3_stats_dec_ref(self.ctx.z3_ctx, self.z3_stats);
         }


### PR DESCRIPTION
The issues with Z3 that caused this to be needed were fixed long
ago, so hopefully this is no longer required.

An earlier version of this patch was developed by <blackbinary@qq.com>.

This replaces the work previously in #143.