### PR TITLE
implementing FuncInterp & FuncEntry

### DIFF
--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -4692,7 +4692,7 @@ extern "C" {
     /// This procedure returns the 'else' value.
     pub fn Z3_func_interp_get_else(c: Z3_context, f: Z3_func_interp) -> Z3_ast;
 
-    /// Return the 'else' value of the given function interpretation.
+    /// Set the 'else' value of the given function interpretation.
     ///
     /// A function interpretation is represented as a finite map and an 'else' value.
     /// This procedure can be used to update the 'else' value.

--- a/z3/src/func_entry.rs
+++ b/z3/src/func_entry.rs
@@ -1,0 +1,62 @@
+use std::fmt;
+
+use ast::Ast;
+use z3_sys::*;
+
+use {ast::Dynamic, Context, FuncEntry};
+
+impl<'ctx> FuncEntry<'ctx> {
+    pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_func_entry: Z3_func_entry) -> Self {
+        Z3_func_entry_inc_ref(ctx.z3_ctx, z3_func_entry);
+        Self { ctx, z3_func_entry }
+    }
+
+    pub fn get_value(&self) -> Dynamic {
+        unsafe {
+            Dynamic::wrap(
+                self.ctx,
+                Z3_func_entry_get_value(self.ctx.z3_ctx, self.z3_func_entry),
+            )
+        }
+    }
+
+    pub fn get_num_args(&self) -> u32 {
+        unsafe { Z3_func_entry_get_num_args(self.ctx.z3_ctx, self.z3_func_entry) }
+    }
+
+    pub fn get_args(&self) -> Vec<Dynamic> {
+        (0..self.get_num_args())
+            .map(|i| unsafe {
+                Dynamic::wrap(
+                    self.ctx,
+                    Z3_func_entry_get_arg(self.ctx.z3_ctx, self.z3_func_entry, i),
+                )
+            })
+            .collect()
+    }
+}
+
+impl<'ctx> fmt::Display for FuncEntry<'ctx> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "[")?;
+        self.get_args()
+            .into_iter()
+            .try_for_each(|a| write!(f, "{a}, "))?;
+        write!(f, "{}", self.get_value())?;
+        write!(f, "]")
+    }
+}
+
+impl<'ctx> fmt::Debug for FuncEntry<'ctx> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        <Self as fmt::Display>::fmt(self, f)
+    }
+}
+
+impl<'ctx> Drop for FuncEntry<'ctx> {
+    fn drop(&mut self) {
+        unsafe {
+            Z3_func_entry_dec_ref(self.ctx.z3_ctx, self.z3_func_entry);
+        }
+    }
+}

--- a/z3/src/func_entry.rs
+++ b/z3/src/func_entry.rs
@@ -11,6 +11,7 @@ impl<'ctx> FuncEntry<'ctx> {
         Self { ctx, z3_func_entry }
     }
 
+    /// Returns the value of the function.
     pub fn get_value(&self) -> Dynamic {
         unsafe {
             Dynamic::wrap(
@@ -20,10 +21,12 @@ impl<'ctx> FuncEntry<'ctx> {
         }
     }
 
+    /// Returns the number of arguments in the function entry.
     pub fn get_num_args(&self) -> u32 {
         unsafe { Z3_func_entry_get_num_args(self.ctx.z3_ctx, self.z3_func_entry) }
     }
 
+    /// Returns the arguments of the function entry.
     pub fn get_args(&self) -> Vec<Dynamic> {
         (0..self.get_num_args())
             .map(|i| unsafe {

--- a/z3/src/func_interp.rs
+++ b/z3/src/func_interp.rs
@@ -1,0 +1,100 @@
+use ast::Ast;
+use std::fmt;
+use z3_sys::*;
+
+use {ast::Dynamic, Context, FuncEntry, FuncInterp};
+
+impl<'ctx> FuncInterp<'ctx> {
+    pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_func_interp: Z3_func_interp) -> Self {
+        Z3_func_interp_inc_ref(ctx.z3_ctx, z3_func_interp);
+
+        Self {
+            ctx,
+            z3_func_interp,
+        }
+    }
+
+    pub fn get_arity(&self) -> usize {
+        unsafe { Z3_func_interp_get_arity(self.ctx.z3_ctx, self.z3_func_interp) as usize }
+    }
+
+    pub fn get_num_entries(&self) -> u32 {
+        unsafe { Z3_func_interp_get_num_entries(self.ctx.z3_ctx, self.z3_func_interp) }
+    }
+
+    pub fn add_entry(&self, args: &[Dynamic<'ctx>], value: &Dynamic<'ctx>) {
+        unsafe {
+            let v = Z3_mk_ast_vector(self.ctx.z3_ctx);
+            Z3_ast_vector_inc_ref(self.ctx.z3_ctx, v);
+            args.iter()
+                .for_each(|a| Z3_ast_vector_push(self.ctx.z3_ctx, v, a.z3_ast));
+
+            Z3_func_interp_add_entry(self.ctx.z3_ctx, self.z3_func_interp, v, value.z3_ast)
+        }
+    }
+
+    pub fn get_entries(&self) -> Vec<FuncEntry> {
+        (0..self.get_num_entries())
+            .map(|i| unsafe {
+                FuncEntry::wrap(
+                    self.ctx,
+                    Z3_func_interp_get_entry(self.ctx.z3_ctx, self.z3_func_interp, i),
+                )
+            })
+            .collect()
+    }
+
+    pub fn get_else(&self) -> Dynamic<'ctx> {
+        unsafe {
+            Dynamic::wrap(
+                self.ctx,
+                Z3_func_interp_get_else(self.ctx.z3_ctx, self.z3_func_interp),
+            )
+        }
+    }
+
+    pub fn set_else(&self, ast: &Dynamic) {
+        unsafe { Z3_func_interp_set_else(self.ctx.z3_ctx, self.z3_func_interp, ast.z3_ast) }
+    }
+}
+
+impl<'ctx> fmt::Display for FuncInterp<'ctx> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "[")?;
+        self.get_entries().into_iter().try_for_each(|e| {
+            let n = e.get_num_args();
+            if n > 1 {
+                write!(f, "[")?
+            };
+            write!(
+                f,
+                "{}",
+                e.get_args()
+                    .into_iter()
+                    .map(|a| a.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )?;
+            if n > 1 {
+                write!(f, "]")?
+            }
+            write!(f, " -> {}, ", e.get_value())
+        })?;
+        write!(f, "else -> {}", self.get_else())?;
+        write!(f, "]")
+    }
+}
+
+impl<'ctx> fmt::Debug for FuncInterp<'ctx> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        <Self as fmt::Display>::fmt(self, f)
+    }
+}
+
+impl<'ctx> Drop for FuncInterp<'ctx> {
+    fn drop(&mut self) {
+        unsafe {
+            Z3_func_interp_dec_ref(self.ctx.z3_ctx, self.z3_func_interp);
+        }
+    }
+}

