### PR TITLE
Expose underlying Z3_context and Z3_sort

### DIFF
--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -17,6 +17,10 @@ impl Context {
         }
     }
 
+    pub fn get_z3_context(&self) -> Z3_context {
+        self.z3_ctx
+    }
+
     /// Interrupt a solver performing a satisfiability test, a tactic processing a goal, or simplify functions.
     pub fn interrupt(&self) {
         self.handle().interrupt();

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -12,6 +12,10 @@ impl<'ctx> Sort<'ctx> {
         Sort { ctx, z3_sort }
     }
 
+    pub fn get_z3_sort(&self) -> Z3_sort {
+        self.z3_sort
+    }
+
     pub fn uninterpreted(ctx: &'ctx Context, name: Symbol) -> Sort<'ctx> {
         unsafe {
             Self::wrap(


### PR DESCRIPTION
This would be useful to use functions from the raw bindings that aren't exposed in the high-level bindings yet. Since the raw bindings are `unsafe`, it should be fine to give access to the `Z3_context` and `Z3_sort`.

Closes #290.