### PR TITLE
Panic through rust if provided an invalid tactic str to prevent SIGSEGV

### DIFF
--- a/z3/src/tactic.rs
+++ b/z3/src/tactic.rs
@@ -84,7 +84,14 @@ impl<'ctx> Tactic<'ctx> {
     /// - [`Tactic::list_all()`]
     pub fn new(ctx: &'ctx Context, name: &str) -> Tactic<'ctx> {
         let tactic_name = CString::new(name).unwrap();
-        unsafe { Self::wrap(ctx, Z3_mk_tactic(ctx.z3_ctx, tactic_name.as_ptr())) }
+	
+        unsafe {
+	    let tactic = Z3_mk_tactic(ctx.z3_ctx, tactic_name.as_ptr());
+	    if tactic.is_null() {
+		panic!("{} is an invalid tactic",name);
+	    } else {
+		Self::wrap(ctx, tactic)}
+	}
     }
 
     /// Return a tactic that just return the given goal.

--- a/z3/src/tactic.rs
+++ b/z3/src/tactic.rs
@@ -84,14 +84,15 @@ impl<'ctx> Tactic<'ctx> {
     /// - [`Tactic::list_all()`]
     pub fn new(ctx: &'ctx Context, name: &str) -> Tactic<'ctx> {
         let tactic_name = CString::new(name).unwrap();
-	
+
         unsafe {
-	    let tactic = Z3_mk_tactic(ctx.z3_ctx, tactic_name.as_ptr());
-	    if tactic.is_null() {
-		panic!("{} is an invalid tactic",name);
-	    } else {
-		Self::wrap(ctx, tactic)}
-	}
+            let tactic = Z3_mk_tactic(ctx.z3_ctx, tactic_name.as_ptr());
+            if tactic.is_null() {
+                panic!("{} is an invalid tactic", name);
+            } else {
+                Self::wrap(ctx, tactic)
+            }
+        }
     }
 
     /// Return a tactic that just return the given goal.


### PR DESCRIPTION
Fix for #338 ... Throwing a panic to let the user know they provided an invalid tactic name when trying to create a new tactic. Current behavior is to use the ptr returned from Z3 which could be a null pointer resulting in a SIGSEGV which may be more difficult to understand than the panic from the Rust side.