### PR TITLE
Add Order instantiation to FuncDecl

### DIFF
--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -2255,6 +2255,22 @@ extern "C" {
         body: Z3_ast,
     );
 
+
+    /// Create a FuncDecl representing a partial order
+    pub fn Z3_mk_partial_order(c: Z3_context, a: Z3_sort, id: usize) -> Z3_func_decl;
+
+    /// Create a FuncDecl representing a piecewise linear order
+    pub fn Z3_mk_piecewise_linear_order(c: Z3_context, a: Z3_sort, id: usize) -> Z3_func_decl;
+
+    /// Create a FuncDecl representing a linear order
+    pub fn Z3_mk_linear_order(c: Z3_context, a: Z3_sort, id: usize) -> Z3_func_decl;
+
+    /// Create a FuncDecl representing a tree order
+    pub fn Z3_mk_tree_order(c: Z3_context, a: Z3_sort, id: usize) -> Z3_func_decl;
+
+    /// Create a FuncDecl representing a transitive closure
+    pub fn Z3_mk_transitive_closure(c: Z3_context, f: Z3_func_decl) -> Z3_func_decl;
+
     /// Create an AST node representing `true`.
     pub fn Z3_mk_true(c: Z3_context) -> Z3_ast;
 

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -37,6 +37,26 @@ impl<'ctx> FuncDecl<'ctx> {
         }
     }
 
+    pub fn partial_order(ctx: &'ctx Context, a: &Sort<'ctx>, id: usize) -> Self {
+        unsafe { Self::wrap(ctx, Z3_mk_partial_order(ctx.z3_ctx, a.z3_sort, id)) }
+    }
+
+    pub fn piecewise_linear_order(ctx: &'ctx Context, a: &Sort<'ctx>, id: usize) -> Self {
+        unsafe { Self::wrap(ctx, Z3_mk_piecewise_linear_order(ctx.z3_ctx, a.z3_sort, id)) }
+    }
+
+    pub fn linear_order(ctx: &'ctx Context, a: &Sort<'ctx>, id: usize) -> Self {
+        unsafe { Self::wrap(ctx, Z3_mk_linear_order(ctx.z3_ctx, a.z3_sort, id)) }
+    }
+
+    pub fn tree_order(ctx: &'ctx Context, a: &Sort<'ctx>, id: usize) -> Self {
+        unsafe { Self::wrap(ctx, Z3_mk_tree_order(ctx.z3_ctx, a.z3_sort, id)) }
+    }
+
+    pub fn transitive_closure(ctx: &'ctx Context, a: &FuncDecl<'ctx>) -> Self {
+        unsafe { Self::wrap(ctx, Z3_mk_transitive_closure(ctx.z3_ctx, a.z3_func_decl)) }
+    }
+
     /// Return the number of arguments of a function declaration.
     ///
     /// If the function declaration is a constant, then the arity is `0`.


### PR DESCRIPTION
FuncDecl for partial/linear/piecewise linear/tree orders.

Z3 specializes these, this is better than adding assertions manually :)

Please help me double check that this does what it's supposed to; and that it does it in a good way.

I am not well versed with the internals of z3 or with this library.

[API Reference](https://z3prover.github.io/api/html/z3__api_8h.html), section "Special relations"