### PR TITLE
Use Borrow in varop arrays

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1,5 +1,6 @@
 //! Abstract syntax tree (AST).
 
+use std::borrow::Borrow;
 use std::cmp::{Eq, PartialEq};
 use std::convert::{TryFrom, TryInto};
 use std::ffi::{CStr, CString};
@@ -176,11 +177,11 @@ macro_rules! varop {
     ) => {
         $(
             $( #[ $attr ] )*
-            pub fn $f(ctx: &'ctx Context, values: &[&Self]) -> $retty {
-                assert!(values.iter().all(|v| v.get_ctx().z3_ctx == ctx.z3_ctx));
+            pub fn $f(ctx: &'ctx Context, values: &[impl Borrow<Self>]) -> $retty {
+                assert!(values.iter().all(|v| v.borrow().get_ctx().z3_ctx == ctx.z3_ctx));
                 unsafe {
                     <$retty>::wrap(ctx, {
-                        let tmp: Vec<_> = values.iter().map(|x| x.z3_ast).collect();
+                        let tmp: Vec<_> = values.iter().map(|x| x.borrow().z3_ast).collect();
                         assert!(tmp.len() <= 0xffff_ffff);
                         $z3fn(ctx.z3_ctx, tmp.len() as u32, tmp.as_ptr())
                     })

--- a/z3/tests/ops.rs
+++ b/z3/tests/ops.rs
@@ -209,6 +209,7 @@ fn test_ast_children() {
     assert_eq!(not_a.nth_child(1), None);
 
     let b = Bool::new_const(&ctx, "b");
+    // This is specifically testing for an array of values, not an array of slices
     let a_or_b = Bool::or(&ctx, &[a.clone(), b.clone()]);
     assert_eq!(a_or_b.num_children(), 2);
     assert_bool_child(&a_or_b, 0, &a);

--- a/z3/tests/ops.rs
+++ b/z3/tests/ops.rs
@@ -209,7 +209,7 @@ fn test_ast_children() {
     assert_eq!(not_a.nth_child(1), None);
 
     let b = Bool::new_const(&ctx, "b");
-    let a_or_b = Bool::or(&ctx, &[&a, &b]);
+    let a_or_b = Bool::or(&ctx, &[a.clone(), b.clone()]);
     assert_eq!(a_or_b.num_children(), 2);
     assert_bool_child(&a_or_b, 0, &a);
     assert_bool_child(&a_or_b, 1, &b);


### PR DESCRIPTION
Hello!

Sometimes when using z3 I follow the pattern of constructing `Bool<'_>` values in a map(Like making a list of variables from a list of names or arguments).

```rust
    let output_assertions = circuit
        .outputs
        .iter()
        .map(|o| {
            let o1 = nodes0.get(o).unwrap();
            let o2 = nodes1.get(o).unwrap();
            o1._eq(o2).not()
        })
        .collect::<Vec<Bool>>();
```

The problem is that variable length operations like `Bool::or` expect a `&[&Self]` which is an array of references, not values. 

Note that because I'm constructing these as values in a closure, I cannot collect a vector of references because the underlying values would be dropped.

I end up writing code like the following:
```rust
    solver.assert(&Bool::or(
        ctx,
        output_assertions.iter().collect::<Vec<_>>().as_slice(),
    ));
```

It appears to me that this is pretty unnecessary since there isn't even any unnecessary copying going on. As a test of this, I've changed Varops to take an `&[impl Borrow<Self>]` instead of a `&[&Self]` and modified only one of the test cases where this occurs to use an array of values instead of an array of references.

This seems pretty backwards compatible since none of the other tests using `Bool::or` fails but I can't be certain. It could be a pattern to use more pervasively to get rid of unnecessary and forced references. It might also hurt the error messages the compiler gives but I'm also not sure about that.

Up to you if this is of interest.