### PR TITLE
Use system-shipped z3 libraries by pkg_config

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,11 +20,23 @@ jobs:
       run: cargo fmt -- --check
 
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build: [linux, macos]
+        include:
+          - build: linux
+            os: ubuntu-latest
+          - build: macos
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: Install Z3
+      if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install libz3-dev
+    - name: Install Z3
+      if: matrix.os == 'macos-latest'
+      run: brew install z3
     - name: Build
       run: cargo build -vv --all
       # XXX: Ubuntu's Z3 package seems to be missing some symbols, like

--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -18,6 +18,7 @@ repository = "https://github.com/prove-rs/z3.rs.git"
 [build-dependencies]
 bindgen = { version = "0.66.0", default-features = false, features = ["runtime"] }
 cmake = { version = "0.1.49", optional = true }
+pkg-config = "0.3.27"
 
 [features]
 # Enable this feature to statically link our own build of Z3, rather than

--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -13,6 +13,7 @@ fn build_static() -> Vec<PathBuf> {
     }
 }
 
+#[cfg(not(feature = "static-link-z3"))]
 fn build_dynamic() -> Vec<PathBuf> {
     if let Ok(lib) = pkg_config::Config::new().statik(false).probe("z3") {
         lib.include_paths

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1221,7 +1221,7 @@ fn test_tactic_fail() {
 
     let tactic = Tactic::new(&ctx, "fail");
     let apply_results = tactic.apply(&goal, Some(&params));
-    assert!(matches!(apply_results, Err(_)));
+    assert!(apply_results.is_err());
 }
 
 #[test]


### PR DESCRIPTION
Probably a bit more elegant way to use precompiled binaries compared to #193 by utilizing `pkg-config`, which is ubiquitous of all *nix platforms.

My usecase is to use homebrew installed z3 library.

Changes:

- Detect dynamic/static precompiled libraries and use them with `pkg_config`
- Add CI for macos using precompile libraries from homebrew. 
- Instead of manually encoded `z3/src/api/z3.h`, use the universal `z3.h` with corresponding include directories added, which should be a more general approach.

No break changes are introduced in theory and should be safe to go.