### PR TITLE
Adjust lifetimes on `ModelIter` to make them more permissive

### DIFF
--- a/z3/src/model.rs
+++ b/z3/src/model.rs
@@ -130,7 +130,7 @@ impl<'ctx> Model<'ctx> {
         }
     }
 
-    pub fn iter(&'ctx self) -> ModelIter<'ctx> {
+    pub fn iter<'a>(&'a self) -> ModelIter<'a, 'ctx> {
         self.into_iter()
     }
 }
@@ -162,15 +162,15 @@ impl<'ctx> Drop for Model<'ctx> {
 
 #[derive(Debug)]
 /// <https://z3prover.github.io/api/html/classz3py_1_1_model_ref.html#a7890b7c9bc70cf2a26a343c22d2c8367>
-pub struct ModelIter<'ctx> {
-    model: &'ctx Model<'ctx>,
+pub struct ModelIter<'a, 'ctx> {
+    model: &'a Model<'ctx>,
     idx: u32,
     len: u32,
 }
 
-impl<'ctx> IntoIterator for &'ctx Model<'ctx> {
+impl<'a, 'ctx> IntoIterator for &'a Model<'ctx> {
     type Item = FuncDecl<'ctx>;
-    type IntoIter = ModelIter<'ctx>;
+    type IntoIter = ModelIter<'a, 'ctx>;
 
     fn into_iter(self) -> Self::IntoIter {
         ModelIter {
@@ -181,7 +181,7 @@ impl<'ctx> IntoIterator for &'ctx Model<'ctx> {
     }
 }
 
-impl<'ctx> Iterator for ModelIter<'ctx> {
+impl<'a, 'ctx> Iterator for ModelIter<'a, 'ctx> {
     type Item = FuncDecl<'ctx>;
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
Currently, iterating over a Model creates `FuncDecls` that reference the lifetime of the reference of the model that they come from, rather than the lifetime of context it contains.

This means that it is impossible to use those `FuncDecls` after the model is dropped, even when the context is still around. From looking at the code, this just seems like a bug, but let me know if this is intentional.

This PR adjusts the lifetimes of `ModelIter` to also explicitly include the lifetime of the model reference. This way it can return `FuncDecl` that properly reference the lifetime of the context.