### PR TITLE
Make it buildable for wasm with emscripten

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,21 @@ jobs:
       # See above.
       if: ${{ success() || failure() }}
 
+  build_on_wasm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install emscripten
+      run: |
+        git clone https://github.com/emscripten-core/emsdk.git
+        cd emsdk
+        git pull
+        ./emsdk install latest
+        ./emsdk activate latest
+        source ./emsdk_env.sh
+    - name: Build
+      run: cargo build -vv --all --target=wasm32-unknown-emscripten
+
   build_z3_statically:
     strategy:
       matrix:


### PR DESCRIPTION
fix #215

Surprisingly, it just needed to use emscripten's sysroot with bindgen. For `wasm32-wasi` target more work is needed, as it doesn't support c++ exceptions yet, but I think `wasm32-unknown-emscripten` is enough for most of use cases (including my use case).