### PR TITLE
Add creating reals from any numeral and getting f64 from reals

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -583,10 +583,17 @@ impl<'ctx> Real<'ctx> {
     }
 
     pub fn from_real_str(ctx: &'ctx Context, num: &str, den: &str) -> Option<Real<'ctx>> {
+        let fraction_string = format!("{num:} / {den:}");
+        Self::from_str(ctx, &fraction_string)
+    }
+
+    /// The string may be of the form \[num\]*\[.\[num\]*\]\[E\[+|-\]\[num\]...+\].
+    /// Or a rational, that is, a string of the form \[num\]* / \[num\]*
+    pub fn from_str(ctx: &'ctx Context, numeral: &str) -> Option<Real<'ctx>> {
         let sort = Sort::real(ctx);
         let ast = unsafe {
-            let fraction_cstring = CString::new(format!("{num:} / {den:}")).unwrap();
-            let numeral_ptr = Z3_mk_numeral(ctx.z3_ctx, fraction_cstring.as_ptr(), sort.z3_sort);
+            let c_numeral = CString::new(numeral).unwrap();
+            let numeral_ptr = Z3_mk_numeral(ctx.z3_ctx, c_numeral.as_ptr(), sort.z3_sort);
             if numeral_ptr.is_null() {
                 return None;
             }

--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -937,6 +937,10 @@ impl<'ctx> Real<'ctx> {
         }
     }
 
+    pub fn as_f64(&self) -> f64 {
+        unsafe { Z3_get_numeral_double(self.ctx.z3_ctx, self.z3_ast) }
+    }
+
     pub fn from_int(ast: &Int<'ctx>) -> Real<'ctx> {
         unsafe { Self::wrap(ast.ctx, Z3_mk_int2real(ast.ctx.z3_ctx, ast.z3_ast)) }
     }


### PR DESCRIPTION
Adds the ability to create Reals from any numeral using [Z3_mk_numeral](https://z3prover.github.io/api/html/group__capi.html#ga2adef1696d308843fdb33ad6b2d4b4a0).
Also adds the method `as_f64` to `Real` which uses [Z3_get_numberal_double](https://z3prover.github.io/api/html/group__capi.html#gaf48e7b61664c0273a4ec77649f0a00cd).

This is useful if you want to represent a real as a f64. Currently you would have to calculate the numerator and denominator in order to create a z3 real from a f64. With this merge request all you would need to do is create a string from your f64 and pass this to `from_str`.
