### PR TITLE
Into i64

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -773,9 +773,9 @@ impl<'ctx> Int<'ctx> {
         }
     }
 
-    pub fn from_i64(ctx: &'ctx Context, i: i64) -> Int<'ctx> {
+    pub fn from_i64<T: Into<i64>>(ctx: &'ctx Context, i: T) -> Int<'ctx> {
         let sort = Sort::int(ctx);
-        unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx, i, sort.z3_sort)) }
+        unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx, i.into(), sort.z3_sort)) }
     }
 
     pub fn from_u64(ctx: &'ctx Context, u: u64) -> Int<'ctx> {
@@ -1217,9 +1217,9 @@ impl<'ctx> BV<'ctx> {
         }
     }
 
-    pub fn from_i64(ctx: &'ctx Context, i: i64, sz: u32) -> BV<'ctx> {
+    pub fn from_i64<T: Into<i64>>(ctx: &'ctx Context, i: T, sz: u32) -> BV<'ctx> {
         let sort = Sort::bitvector(ctx, sz);
-        unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx, i, sort.z3_sort)) }
+        unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx, i.into(), sort.z3_sort)) }
     }
 
     pub fn from_u64(ctx: &'ctx Context, u: u64, sz: u32) -> BV<'ctx> {

--- a/z3/src/ops.rs
+++ b/z3/src/ops.rs
@@ -180,6 +180,19 @@ macro_rules! impl_binary_op_bool {
     };
 }
 
+macro_rules! all_num_versions {
+    ($macro_id:ident, $ty:ty, $($rest:tt)*) => {
+        $macro_id!($ty, u64, from_u64, $($rest)*);
+/*         $macro_id!($ty, u32, from_u64, $($rest)*);
+        $macro_id!($ty, u16, from_u64, $($rest)*);
+        $macro_id!($ty, u8, from_u64, $($rest)*); */
+        $macro_id!($ty, i64, from_i64, $($rest)*);
+        $macro_id!($ty, i32, from_i64, $($rest)*);
+        $macro_id!($ty, i16, from_i64, $($rest)*);
+        $macro_id!($ty, i8, from_i64, $($rest)*);
+    }
+}
+
 macro_rules! impl_binary_op {
     ($ty:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $function:ident, $construct_constant:ident) => {
         impl_binary_op_without_numbers!(
@@ -190,32 +203,10 @@ macro_rules! impl_binary_op {
             $assign_fn,
             $function
         );
-        impl_binary_op_assign_number_raw!(
+
+        all_num_versions!(
+            impl_binary_op_assign_number_raw,
             $ty,
-            u64,
-            from_u64,
-            $ty,
-            $base_trait,
-            $assign_trait,
-            $base_fn,
-            $assign_fn,
-            $function,
-            $construct_constant
-        );
-        impl_binary_op_number_raw!(
-            &$ty,
-            u64,
-            from_u64,
-            $ty,
-            $base_trait,
-            $base_fn,
-            $function,
-            $construct_constant
-        );
-        impl_binary_op_assign_number_raw!(
-            $ty,
-            i64,
-            from_i64,
             $ty,
             $base_trait,
             $assign_trait,
@@ -224,10 +215,10 @@ macro_rules! impl_binary_op {
             $function,
             $construct_constant
         );
-        impl_binary_op_number_raw!(
+
+        all_num_versions!(
+            impl_binary_op_number_raw,
             &$ty,
-            i64,
-            from_i64,
             $ty,
             $base_trait,
             $base_fn,
@@ -408,30 +399,10 @@ macro_rules! impl_binary_mult_op {
             $base_fn,
             $assign_fn
         );
-        impl_binary_mult_op_assign_number_raw!(
+
+        all_num_versions!(
+            impl_binary_mult_op_assign_number_raw,
             $ty,
-            u64,
-            from_u64,
-            $ty,
-            $base_trait,
-            $assign_trait,
-            $base_fn,
-            $assign_fn,
-            $construct_constant
-        );
-        impl_binary_mult_op_number_raw!(
-            &$ty,
-            u64,
-            from_u64,
-            $ty,
-            $base_trait,
-            $base_fn,
-            $construct_constant
-        );
-        impl_binary_mult_op_assign_number_raw!(
-            $ty,
-            i64,
-            from_i64,
             $ty,
             $base_trait,
             $assign_trait,
@@ -439,10 +410,10 @@ macro_rules! impl_binary_mult_op {
             $assign_fn,
             $construct_constant
         );
-        impl_binary_mult_op_number_raw!(
+
+        all_num_versions!(
+            impl_binary_mult_op_number_raw,
             &$ty,
-            i64,
-            from_i64,
             $ty,
             $base_trait,
             $base_fn,


### PR DESCRIPTION
I wanted to concertize my idea from #270 into some code. Instead of creating additional `from_i*` methods I propose using `Into<i64>` for `from_i64`. Leveraging the trait system here runs into some non-obvious issues.

- One probably can't implement `from_u64` with `Into<u64>`. Well, it's allowed but then calling `Int::from_u64(1)` is a typing error because the type of `1` here is ambigious(under-constrained). When an integer literal has an ambigious type, it defaults to `i32` and therefore fails. This is fine for `Into<i64>` since `i32` implements `Into<i64>`
- It's rather non-trivial to try to write something like `impl<'ctx, T: Into<i64>> Div<T> for Int<'ctx> {` because there are other implementations of `Div` for `Int<'ctx>` that the compiler can't prove to not overlap(either currently or in some future version which would lead to breakage). Maybe there is something I'm missing or some kind of nightly negative trait impls that one could use. `ops.rs` already heavily makes use of macros so I figure it's find to make a new macro that generalizes over the valid integer types: `u64, i64, i32, i16, i8`