### PR TITLE
Update dependencies and appease Clippy

### DIFF
--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -16,8 +16,8 @@ homepage = "https://github.com/prove-rs/z3.rs"
 repository = "https://github.com/prove-rs/z3.rs.git"
 
 [build-dependencies]
-bindgen = { version = "0.60", default-features = false, features = ["runtime"] }
-cmake = { version = "0.1", optional = true }
+bindgen = { version = "0.64.0", default-features = false, features = ["runtime"] }
+cmake = { version = "0.1.49", optional = true }
 
 [features]
 # Enable this feature to statically link our own build of Z3, rather than

--- a/z3/src/datatype_builder.rs
+++ b/z3/src/datatype_builder.rs
@@ -138,7 +138,7 @@ pub fn create_datatypes<'ctx>(
         unsafe { Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, z3_sort)) };
         let sort = Sort { ctx, z3_sort };
 
-        let mut variants: Vec<DatatypeVariant<'ctx>> = Vec::with_capacity(num_cs as usize);
+        let mut variants: Vec<DatatypeVariant<'ctx>> = Vec::with_capacity(num_cs);
 
         for (j, (_cname, fs)) in datatype_builder.constructors.iter().enumerate() {
             let num_fs = fs.len();

--- a/z3/src/goal.rs
+++ b/z3/src/goal.rs
@@ -90,7 +90,7 @@ impl<'ctx> Goal<'ctx> {
         let goal_size = self.get_size() as usize;
         let z3_ctx = self.ctx.z3_ctx;
         let z3_goal = self.z3_goal;
-        (0..goal_size).into_iter().map(move |i| {
+        (0..goal_size).map(move |i| {
             let formula = unsafe { Z3_goal_formula(z3_ctx, z3_goal, i as u32) };
             unsafe { T::wrap(self.ctx, formula) }
         })

--- a/z3/src/probe.rs
+++ b/z3/src/probe.rs
@@ -24,7 +24,7 @@ impl<'ctx> Probe<'ctx> {
     /// let cfg = Config::new();
     /// let ctx = Context::new(&cfg);
     /// let probes: Vec<_> = Probe::list_all(&ctx).filter_map(|r| r.ok()).collect();
-    /// assert!(probes.contains(&"is-qfbv"));
+    /// assert!(probes.contains(&"is-quasi-pb"));
     /// ```
     pub fn list_all(
         ctx: &'ctx Context,

--- a/z3/src/probe.rs
+++ b/z3/src/probe.rs
@@ -30,7 +30,7 @@ impl<'ctx> Probe<'ctx> {
         ctx: &'ctx Context,
     ) -> impl Iterator<Item = std::result::Result<&'ctx str, Utf8Error>> {
         let p = unsafe { Z3_get_num_probes(ctx.z3_ctx) };
-        (0..p).into_iter().map(move |n| {
+        (0..p).map(move |n| {
             let t = unsafe { Z3_get_probe_name(ctx.z3_ctx, n) };
             unsafe { CStr::from_ptr(t) }.to_str()
         })

--- a/z3/src/statistics.rs
+++ b/z3/src/statistics.rs
@@ -69,7 +69,7 @@ impl<'ctx> Statistics<'ctx> {
     /// Iterate over all of the entries in this set of statistics.
     pub fn entries(&self) -> impl Iterator<Item = StatisticsEntry> + '_ {
         let p = unsafe { Z3_stats_size(self.ctx.z3_ctx, self.z3_stats) };
-        (0..p).into_iter().map(move |n| unsafe {
+        (0..p).map(move |n| unsafe {
             let t = Z3_stats_get_key(self.ctx.z3_ctx, self.z3_stats, n);
             StatisticsEntry {
                 key: CStr::from_ptr(t).to_str().unwrap().to_owned(),

--- a/z3/src/tactic.rs
+++ b/z3/src/tactic.rs
@@ -27,7 +27,7 @@ impl<'ctx> ApplyResult<'ctx> {
     pub fn list_subgoals(self) -> impl Iterator<Item = Goal<'ctx>> {
         let num_subgoals =
             unsafe { Z3_apply_result_get_num_subgoals(self.ctx.z3_ctx, self.z3_apply_result) };
-        (0..num_subgoals).into_iter().map(move |i| unsafe {
+        (0..num_subgoals).map(move |i| unsafe {
             Goal::wrap(
                 self.ctx,
                 Z3_apply_result_get_subgoal(self.ctx.z3_ctx, self.z3_apply_result, i),
@@ -61,7 +61,7 @@ impl<'ctx> Tactic<'ctx> {
         ctx: &'ctx Context,
     ) -> impl Iterator<Item = std::result::Result<&'ctx str, Utf8Error>> {
         let p = unsafe { Z3_get_num_tactics(ctx.z3_ctx) };
-        (0..p).into_iter().map(move |n| {
+        (0..p).map(move |n| {
             let t = unsafe { Z3_get_tactic_name(ctx.z3_ctx, n) };
             unsafe { CStr::from_ptr(t) }.to_str()
         })

--- a/z3/src/tactic.rs
+++ b/z3/src/tactic.rs
@@ -55,7 +55,7 @@ impl<'ctx> Tactic<'ctx> {
     /// let cfg = Config::new();
     /// let ctx = Context::new(&cfg);
     /// let tactics: Vec<_> = Tactic::list_all(&ctx).filter_map(|r| r.ok()).collect();
-    /// assert!(tactics.contains(&"nlsat"));
+    /// assert!(tactics.contains(&"ufbv"));
     /// ```
     pub fn list_all(
         ctx: &'ctx Context,

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -598,7 +598,6 @@ fn test_rec_func_def_unsat() {
 }
 
 #[test]
-#[ignore = "See https://github.com/Z3Prover/z3/issues/5702"]
 fn test_solver_unknown() {
     let _ = env_logger::try_init();
     let mut cfg = Config::new();


### PR DESCRIPTION
First of all, thanks _very_ much for this project! It makes it very straightforward to reach for Z3 from Rust.

If you don't mind, this PR makes two changes, both in the interest of appeasing Clippy:

1.  bump dependencies in `z3-sys/Cargo.toml` to ensure a newer `nom` version is used, ameliorating a Clippy's objection `warning: the following packages contain code that will be rejected by a future version of Rust: nom v5.1.2`
2. other small changes in `z3` to appease Clippy & silence warnings

Thanks!