### PR TITLE
Add clippy allow Attribute

### DIFF
--- a/z3/src/goal.rs
+++ b/z3/src/goal.rs
@@ -68,6 +68,7 @@ impl<'ctx> Goal<'ctx> {
     }
 
     /// Copy a goal `g` from the context `source` to the context `target`.
+    #[allow(clippy::needless_lifetimes)]
     pub fn translate<'dest_ctx>(self, ctx: &'dest_ctx Context) -> Goal<'dest_ctx> {
         unsafe {
             Goal::wrap(


### PR DESCRIPTION
A drive-by pr to address a clippy warning. I figured the name of the lifetime was informative, so I just added the allow attribute instead of removing the lifetime/switching to `Goal<'_>`.

One odd thing about the current documentation. For a function like https://docs.rs/z3/latest/z3/struct.Solver.html#method.assert_and_track, I was initially confused that the documentation page referenced an `a` that is not the function argument(which would be `ast`) but instead references the underlying function implementation that is called which has an argument named `a`. This made sense reading the source, but is strange when just reading from the generated docs. I have no suggested change, just an observation of an outsider.
```
/// Assert a constraint `a` into the solver, and track it (in the
/// unsat) core using the Boolean constant `p`.
...
pub fn assert_and_track(&self, ast: &ast::Bool<'ctx>, p: &ast::Bool<'ctx>) {
```