### PR TITLE
ci: Run clippy on macOS against brew z3.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -145,10 +145,10 @@ jobs:
         run: cargo test --manifest-path z3/Cargo.toml -vv --features 'vcpkg arbitrary-size-numeral'
 
   run_clippy:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
+    - name: Install Z3
+      run: brew install z3
     - name: Run clippy
-      run: cargo clippy -vv --features static-link-z3 --all-targets
+      run: cargo clippy -vv --workspace --all-targets


### PR DESCRIPTION
This is faster than having it do a build of Z3 as it does now and by running it on macOS against the brew installed Z3, it is going to be a more recent version of Z3 than what the system Z3 on Linux would be.