### PR TITLE
Check Kind for optimize maximize

### DIFF
--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -85,6 +85,11 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::assert()`]
     /// - [`Optimize::minimize()`]
     pub fn maximize(&self, ast: &impl Ast<'ctx>) {
+        // https://github.com/Z3Prover/z3/blob/09f911d8a84cd91988e5b96b69485b2a9a2edba3/src/opt/opt_context.cpp#L118-L120
+        assert!(matches!(
+            ast.get_sort().kind(),
+            SortKind::Int | SortKind::Real | SortKind::BV
+        ));
         unsafe { Z3_optimize_maximize(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
     }
 
@@ -95,6 +100,10 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::assert()`]
     /// - [`Optimize::maximize()`]
     pub fn minimize(&self, ast: &impl Ast<'ctx>) {
+        assert!(matches!(
+            ast.get_sort().kind(),
+            SortKind::Int | SortKind::Real | SortKind::BV
+        ));
         unsafe { Z3_optimize_minimize(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
     }
 


### PR DESCRIPTION
With the error_handler turned off, I had the following warning suppressed when using `Optimize::maximize`: `Error: Objective must be bit-vector, integer or real`.

I am suggesting that an assertion or result type is added to help catch this. Also holds true for minimize.