### PR TITLE
ci: Use slightly older emscripten for now

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   RUSTFLAGS: "-D warnings"
+  EMSCRIPTEN_VERSION: "3.1.59" # Change back to `latest` once Z3 4.13.1 or later is out.
 
 jobs:
   check-formatting:
@@ -52,8 +53,8 @@ jobs:
         git clone https://github.com/emscripten-core/emsdk.git
         cd emsdk
         git pull
-        ./emsdk install latest
-        ./emsdk activate latest
+        ./emsdk install ${{ env.EMSCRIPTEN_VERSION }}
+        ./emsdk activate ${{ env.EMSCRIPTEN_VERSION }}
         source ./emsdk_env.sh
     - name: Install wasm32-unknown-emscripten target
       run: rustup target add wasm32-unknown-emscripten


### PR DESCRIPTION
An update to emscripten brought a newer compiler and that found a longstanding bug in Z3 that broke compilation.

For now, use a slightly older version until a new version of Z3 (after 4.13.0) is released with the fix.

See https://github.com/Z3Prover/z3/pull/7235 for the Z3 fix.