### PR TITLE
Add binding for FPA to IEEE-754 bit-vector

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1134,12 +1134,7 @@ impl<'ctx> Float<'ctx> {
 
     // Convert to IEEE-754 bit-vector
     pub fn to_ieee_bv(&self) -> BV<'ctx> {
-        unsafe {
-            BV::wrap(
-                self.ctx,
-                Z3_mk_fpa_to_ieee_bv(self.ctx.z3_ctx, self.z3_ast),
-            )
-        }
+        unsafe { BV::wrap(self.ctx, Z3_mk_fpa_to_ieee_bv(self.ctx.z3_ctx, self.z3_ast)) }
     }
 
     unop! {

--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1132,6 +1132,16 @@ impl<'ctx> Float<'ctx> {
         Self::round_towards_zero(self.ctx).div(self, other)
     }
 
+    // Convert to IEEE-754 bit-vector
+    pub fn to_ieee_bv(&self) -> BV<'ctx> {
+        unsafe {
+            BV::wrap(
+                self.ctx,
+                Z3_mk_fpa_to_ieee_bv(self.ctx.z3_ctx, self.z3_ast),
+            )
+        }
+    }
+
     unop! {
         unary_abs(Z3_mk_fpa_abs, Self);
         unary_neg(Z3_mk_fpa_neg, Self);


### PR DESCRIPTION
This PR exposes the `Z3_mk_fpa_to_ieee_bv()` API which is useful for interpreter memory model.