### PR TITLE
Real approx functions

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -940,7 +940,7 @@ impl<'ctx> Real<'ctx> {
         }
         .to_str()
         .unwrap();
-        s.strip_suffix("?").unwrap_or(s).to_owned()
+        s.strip_suffix('?').unwrap_or(s).to_owned()
     }
     pub fn approx_f64(&self) -> f64 {
         self.approx(17).parse().unwrap() // 17 decimal digits needed to get full f64 precision

--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -930,6 +930,16 @@ impl<'ctx> Real<'ctx> {
         }
     }
 
+    pub fn approx(&self, precision: usize) -> ::std::string::String {
+        let s = unsafe {
+            CStr::from_ptr(Z3_get_numeral_decimal_string(self.ctx.z3_ctx, self.z3_ast, precision as _))
+        }.to_str().unwrap();
+        s.strip_suffix("?").unwrap_or(s).to_owned()
+    }
+    pub fn approx_f64(&self) -> f64 {
+        self.approx(17).parse().unwrap() // 17 decimal digits needed to get full f64 precision
+    }
+
     pub fn from_int(ast: &Int<'ctx>) -> Real<'ctx> {
         unsafe { Self::wrap(ast.ctx, Z3_mk_int2real(ast.ctx.z3_ctx, ast.z3_ast)) }
     }

--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -932,8 +932,14 @@ impl<'ctx> Real<'ctx> {
 
     pub fn approx(&self, precision: usize) -> ::std::string::String {
         let s = unsafe {
-            CStr::from_ptr(Z3_get_numeral_decimal_string(self.ctx.z3_ctx, self.z3_ast, precision as _))
-        }.to_str().unwrap();
+            CStr::from_ptr(Z3_get_numeral_decimal_string(
+                self.ctx.z3_ctx,
+                self.z3_ast,
+                precision as _,
+            ))
+        }
+        .to_str()
+        .unwrap();
         s.strip_suffix("?").unwrap_or(s).to_owned()
     }
     pub fn approx_f64(&self) -> f64 {

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -8,6 +8,10 @@ use z3::*;
 use num::{bigint::BigInt, rational::BigRational};
 use std::str::FromStr;
 
+mod objectives;
+mod ops;
+mod semver_tests;
+
 #[test]
 fn test_config() {
     let _ = env_logger::try_init();

--- a/z3/tests/ops.rs
+++ b/z3/tests/ops.rs
@@ -1,7 +1,7 @@
 use z3::{
     ast,
     ast::{Array, Ast, AstKind, Bool, Dynamic, Float, Int, Real, BV},
-    Config, Context, DeclKind, FuncDecl, Sort, Solver, SatResult
+    Config, Context, DeclKind, FuncDecl, SatResult, Solver, Sort,
 };
 
 #[test]

--- a/z3/tests/ops.rs
+++ b/z3/tests/ops.rs
@@ -312,7 +312,7 @@ fn test_real_approx() {
     let res = m.eval(&x, false).unwrap();
     assert_eq!(res.as_real(), None); // sqrt is irrational
     println!("f64 res: {}", res.approx_f64());
-    assert!((res.approx_f64() - 1.4142135623730950488016887242).abs() < 1e-20);
+    assert!((res.approx_f64() - ::std::f64::consts::SQRT_2).abs() < 1e-20);
     assert_eq!(res.approx(0), "1.");
     assert_eq!(res.approx(1), "1.4");
     assert_eq!(res.approx(2), "1.41");


### PR DESCRIPTION
It's a bit difficult to work with `Real` (in `z3`, not `z3-sys`) since the only provided way to get a value out at the end is `Real::as_real(&self) -> Option<(i64, i64)>`, which really only works for rational numbers. In this PR I've added two new functions to help:

- `Real::approx(&self, precision: usize) -> ::std::string::String`, which gives a string approximation of the real value up to `precision` correct digits after the decimal (via `Z3_get_numeral_decimal_string`).
- `Real::approx_f64(&self) -> f64`, which is just a convenience wrapper for `self.approx(17).parse().unwrap()` to get a full-precision `f64` approximation of the real number.

I also noticed that `tests/objectives.rs`, `tests/ops.rs`, and `tests/semver_tests.rs` weren't actually having their tests executed since they weren't linked into the lib, so I declared them as (test) modules. It looks like some of those are failing, but that's not something that this PR caused.