### PR TITLE
Aligning `apply` methods of FuncDecl and RecFuncDecl

### DIFF
--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -181,6 +181,8 @@ pub struct FuncEntry<'ctx> {
 /// the sort (i.e., type) of each of its arguments. This is the function declaration type
 /// you should use if you want to add a definition to your function, recursive or not.
 ///
+/// This struct can dereference into a [`FuncDecl`] to access its methods.
+///
 /// # See also:
 ///
 /// - [`RecFuncDecl::add_def`]

--- a/z3/src/rec_func_decl.rs
+++ b/z3/src/rec_func_decl.rs
@@ -3,8 +3,9 @@ use ast::Ast;
 use std::convert::TryInto;
 use std::ffi::CStr;
 use std::fmt;
+use std::ops::Deref;
 use z3_sys::*;
-use {Context, RecFuncDecl, Sort, Symbol};
+use {Context, FuncDecl, RecFuncDecl, Sort, Symbol};
 
 impl<'ctx> RecFuncDecl<'ctx> {
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_func_decl: Z3_func_decl) -> Self {
@@ -91,67 +92,6 @@ impl<'ctx> RecFuncDecl<'ctx> {
             );
         }
     }
-
-    /// Return the number of arguments of a function declaration.
-    ///
-    /// If the function declaration is a constant, then the arity is `0`.
-    ///
-    /// ```
-    /// # use z3::{Config, Context, RecFuncDecl, Solver, Sort, Symbol};
-    /// # let cfg = Config::new();
-    /// # let ctx = Context::new(&cfg);
-    /// let f = RecFuncDecl::new(
-    ///     &ctx,
-    ///     "f",
-    ///     &[&Sort::int(&ctx), &Sort::real(&ctx)],
-    ///     &Sort::int(&ctx));
-    /// assert_eq!(f.arity(), 2);
-    /// ```
-    pub fn arity(&self) -> usize {
-        unsafe { Z3_get_arity(self.ctx.z3_ctx, self.z3_func_decl) as usize }
-    }
-
-    /// Create a constant (if `args` has length 0) or function application (otherwise).
-    ///
-    /// Note that `args` should have the types corresponding to the `domain` of the `RecFuncDecl`.
-    pub fn apply(&self, args: &[&dyn ast::Ast<'ctx>]) -> ast::Dynamic<'ctx> {
-        assert!(args.iter().all(|s| s.get_ctx().z3_ctx == self.ctx.z3_ctx));
-
-        let args: Vec<_> = args.iter().map(|a| a.get_z3_ast()).collect();
-
-        unsafe {
-            ast::Dynamic::wrap(self.ctx, {
-                Z3_mk_app(
-                    self.ctx.z3_ctx,
-                    self.z3_func_decl,
-                    args.len().try_into().unwrap(),
-                    args.as_ptr(),
-                )
-            })
-        }
-    }
-
-    /// Return the `DeclKind` of this `RecFuncDecl`.
-    pub fn kind(&self) -> DeclKind {
-        unsafe { Z3_get_decl_kind(self.ctx.z3_ctx, self.z3_func_decl) }
-    }
-
-    /// Return the name of this `RecFuncDecl`.
-    ///
-    /// Strings will return the `Symbol`.  Ints will have a `"k!"` prepended to
-    /// the `Symbol`.
-    pub fn name(&self) -> String {
-        unsafe {
-            let z3_ctx = self.ctx.z3_ctx;
-            let symbol = Z3_get_decl_name(z3_ctx, self.z3_func_decl);
-            match Z3_get_symbol_kind(z3_ctx, symbol) {
-                SymbolKind::String => CStr::from_ptr(Z3_get_symbol_string(z3_ctx, symbol))
-                    .to_string_lossy()
-                    .into_owned(),
-                SymbolKind::Int => format!("k!{}", Z3_get_symbol_int(z3_ctx, symbol)),
-            }
-        }
-    }
 }
 
 impl<'ctx> fmt::Display for RecFuncDecl<'ctx> {
@@ -181,5 +121,13 @@ impl<'ctx> Drop for RecFuncDecl<'ctx> {
                 Z3_func_decl_to_ast(self.ctx.z3_ctx, self.z3_func_decl),
             );
         }
+    }
+}
+
+impl<'ctx> Deref for RecFuncDecl<'ctx> {
+    type Target = FuncDecl<'ctx>;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*(self as *const _ as *const Self::Target) }
     }
 }

