### PR TITLE
Expose sequence sort and AST

### DIFF
--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -3098,7 +3098,8 @@ extern "C" {
     /// Retrieve from `s` the unit sequence positioned at position `index`.
     pub fn Z3_mk_seq_at(c: Z3_context, s: Z3_ast, index: Z3_ast) -> Z3_ast;
 
-    /// Retrieve from s the element positioned at position index. The function is under-specified if the index is out of bounds.
+    /// Retrieve from `s` the element positioned at position `index`.
+    /// The function is under-specified if the index is out of bounds.
     pub fn Z3_mk_seq_nth(c: Z3_context, s: Z3_ast, index: Z3_ast) -> Z3_ast;
 
     /// Return the length of the sequence `s`.

--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -3098,6 +3098,9 @@ extern "C" {
     /// Retrieve from `s` the unit sequence positioned at position `index`.
     pub fn Z3_mk_seq_at(c: Z3_context, s: Z3_ast, index: Z3_ast) -> Z3_ast;
 
+    /// Retrieve from s the element positioned at position index. The function is under-specified if the index is out of bounds.
+    pub fn Z3_mk_seq_nth(c: Z3_context, s: Z3_ast, index: Z3_ast) -> Z3_ast;
+
     /// Return the length of the sequence `s`.
     pub fn Z3_mk_seq_length(c: Z3_context, s: Z3_ast) -> Z3_ast;
 

--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1687,7 +1687,8 @@ impl<'ctx> Seq<'ctx> {
         }
     }
 
-    /// Retrieve from s the unit sequence positioned at position index.
+    /// Retrieve the unit sequence positioned at position `index`.
+    /// Use [`Seq::nth`] to get just the element.
     pub fn at(&self, index: &Int<'ctx>) -> Self {
         unsafe {
             Self::wrap(
@@ -1697,7 +1698,7 @@ impl<'ctx> Seq<'ctx> {
         }
     }
 
-    /// Retrieve from s the element positioned at position index.
+    /// Retrieve the element positioned at position `index`.
     ///
     /// # Examples
     /// ```

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -70,6 +70,10 @@ impl<'ctx> Sort<'ctx> {
         unsafe { Self::wrap(ctx, Z3_mk_set_sort(ctx.z3_ctx, elt.z3_sort)) }
     }
 
+    pub fn seq(ctx: &'ctx Context, elt: &Sort<'ctx>) -> Sort<'ctx> {
+        unsafe { Self::wrap(ctx, Z3_mk_seq_sort(ctx.z3_ctx, elt.z3_sort)) }
+    }
+
     /// Create an enumeration sort.
     ///
     /// Creates a Z3 enumeration sort with the given `name`.


### PR DESCRIPTION
This commit exposes the sequence sort in the high level z3 binding and adds the `Z3_mk_seq_nth()` low level binding.