--- a/z3/src/func_interp.rs
+++ b/z3/src/func_interp.rs
@@ -14,14 +14,17 @@ impl<'ctx> FuncInterp<'ctx> {
         }
     }
 
+    /// Returns the number of arguments in the function interpretation.
     pub fn get_arity(&self) -> usize {
         unsafe { Z3_func_interp_get_arity(self.ctx.z3_ctx, self.z3_func_interp) as usize }
     }
 
+    /// Returns the number of entries in the function interpretation.
     pub fn get_num_entries(&self) -> u32 {
         unsafe { Z3_func_interp_get_num_entries(self.ctx.z3_ctx, self.z3_func_interp) }
     }
 
+    /// Adds an entry to the function interpretation.
     pub fn add_entry(&self, args: &[Dynamic<'ctx>], value: &Dynamic<'ctx>) {
         unsafe {
             let v = Z3_mk_ast_vector(self.ctx.z3_ctx);
@@ -33,6 +36,7 @@ impl<'ctx> FuncInterp<'ctx> {
         }
     }
 
+    /// Returns the entries of the function interpretation.
     pub fn get_entries(&self) -> Vec<FuncEntry> {
         (0..self.get_num_entries())
             .map(|i| unsafe {
@@ -44,6 +48,8 @@ impl<'ctx> FuncInterp<'ctx> {
             .collect()
     }
 
+    /// Returns the else value of the function interpretation.
+    /// Returns None if the else value is not set by Z3.
     pub fn get_else(&self) -> Dynamic<'ctx> {
         unsafe {
             Dynamic::wrap(
@@ -53,6 +59,7 @@ impl<'ctx> FuncInterp<'ctx> {
         }
     }
 
+    /// Sets the else value of the function interpretation.
     pub fn set_else(&self, ast: &Dynamic) {
         unsafe { Z3_func_interp_set_else(self.ctx.z3_ctx, self.z3_func_interp, ast.z3_ast) }
     }

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -22,6 +22,8 @@ mod config;
 mod context;
 pub mod datatype_builder;
 mod func_decl;
+mod func_entry;
+mod func_interp;
 mod goal;
 mod model;
 mod ops;
@@ -157,6 +159,16 @@ pub struct Optimize<'ctx> {
 pub struct FuncDecl<'ctx> {
     ctx: &'ctx Context,
     z3_func_decl: Z3_func_decl,
+}
+
+pub struct FuncInterp<'ctx> {
+    ctx: &'ctx Context,
+    z3_func_interp: Z3_func_interp,
+}
+
+pub struct FuncEntry<'ctx> {
+    ctx: &'ctx Context,
+    z3_func_entry: Z3_func_entry,
 }
 
 /// Recursive function declaration. Every function has an associated declaration.

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -161,11 +161,15 @@ pub struct FuncDecl<'ctx> {
     z3_func_decl: Z3_func_decl,
 }
 
+/// Stores the interpretation of a function in a Z3 model.
+/// https://z3prover.github.io/api/html/classz3py_1_1_func_interp.html
 pub struct FuncInterp<'ctx> {
     ctx: &'ctx Context,
     z3_func_interp: Z3_func_interp,
 }
 
+/// Store the value of the interpretation of a function in a particular point.
+/// https://z3prover.github.io/api/html/classz3py_1_1_func_entry.html
 pub struct FuncEntry<'ctx> {
     ctx: &'ctx Context,
     z3_func_entry: Z3_func_entry,

--- a/z3/src/model.rs
+++ b/z3/src/model.rs
@@ -61,6 +61,8 @@ impl<'ctx> Model<'ctx> {
         }
     }
 
+    /// Returns the interpretation of the given `f` in the `Model`
+    /// Returns `None` if there is no interpretation in the `Model`
     pub fn get_func_interp(&self, f: &FuncDecl) -> Option<FuncInterp<'ctx>> {
         if f.arity() == 0 {
             let ret =


### PR DESCRIPTION
I am interested in getting the interpretation that a model has of a function by exposing `FuncInterp` to the high level bindings.

I've heavily drawn from the other Z3 bindings in the public facing methods I've implemented while following the same general format that other structs have with the `wrap` and `Drop` implementations.

Some/most bindings overload the `get_const_interp` method to handle both `Ast`'s and `FuncDecl`'s which I haven't done.

I'll note that `get_func_interp` is particularly complex compared to most of the methods implemented, though it is almost entirely drawn from other implementations and I've free-handed the use of `Z3_mk_ast_vector` in `add_entry`. These probably require additional attention.

I'll be looking to add some rough documentation/tests.

Related to #213