### PR TITLE
Support for more regular expression operations

### DIFF
--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -3124,7 +3124,7 @@ extern "C" {
     /// Create the regular language `re*`.
     pub fn Z3_mk_re_star(c: Z3_context, re: Z3_ast) -> Z3_ast;
 
-    /// Create the regular language `[re]`.
+    /// Create the regular language `re?`.
     pub fn Z3_mk_re_option(c: Z3_context, re: Z3_ast) -> Z3_ast;
 
     /// Create the union of the regular languages.

--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1825,11 +1825,35 @@ impl<'ctx> Regexp<'ctx> {
         }
     }
 
+    /// Creates a regular expression that recognizes this regular expression
+    /// n number of times
+    /// Requires Z3 4.8.15 or later.
+    pub fn power(&self, n: u32) -> Self {
+        unsafe {
+            Self::wrap(self.ctx, {
+                Z3_mk_re_power(self.ctx.z3_ctx, self.z3_ast, n)
+            })
+        }
+    }
+
     /// Creates a regular expression that recognizes all sequences
     pub fn full(ctx: &'ctx Context) -> Self {
         unsafe {
             Self::wrap(ctx, {
                 Z3_mk_re_full(
+                    ctx.z3_ctx,
+                    Z3_mk_re_sort(ctx.z3_ctx, Z3_mk_string_sort(ctx.z3_ctx)),
+                )
+            })
+        }
+    }
+
+    /// Creates a regular expression that accepts all singleton sequences of the characters
+    /// Requires Z3 4.8.13 or later.
+    pub fn allchar(ctx: &'ctx Context) -> Self {
+        unsafe {
+            Self::wrap(ctx, {
+                Z3_mk_re_allchar(
                     ctx.z3_ctx,
                     Z3_mk_re_sort(ctx.z3_ctx, Z3_mk_string_sort(ctx.z3_ctx)),
                 )
@@ -1858,6 +1882,13 @@ impl<'ctx> Regexp<'ctx> {
        /// Creates a regular expression that recognizes any sequence that this regular expression
        /// doesn't
        complement(Z3_mk_re_complement, Self);
+       /// Creates a regular expression that optionally accepts this regular expression (e.g. `a?`)
+       option(Z3_mk_re_option, Self);
+    }
+    binop! {
+        /// Creates a difference regular expression
+        /// Requires Z3 4.8.14 or later.
+        diff(Z3_mk_re_diff, Self);
     }
     varop! {
        /// Concatenates regular expressions

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1649,6 +1649,44 @@ fn test_regex_capital_foobar_intersect_az_plus_is_unsat() {
 }
 
 #[test]
+fn test_regex_union() {
+    let cfg = Config::new();
+    let ctx = &Context::new(&cfg);
+    let solver = Solver::new(ctx);
+    let a = ast::String::new_const(ctx, "a");
+    let b = ast::String::new_const(ctx, "b");
+    let c = ast::String::new_const(ctx, "c");
+    let re = ast::Regexp::union(
+        ctx,
+        &[
+            ast::Regexp::literal(ctx, "a"),
+            ast::Regexp::literal(ctx, "b"),
+        ],
+    );
+    solver.assert(&a.regex_matches(&re));
+    solver.assert(&b.regex_matches(&re));
+    solver.assert(&c.regex_matches(&re).not());
+    assert!(solver.check() == SatResult::Sat);
+}
+
+#[test]
+fn test_regex_union2() {
+    let cfg = Config::new();
+    let ctx = &Context::new(&cfg);
+    let solver = Solver::new(ctx);
+    let c = ast::String::new_const(ctx, "c");
+    let re = ast::Regexp::union(
+        ctx,
+        &[
+            ast::Regexp::literal(ctx, "a"),
+            ast::Regexp::literal(ctx, "b"),
+        ],
+    );
+    solver.assert(&c.regex_matches(&re));
+    assert!(solver.check() == SatResult::Unsat);
+}
+
+#[test]
 /// <https://github.com/Z3Prover/z3/blob/21e59f7c6e5033006265fc6bc16e2c9f023db0e8/examples/dotnet/Program.cs#L329-L370>
 fn test_array_example1() {
     let cfg = Config::new();

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1653,9 +1653,9 @@ fn test_regex_union() {
     let cfg = Config::new();
     let ctx = &Context::new(&cfg);
     let solver = Solver::new(ctx);
-    let a = ast::String::new_const(ctx, "a");
-    let b = ast::String::new_const(ctx, "b");
-    let c = ast::String::new_const(ctx, "c");
+    let a = ast::String::from_str(ctx, "a").unwrap();
+    let b = ast::String::from_str(ctx, "b").unwrap();
+    let c = ast::String::from_str(ctx, "c").unwrap();
     let re = ast::Regexp::union(
         ctx,
         &[
@@ -1674,7 +1674,7 @@ fn test_regex_union2() {
     let cfg = Config::new();
     let ctx = &Context::new(&cfg);
     let solver = Solver::new(ctx);
-    let c = ast::String::new_const(ctx, "c");
+    let c = ast::String::from_str(ctx, "c").unwrap();
     let re = ast::Regexp::union(
         ctx,
         &[


### PR DESCRIPTION
Fixes #272

(First two commits) My attempt at adding the new regular expression operations: `power`, `allchar`, and `diff`. I also noticed that `option` was exposed but not implemented so I've added that as well.

(Third commit) I was looking to test my inclusions to the code base but I realized that I'm not sure about the semantics of regular expressions in Z3? I ran into some weird behavior I don't understand so I just added a simple test from https://z3prover.github.io/api/html/z3py_8py_source.html#l11172 to get some advice. `test_regex_union` works as expected, checking that `(a|b)` matches with `a` and `b` but not `c`. However, I found that I get `SatResult::Sat` in more cases than I expect like in `test_regex_union2` which just checks that `c` matches with `(a|b)`. I would expect to get `SatResult::Unsat` but I don't?