--- a/z3/src/rec_func_decl.rs
+++ b/z3/src/rec_func_decl.rs
@@ -55,7 +55,7 @@ impl<'ctx> RecFuncDecl<'ctx> {
     ///     &Int::add(&ctx, &[&n, &Int::from_i64(&ctx, 1)])
     /// );
     ///
-    /// let f_of_n = &f.apply(&[&n.clone().into()]);
+    /// let f_of_n = &f.apply(&[&n.clone()]);
     ///
     /// let solver = Solver::new(&ctx);
     /// let forall: z3::ast::Bool = z3::ast::forall_const(
@@ -114,7 +114,7 @@ impl<'ctx> RecFuncDecl<'ctx> {
     /// Create a constant (if `args` has length 0) or function application (otherwise).
     ///
     /// Note that `args` should have the types corresponding to the `domain` of the `RecFuncDecl`.
-    pub fn apply(&self, args: &[&ast::Dynamic<'ctx>]) -> ast::Dynamic<'ctx> {
+    pub fn apply(&self, args: &[&dyn ast::Ast<'ctx>]) -> ast::Dynamic<'ctx> {
         assert!(args.iter().all(|s| s.get_ctx().z3_ctx == self.ctx.z3_ctx));
 
         let args: Vec<_> = args.iter().map(|a| a.get_z3_ast()).collect();

--- a/z3/src/rec_func_decl.rs
+++ b/z3/src/rec_func_decl.rs
@@ -52,7 +52,7 @@ impl<'ctx> RecFuncDecl<'ctx> {
     ///     &Sort::int(&ctx));
     /// let n = Int::new_const(&ctx, "n");
     /// f.add_def(
-    ///     &[&n.clone().into()],
+    ///     &[&n],
     ///     &Int::add(&ctx, &[&n, &Int::from_i64(&ctx, 1)])
     /// );
     ///
@@ -72,8 +72,8 @@ impl<'ctx> RecFuncDecl<'ctx> {
     /// ```
     ///
     /// Note that `args` should have the types corresponding to the `domain` of the `RecFuncDecl`.
-    pub fn add_def(&self, args: &[&ast::Dynamic<'ctx>], body: &impl Ast<'ctx>) {
-        assert!(args.iter().all(|arg| arg.ctx == body.get_ctx()));
+    pub fn add_def(&self, args: &[&dyn ast::Ast<'ctx>], body: &dyn Ast<'ctx>) {
+        assert!(args.iter().all(|arg| arg.get_ctx() == body.get_ctx()));
         assert_eq!(self.ctx, body.get_ctx());
 
         let mut args: Vec<_> = args.iter().map(|s| s.get_z3_ast()).collect();

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -562,7 +562,7 @@ fn test_rec_func_def() {
     let fac = RecFuncDecl::new(&ctx, "fac", &[&Sort::int(&ctx)], &Sort::int(&ctx));
     let n = ast::Int::new_const(&ctx, "n");
     let n_minus_1 = ast::Int::sub(&ctx, &[&n, &ast::Int::from_i64(&ctx, 1)]);
-    let fac_of_n_minus_1 = fac.apply(&[&n_minus_1.into()]);
+    let fac_of_n_minus_1 = fac.apply(&[&n_minus_1]);
     let cond: ast::Bool = n.le(&ast::Int::from_i64(&ctx, 0));
     let body = cond.ite(
         &ast::Int::from_i64(&ctx, 1),
@@ -578,7 +578,7 @@ fn test_rec_func_def() {
 
     solver.assert(
         &x._eq(
-            &fac.apply(&[&ast::Int::from_i64(&ctx, 4).into()])
+            &fac.apply(&[&ast::Int::from_i64(&ctx, 4)])
                 .as_int()
                 .unwrap(),
         ),
@@ -586,7 +586,7 @@ fn test_rec_func_def() {
     solver.assert(&y._eq(&ast::Int::mul(&ctx, &[&ast::Int::from_i64(&ctx, 5), &x])));
     solver.assert(
         &y._eq(
-            &fac.apply(&[&ast::Int::from_i64(&ctx, 5).into()])
+            &fac.apply(&[&ast::Int::from_i64(&ctx, 5)])
                 .as_int()
                 .unwrap(),
         ),
@@ -606,7 +606,7 @@ fn test_rec_func_def_unsat() {
     let fac = RecFuncDecl::new(&ctx, "fac", &[&Sort::int(&ctx)], &Sort::int(&ctx));
     let n = ast::Int::new_const(&ctx, "n");
     let n_minus_1 = ast::Int::sub(&ctx, &[&n, &ast::Int::from_i64(&ctx, 1)]);
-    let fac_of_n_minus_1 = fac.apply(&[&n_minus_1.into()]);
+    let fac_of_n_minus_1 = fac.apply(&[&n_minus_1]);
     let cond: ast::Bool = n.le(&ast::Int::from_i64(&ctx, 0));
     let body = cond.ite(
         &ast::Int::from_i64(&ctx, 1),
@@ -622,7 +622,7 @@ fn test_rec_func_def_unsat() {
 
     solver.assert(
         &x._eq(
-            &fac.apply(&[&ast::Int::from_i64(&ctx, 4).into()])
+            &fac.apply(&[&ast::Int::from_i64(&ctx, 4)])
                 .as_int()
                 .unwrap(),
         ),
@@ -630,7 +630,7 @@ fn test_rec_func_def_unsat() {
     solver.assert(&y._eq(&ast::Int::mul(&ctx, &[&ast::Int::from_i64(&ctx, 5), &x])));
     solver.assert(
         &y._eq(
-            &fac.apply(&[&ast::Int::from_i64(&ctx, 5).into()])
+            &fac.apply(&[&ast::Int::from_i64(&ctx, 5)])
                 .as_int()
                 .unwrap(),
         ),

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -569,7 +569,7 @@ fn test_rec_func_def() {
         &ast::Int::mul(&ctx, &[&n, &fac_of_n_minus_1.as_int().unwrap()]),
     );
 
-    fac.add_def(&[&n.into()], &body);
+    fac.add_def(&[&n], &body);
 
     let x = ast::Int::new_const(&ctx, "x");
     let y = ast::Int::new_const(&ctx, "y");
@@ -613,7 +613,7 @@ fn test_rec_func_def_unsat() {
         &ast::Int::mul(&ctx, &[&n, &fac_of_n_minus_1.as_int().unwrap()]),
     );
 
-    fac.add_def(&[&n.into()], &body);
+    fac.add_def(&[&n], &body);
 
     let x = ast::Int::new_const(&ctx, "x");
     let y = ast::Int::new_const(&ctx, "y");


### PR DESCRIPTION
Given that both structs(`FuncDecl` and `RecFuncDecl`) provide the same functionality modulo `add_def`, it's kind of unfortunate that the signatures for `apply` uses a different type for the `args`.

https://github.com/prove-rs/z3.rs/blob/691ac9782f361969e87ac745a3d9a6816593741a/z3/src/func_decl.rs#L62

vs 

https://github.com/prove-rs/z3.rs/blob/691ac9782f361969e87ac745a3d9a6816593741a/z3/src/rec_func_decl.rs#L117

In this case it's slightly better to pass a `&dyn Ast` instead of a `&Dynamic` because the latter may require creating a temporary that is only used by reference when creating an array to pass as `args`(which can make some code a bit awkward).

I've made this short change in the first commit and removed the `into` conversions from the tests which are now ambiguous.

I've also thought of a more aggressive change which implements [`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html) for `RecFuncDecl`. With this, the compiler can use auto-deref magic to allow the user to call `FuncDecl` methods on a `RecFuncDecl`. Note how this change does not require any changes to the tests. With this, I'm making an assumption that the implementation of both structs is the same. In general, this kind of change would bring the underlying implementation of this functionality more in line with the other language bindings. This is implemented in the second commit.

It could also be reasonable to just make `RecFuncDecl` a wrapper struct containing a `FuncDecl` which would simplifying all of it's impls greatly.

If this issue makes sense to fix, I'm not particularly attached to any of the solutions here and would be happy to adjust this pr as needed(only the first commit, only the second commit, modifying `RecFuncDecl` to be a wrapper around `FuncDecl`, or something else).