### PR TITLE
Fix smt based tests

### DIFF
--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -237,9 +237,9 @@ fn test_solver_new_from_smtlib2() {
     let cfg = Config::new();
     let ctx = Context::new(&cfg);
     let problem = r#"
-(declare -const x Real)
-(declare -const y Real)
-(declare -const z Real)
+(declare-const x Real)
+(declare-const y Real)
+(declare-const z Real)
 (assert (=( -(+(* 3 x) (* 2 y)) z) 1))
 (assert (=(+( -(* 2 x) (* 2 y)) (* 4 z)) -2))
 "#;
@@ -701,9 +701,9 @@ fn test_optimize_new_from_smtlib2() {
     let cfg = Config::new();
     let ctx = Context::new(&cfg);
     let problem = r#"
-(declare -const x Real)
-(declare -const y Real)
-(declare -const z Real)
+(declare-const x Real)
+(declare-const y Real)
+(declare-const z Real)
 (assert (=( -(+(* 3 x) (* 2 y)) z) 1))
 (assert (=(+( -(* 2 x) (* 2 y)) (* 4 z)) -2))
 "#;


### PR DESCRIPTION
In playing around with enabling the error_handler, I noticed that the tests for #226 were actually incorrect but there was no error checking so this was just ignored.(Whoops, my bad)

Maybe the api should be changed to avoid this? Something akin to https://github.com/prove-rs/z3.rs/blob/691ac9782f361969e87ac745a3d9a6816593741a/z3/src/tactic.rs#L207-L211. In general, I think there should be a better story for integrating with Z3's errors.