### PR TITLE
Make `z3_ctx` `pub`

### DIFF
--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -68,6 +68,7 @@ pub struct Config {
 /// - [`Config`]
 /// - [`Context::new()`]
 #[derive(PartialEq, Eq, Debug)]
+#[repr(transparent)]
 pub struct Context {
     z3_ctx: Z3_context,
 }

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -68,9 +68,8 @@ pub struct Config {
 /// - [`Config`]
 /// - [`Context::new()`]
 #[derive(PartialEq, Eq, Debug)]
-#[repr(transparent)]
 pub struct Context {
-    z3_ctx: Z3_context,
+    pub z3_ctx: Z3_context,
 }
 
 /// Handle that can be used to interrupt a computation from another thread.


### PR DESCRIPTION
I'm working on writing Python bindings for some code that I have that uses z3.rs. I would like my bindings to be able to work seamlessly with python's z3 library (producing terms and assertions to be used in python's handle to a solver for instance). I'm writing an opinionated API around the assumption that Python is always "driving" and that we are ALWAYS using Python's global Z3 context (allocated once on first use, never dropped or moved).

Pyo3 has the requirement that any Rust type passing into Python cannot have a lifetime other than `'static`, and all my structs have the z3.rs `'ctx` lifetime.

I'm working around this by pulling in a pointer to Python's global `Z3_Context` and storing it in a `thread_local` `RefCell<Z3_Context>`. I have a second `thread_local` with a `'static` reference to the contents of the `RefCell`.

If `Context` is `#[repr(transparent)]` then I believe I can safely transmute this reference into a `&'static Context`, which I can then use for all my FFI types.

I've already tried this and it seems to work fine, but to actually do this, I need the guarantee of `transparent`. 

I don't think that making this change would break anything. I assume this is also a less dangerous change for `z3.rs` to make than allowing for constructing `Context` structs out of raw pointers in the high-level API.
