### PR TITLE
Z3 from string

### DIFF
--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -5566,7 +5566,7 @@ extern "C" {
     ///
     /// - [`Z3_solver_from_file`]
     /// - [`Z3_solver_to_string`]
-    pub fn Z3_solver_from_string(c: Z3_context, s: Z3_solver, file_name: Z3_string);
+    pub fn Z3_solver_from_string(c: Z3_context, s: Z3_solver, c_str: Z3_string);
 
     /// Return the set of asserted formulas on the solver.
     pub fn Z3_solver_get_assertions(c: Z3_context, s: Z3_solver) -> Z3_ast_vector;

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -27,6 +27,22 @@ impl<'ctx> Optimize<'ctx> {
         unsafe { Self::wrap(ctx, Z3_mk_optimize(ctx.z3_ctx)) }
     }
 
+    /// Parse an SMT-LIB2 string with assertions, soft constraints and optimization objectives.
+    /// Add the parsed constraints and objectives to a new created optimization context.
+    pub fn new_from_smtlib2(ctx: &'ctx Context, source_string: String) -> Optimize<'ctx> {
+        let source_cstring = CString::new(source_string).unwrap();
+        Optimize {
+            ctx,
+            z3_opt: unsafe {
+                let _guard = Z3_MUTEX.lock().unwrap();
+                let opt = Z3_mk_optimize(ctx.z3_ctx);
+                Z3_optimize_inc_ref(ctx.z3_ctx, opt);
+                Z3_optimize_from_string(ctx.z3_ctx, opt, source_cstring.as_ptr());
+                opt
+            },
+        }
+    }
+
     /// Get this optimizers 's context.
     pub fn get_context(&self) -> &'ctx Context {
         self.ctx

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -28,18 +28,11 @@ impl<'ctx> Optimize<'ctx> {
     }
 
     /// Parse an SMT-LIB2 string with assertions, soft constraints and optimization objectives.
-    /// Add the parsed constraints and objectives to a new created optimization context.
-    pub fn new_from_smtlib2(ctx: &'ctx Context, source_string: String) -> Optimize<'ctx> {
+    /// Add the parsed constraints and objectives to the optimizer.
+    pub fn from_string<T: Into<Vec<u8>>>(&self, source_string: T) {
         let source_cstring = CString::new(source_string).unwrap();
-        Optimize {
-            ctx,
-            z3_opt: unsafe {
-                let _guard = Z3_MUTEX.lock().unwrap();
-                let opt = Z3_mk_optimize(ctx.z3_ctx);
-                Z3_optimize_inc_ref(ctx.z3_ctx, opt);
-                Z3_optimize_from_string(ctx.z3_ctx, opt, source_cstring.as_ptr());
-                opt
-            },
+        unsafe {
+            Z3_optimize_from_string(self.ctx.z3_ctx, self.z3_opt, source_cstring.as_ptr());
         }
     }
 

--- a/z3/src/solver.rs
+++ b/z3/src/solver.rs
@@ -53,20 +53,13 @@ impl<'ctx> Solver<'ctx> {
     }
 
     /// Parse an SMT-LIB2 string with assertions, soft constraints and optimization objectives.
-    /// Add the parsed constraints and objectives to a new created solver context.
-    pub fn new_from_smtlib2(ctx: &'ctx Context, source_string: String) -> Solver<'ctx> {
+    /// Add the parsed constraints and objectives to the solver.
+    pub fn from_string<T: Into<Vec<u8>>>(&self, source_string: T) {
         let source_cstring = CString::new(source_string).unwrap();
-        Solver {
-            ctx,
-            z3_slv: unsafe {
-                let _guard = Z3_MUTEX.lock().unwrap();
-                let opt = Z3_mk_solver(ctx.z3_ctx);
-                Z3_solver_from_string(ctx.z3_ctx, opt, source_cstring.as_ptr());
-                opt
-            },
+        unsafe {
+            Z3_solver_from_string(self.ctx.z3_ctx, self.z3_slv, source_cstring.as_ptr());
         }
     }
-
 
     /// Create a new solver customized for the given logic.
     /// It returns `None` if the logic is unknown or unsupported.

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -243,7 +243,8 @@ fn test_solver_new_from_smtlib2() {
 (assert (=( -(+(* 3 x) (* 2 y)) z) 1))
 (assert (=(+( -(* 2 x) (* 2 y)) (* 4 z)) -2))
 "#;
-    let solver = Solver::new_from_smtlib2(&ctx, problem.into());
+    let solver = Solver::new(&ctx);
+    solver.from_string(problem);
     assert_eq!(solver.check(), SatResult::Sat);
 }
 
@@ -706,7 +707,8 @@ fn test_optimize_new_from_smtlib2() {
 (assert (=( -(+(* 3 x) (* 2 y)) z) 1))
 (assert (=(+( -(* 2 x) (* 2 y)) (* 4 z)) -2))
 "#;
-    let optimize = Optimize::new_from_smtlib2(&ctx, problem.into());
+    let optimize = Optimize::new(&ctx);
+    optimize.from_string(problem);
     assert_eq!(optimize.check(&[]), SatResult::Sat);
 }
 

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -233,6 +233,21 @@ fn test_ast_translate() {
 }
 
 #[test]
+fn test_solver_new_from_smtlib2() {
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+    let problem = r#"
+(declare -const x Real)
+(declare -const y Real)
+(declare -const z Real)
+(assert (=( -(+(* 3 x) (* 2 y)) z) 1))
+(assert (=(+( -(* 2 x) (* 2 y)) (* 4 z)) -2))
+"#;
+    let solver = Solver::new_from_smtlib2(&ctx, problem.into());
+    assert_eq!(solver.check(), SatResult::Sat);
+}
+
+#[test]
 fn test_solver_translate() {
     let cfg = Config::new();
     let source = Context::new(&cfg);
@@ -677,6 +692,22 @@ fn test_optimize_unknown() {
 
     assert_eq!(optimize.check(&[]), SatResult::Unknown);
     assert!(optimize.get_reason_unknown().is_some());
+}
+
+#[test]
+fn test_optimize_new_from_smtlib2() {
+    let _ = env_logger::try_init();
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+    let problem = r#"
+(declare -const x Real)
+(declare -const y Real)
+(declare -const z Real)
+(assert (=( -(+(* 3 x) (* 2 y)) z) 1))
+(assert (=(+( -(* 2 x) (* 2 y)) (* 4 z)) -2))
+"#;
+    let optimize = Optimize::new_from_smtlib2(&ctx, problem.into());
+    assert_eq!(optimize.check(&[]), SatResult::Sat);
 }
 
 #[test]


### PR DESCRIPTION
I am interested in pushing through #194.

The changes I made are:
- Loosening the input type to be `Into<Vec<u8>>` which is the most general type CString expects. This allows one to pass a &str to this function as shown in the tests. (Comment in https://github.com/prove-rs/z3.rs/pull/194#discussion_r927060804)
- The inner unsafe code is reworked to the current style used in the library with `Self::wrap` for construction.
- Renamed the function argument in `Z3_solver_from_string` to be `c_str` which matches the cpp api https://github.com/Z3Prover/z3/blob/a0f3727e90c4446ba2c1fa7e4392637587ad9632/src/api/api_solver.cpp#L358-L369 and makes more sense to me