### PR TITLE
Implement Iterator over a Model

### DIFF
--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1654,3 +1654,60 @@ fn return_number_args_in_given_entry() {
 
     assert!(model.to_string() == "f -> {\n  1 2 -> 20\n  else -> 10\n}\n");
 }
+
+#[test]
+/// https://stackoverflow.com/questions/13395391/z3-finding-all-satisfying-models
+fn iterate_all_solutions() {
+    let cfg = Config::new();
+    let ctx = &Context::new(&cfg);
+    let solver = Solver::new(ctx);
+    let a = &Int::new_const(ctx, "a");
+    let b = &Int::new_const(ctx, "b");
+    let one = Int::from_u64(ctx, 1);
+    let two = Int::from_u64(ctx, 2);
+    let five = &Int::from_u64(ctx, 5);
+
+    solver.assert(&one.le(a));
+    solver.assert(&a.le(five));
+    solver.assert(&one.le(b));
+    solver.assert(&b.le(five));
+    solver.assert(&a.ge(&(two * b)));
+
+    let mut solutions = std::collections::HashSet::new();
+    while solver.check() == SatResult::Sat {
+        let model = solver.get_model().unwrap();
+        let mut modifications = Vec::new();
+        let this_solution = model
+            .iter()
+            .map(|fd| {
+                modifications.push(
+                    fd.apply(&[])
+                        ._eq(&model.get_const_interp(&fd.apply(&[])).unwrap())
+                        .not(),
+                );
+                format!(
+                    "{} = {}",
+                    fd.name(),
+                    model.get_const_interp(&fd.apply(&[])).unwrap()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        solutions.insert(format!("[{this_solution}]"));
+        solver.assert(&Bool::or(ctx, &modifications.iter().collect::<Vec<_>>()));
+    }
+
+    assert!(
+        solutions
+            == vec![
+                "[b = 1, a = 2]".to_string(),
+                "[b = 2, a = 4]".to_string(),
+                "[b = 1, a = 3]".to_string(),
+                "[b = 2, a = 5]".to_string(),
+                "[b = 1, a = 4]".to_string(),
+                "[b = 1, a = 5]".to_string()
+            ]
+            .into_iter()
+            .collect()
+    )
+}


### PR DESCRIPTION
One nice abstraction that the python bindings implement is to be able to iterate over a `Model`. One can then use the features added in #221 to get the interpretations that the `Model` assigns for these declarations.

If this is worth adding, the implementation comes from https://z3prover.github.io/api/html/classz3py_1_1_model_ref.html#a7890b7c9bc70cf2a26a343c22d2c8367 where they hook into Python's `__len__` and `__getitem__` to extract all consts and funcs from a model when using a for loop. I think the only difference here is that for Rust we need to manage a struct that does the iteration, here `ModelIter`(akin to https://doc.rust-lang.org/std/slice/struct.Iter.html) which contains the current index into the model and the total length.

The testcase is related to #221.