### PR TITLE
Update bundled Z3 to z3 4.12.3.

### DIFF
--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -150,6 +150,7 @@ fn build_bundled_z3() {
         cfg.build_arg("-m");
         cfg.cxxflag("-DWIN32");
         cfg.cxxflag("-D_WINDOWS");
+        cfg.define("CMAKE_MSVC_RUNTIME_LIBRARY", "MultiThreadedDLL");
     }
 
     let dst = cfg.build();


### PR DESCRIPTION
This also changes a test to be less specific about the exact answer since it varies between versions of Z3.