### PR TITLE
ref ast conversion into Dynamic

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -524,6 +524,12 @@ macro_rules! impl_from_try_into_dynamic {
             }
         }
 
+        impl<'ctx> From<&$ast<'ctx>> for Dynamic<'ctx> {
+            fn from(ast: &$ast<'ctx>) -> Self {
+                unsafe { Dynamic::wrap(ast.ctx, ast.z3_ast) }
+            }
+        }
+
         impl<'ctx> TryFrom<Dynamic<'ctx>> for $ast<'ctx> {
             type Error = std::string::String;
             fn try_from(ast: Dynamic<'ctx>) -> Result<Self, std::string::String> {

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -168,8 +168,8 @@ pub struct FuncDecl<'ctx> {
 /// # See also:
 ///
 /// - [`RecFuncDecl::add_def`]
-// Note for in-crate users: Never construct a `FuncDecl` directly; only use
-// `FuncDecl::new()` which handles Z3 refcounting properly.
+// Note for in-crate users: Never construct a `RecFuncDecl` directly; only use
+// `RecFuncDecl::new()` which handles Z3 refcounting properly.
 pub struct RecFuncDecl<'ctx> {
     ctx: &'ctx Context,
     z3_func_decl: Z3_func_decl,


### PR DESCRIPTION
I found myself making what I think are unnecessary clones when getting the dynamic versions of an Ast(while still holding onto the typed version of the Ast). I've added an additional `From` impl which I believe to be safe because `Dynamic::as_{bool, int, real}` do the inverse of this. https://github.com/prove-rs/z3.rs/blob/ee521b74bbe0e76113b2399e1a4640b3d6995181/z3/src/ast.rs#L1626-L1655

I also fixed a small copy-paste error.