### PR TITLE
Improve CI speed.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,19 +25,15 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install Z3
       run: sudo apt-get install libz3-dev
-    - name: Build
-      run: cargo build -vv --all
+    - name: Run tests
+      run: cargo test --workspace
       # XXX: Ubuntu's Z3 package seems to be missing some symbols, like
       # `Z3_mk_pbeq`, leading to linker errors. Just ignore this, I guess, until
       # we figure out how to work around it. At least we have the
       # statically-linked Z3 tests below...
       if: ${{ success() || failure() }}
-    - name: Run tests
-      run: cargo test -vv --all
-      # See above.
-      if: ${{ success() || failure() }}
     - name: Run tests with `arbitrary-size-numeral` enabled
-      run: cargo test --manifest-path z3/Cargo.toml -vv --features arbitrary-size-numeral
+      run: cargo test --workspace --features arbitrary-size-numeral
       # See above.
       if: ${{ success() || failure() }}
 
@@ -61,7 +57,7 @@ jobs:
     - name: Build z3-sys and z3 with statically linked Z3
       run: |
         source ~/emsdk/emsdk_env.sh
-        cargo build --target=wasm32-unknown-emscripten -vv --features static-link-z3
+        cargo build --target=wasm32-unknown-emscripten --features static-link-z3
 
   build_z3_statically:
     strategy:
@@ -88,12 +84,10 @@ jobs:
       - name: Set LIBCLANG_PATH
         run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
         if: matrix.os == 'windows-latest'
-      - name: Build `z3-sys` and `z3` with statically linked Z3
-        run: cargo build -vv --features static-link-z3
       - name: Test `z3-sys` and `z3` with statically linked Z3
-        run: cargo test -vv --features static-link-z3
+        run: cargo test --workspace --features static-link-z3
       - name: Test `z3` with statically linked Z3 and `arbitrary-size-numeral` enabled
-        run: cargo test --manifest-path z3/Cargo.toml -vv --features 'static-link-z3 arbitrary-size-numeral'
+        run: cargo test --workspace --features 'static-link-z3 arbitrary-size-numeral'
   build_with_vcpkg_installed_z3:
     strategy:
       matrix:
@@ -137,12 +131,10 @@ jobs:
           extra-args: --clean-buildtrees-after-build
       - name: Show default toolchain of rust.
         run: rustup default
-      - name: Build `z3-sys` and `z3` with vcpkg installed Z3
-        run: cargo build -vv --features vcpkg
       - name: Test `z3-sys` and `z3` with vcpkg installed Z3
-        run: cargo test -vv --features vcpkg
+        run: cargo test --workspace --features vcpkg
       - name: Test `z3` with vcpkg installed Z3 and `arbitrary-size-numeral` enabled
-        run: cargo test --manifest-path z3/Cargo.toml -vv --features 'vcpkg arbitrary-size-numeral'
+        run: cargo test --workspace --features 'vcpkg arbitrary-size-numeral'
 
   run_clippy:
     runs-on: macos-latest
@@ -151,4 +143,4 @@ jobs:
     - name: Install Z3
       run: brew install z3
     - name: Run clippy
-      run: cargo clippy -vv --workspace --all-targets
+      run: cargo clippy --workspace --all-targets


### PR DESCRIPTION
Instead of building the lib and then doing the tests, just do the tests. Otherwise, we end up building the lib twice.

This also:

* No longer uses `-vv` for very verbose output.
* Uses `--workspace` instead of `--all`.