### PR TITLE
z3-sys: Fix return type of Z3_parse_smtlib2_string and Z3_parse_smtlib2_file

### DIFF
--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -4929,7 +4929,7 @@ extern "C" {
         num_decls: ::std::os::raw::c_uint,
         decl_names: *const Z3_symbol,
         decls: *const Z3_func_decl,
-    ) -> Z3_ast;
+    ) -> Z3_ast_vector;
 
     /// Similar to [`Z3_parse_smtlib2_string`], but reads the benchmark from a file.
     pub fn Z3_parse_smtlib2_file(
@@ -4941,7 +4941,7 @@ extern "C" {
         num_decls: ::std::os::raw::c_uint,
         decl_names: *const Z3_symbol,
         decls: *const Z3_func_decl,
-    ) -> Z3_ast;
+    ) -> Z3_ast_vector;
 
     /// Parse and evaluate and SMT-LIB2 command sequence. The state from a previous
     /// call is saved so the next evaluation builds on top of the previous call.


### PR DESCRIPTION
`Z3_parse_smtlib2_string` and `Z3_parse_smtlib2_file` are marked as returning a `Z3_ast`, while they should be returning a `Z3_ast_vector` (https://z3prover.github.io/api/html/group__capi.html#ga7905ebec9289b9fe5debcad965f6267e). This (tiny) PR fixes the problem.