### PR TITLE
z3-sys: Use `pkg-config` when using system libs.

### DIFF
--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -18,6 +18,7 @@ repository = "https://github.com/prove-rs/z3.rs.git"
 [build-dependencies]
 bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
 cmake = { version = "0.1.49", optional = true }
+pkg-config = "0.3.27"
 vcpkg = { version = "0.2.15", optional = true }
 
 [features]


### PR DESCRIPTION
This helps find the lib and includes more accurately than not using it.

This builds on previous work by @poscat0x04 and @wtdcode.