### PR TITLE
Allow creating Int from i32

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -778,6 +778,11 @@ impl<'ctx> Int<'ctx> {
         unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx, i, sort.z3_sort)) }
     }
 
+    pub fn from_i32(ctx: &'ctx Context, i: i32) -> Int<'ctx> {
+        let sort = Sort::int(ctx);
+        unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx, i as i64, sort.z3_sort)) }
+    }
+
     pub fn from_u64(ctx: &'ctx Context, u: u64) -> Int<'ctx> {
         let sort = Sort::int(ctx);
         unsafe { Self::wrap(ctx, Z3_mk_unsigned_int64(ctx.z3_ctx, u, sort.z3_sort)) }
@@ -1220,6 +1225,11 @@ impl<'ctx> BV<'ctx> {
     pub fn from_i64(ctx: &'ctx Context, i: i64, sz: u32) -> BV<'ctx> {
         let sort = Sort::bitvector(ctx, sz);
         unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx, i, sort.z3_sort)) }
+    }
+
+    pub fn from_i32(ctx: &'ctx Context, i: i32, sz: u32) -> BV<'ctx> {
+        let sort = Sort::bitvector(ctx, sz);
+        unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx, i as i64, sort.z3_sort)) }
     }
 
     pub fn from_u64(ctx: &'ctx Context, u: u64, sz: u32) -> BV<'ctx> {

--- a/z3/src/ops.rs
+++ b/z3/src/ops.rs
@@ -214,6 +214,28 @@ macro_rules! impl_binary_op {
         );
         impl_binary_op_assign_number_raw!(
             $ty,
+            i32,
+            from_i32,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $function,
+            $construct_constant
+        );
+        impl_binary_op_number_raw!(
+            &$ty,
+            i32,
+            from_i32,
+            $ty,
+            $base_trait,
+            $base_fn,
+            $function,
+            $construct_constant
+        );
+        impl_binary_op_assign_number_raw!(
+            $ty,
             i64,
             from_i64,
             $ty,
@@ -423,6 +445,26 @@ macro_rules! impl_binary_mult_op {
             &$ty,
             u64,
             from_u64,
+            $ty,
+            $base_trait,
+            $base_fn,
+            $construct_constant
+        );
+        impl_binary_mult_op_assign_number_raw!(
+            $ty,
+            i32,
+            from_i32,
+            $ty,
+            $base_trait,
+            $assign_trait,
+            $base_fn,
+            $assign_fn,
+            $construct_constant
+        );
+        impl_binary_mult_op_number_raw!(
+            &$ty,
+            i32,
+            from_i32,
             $ty,
             $base_trait,
             $base_fn,


### PR DESCRIPTION
Hi,

Thank you for the neat package. I've been a long time user of Z3 through Python, and am now looking into switching to Rust for more performance. One hurdle I encountered is mathematical operations with `Int` and i32. E.g., I would like to do the following:

```
let s = ast::Int::new_const(&ctx, "s");
let o = ast::Int::new_const(&ctx, "o");
let mult = &s * 10;
solver.assert(&s._eq(&o));
```
This would fail, because by default integers in Rust are i32 and `ast::Int` can currently only be created from i64 or u64. As constantly writing `as i64` is tedious, I open this MR to (1) allow generating `ast::Int` from i32, and (2) to support automatically converting i32 to Int in binops.

Implementation-wise, it's really nothing special: cast the i32 to i64 and use `from_i64`. Not sure if this fits within the Rust ideology, but from Z3's point of view it doesn't matter anyway. Is this something that would be useful?