### PR TITLE
Add bindings to the user propagator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ target
 Cargo.lock
 *~
 .z3-trace
+.DS_Store
+
+# nix
+.envrc
+.direnv
+result

--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -1569,7 +1569,7 @@ pub type Z3_pop_eh = ::std::option::Option<
     unsafe extern "C" fn(
         ctx: *mut ::std::ffi::c_void,
         cb: Z3_solver_callback,
-        num_scopes: ::std::ffi::c_uint,
+        num_scopes: ::std::os::raw::c_uint,
     ),
 >;
 pub type Z3_fresh_eh = ::std::option::Option<
@@ -1605,7 +1605,7 @@ pub type Z3_decide_eh = ::std::option::Option<
         cyx: *mut ::std::ffi::c_void,
         cd: Z3_solver_callback,
         t: Z3_ast,
-        idx: ::std::ffi::c_uint,
+        idx: ::std::os::raw::c_uint,
         phase: bool,
     ),
 >;
@@ -1613,8 +1613,8 @@ pub type Z3_on_clause_eh = ::std::option::Option<
     unsafe extern "C" fn(
         ctx: *mut ::std::ffi::c_void,
         proof_hint: Z3_ast,
-        n: ::std::ffi::c_uint,
-        deps: *const ::std::ffi::c_uint,
+        n: ::std::os::raw::c_uint,
+        deps: *const ::std::os::raw::c_uint,
         literals: Z3_ast_vector,
     ),
 >;

--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -8134,7 +8134,7 @@ extern "C" {
     /// - `num_eqs`: number of equalities used as premise to propagation
     /// - `lhs`: left side of equalities
     /// - `rhs`: right side of equalities
-    /// - `consequence`: consequence to propagate. It is typically an atomic formula, but 
+    /// - `consequence`: consequence to propagate. It is typically an atomic formula, but
     ///                  it can be an arbitrary formula.
     ///
     /// Assume the callback has the signature:
@@ -8152,21 +8152,13 @@ extern "C" {
 
     /// register a callback when a new expression with a registered function is
     /// used by the solver The registered function appears at the top level and
-    /// is created using [Z3_solver_propagate_declare]. 
-    pub fn Z3_solver_propagate_created(
-        c: Z3_context,
-        s: Z3_solver,
-        created_eh: Z3_created_eh
-    );
+    /// is created using [Z3_solver_propagate_declare].
+    pub fn Z3_solver_propagate_created(c: Z3_context, s: Z3_solver, created_eh: Z3_created_eh);
 
     /// register a callback when the solver decides to split on a registered
     /// expression. The callback may change the arguments by providing other
     /// values by calling [Z3_solver_next_split].
-    pub fn Z3_solver_propagate_decide(
-        c: Z3_context,
-        s: Z3_solver,
-        decide_eh: Z3_decide_eh
-    );
+    pub fn Z3_solver_propagate_decide(c: Z3_context, s: Z3_solver, decide_eh: Z3_decide_eh);
 
     /// Create uninterpreted function declaration for the user propagator. When
     /// expressions using the function are created by the solver invoke a
@@ -8182,28 +8174,20 @@ extern "C" {
         name: Z3_symbol,
         n: ::std::os::raw::c_uint,
         domain: *const Z3_sort,
-        range: Z3_sort
+        range: Z3_sort,
     ) -> Z3_func_decl;
 
-    /// register a callback on expression dis-equalities. 
-    pub fn Z3_solver_propagate_diseq(
-        c: Z3_context,
-        s: Z3_solver,
-        eq_eh: Z3_eq_eh
-    );
+    /// register a callback on expression dis-equalities.
+    pub fn Z3_solver_propagate_diseq(c: Z3_context, s: Z3_solver, eq_eh: Z3_eq_eh);
 
     /// register a callback on expression equalities.
-    pub fn Z3_solver_propagate_eq(
-        c: Z3_context,
-        s: Z3_solver,
-        eq_eh: Z3_eq_eh
-    );
+    pub fn Z3_solver_propagate_eq(c: Z3_context, s: Z3_solver, eq_eh: Z3_eq_eh);
 
     /// register a callback on final check. This provides freedom to the
     /// propagator to delay actions or implement a branch-and bound solver. The
     /// final check is invoked when all decision variables have been assigned by
     /// the solver.
-    /// 
+    ///
     /// The final_eh callback takes as argument the original user_context that
     /// was used when calling [Z3_solver_propagate_init], and it takes a callback
     /// context with the opaque type [Z3_solver_callback]. The callback context is
@@ -8212,23 +8196,15 @@ extern "C" {
     /// for dynamically registering expressions) within a callback. If the
     /// callback context gets used for propagation or conflicts, those
     /// propagations take effect and may trigger new decision variables to be
-    /// set. 
-    pub fn Z3_solver_propagate_final(
-        c: Z3_context,
-        s: Z3_solver,
-        final_eh: Z3_final_eh
-    );
+    /// set.
+    pub fn Z3_solver_propagate_final(c: Z3_context, s: Z3_solver, final_eh: Z3_final_eh);
 
     /// register a callback for when an expression is bound to a fixed value.
     /// The supported expression types are:
     ///
     /// - Booleans
     /// - Bit-vectors
-    pub fn Z3_solver_propagate_fixed(
-        c: Z3_context,
-        s: Z3_solver,
-        fixed_eh: Z3_fixed_eh
-    );
+    pub fn Z3_solver_propagate_fixed(c: Z3_context, s: Z3_solver, fixed_eh: Z3_fixed_eh);
 
     /// register a user-propagator with the solver.
     ///
@@ -8239,34 +8215,26 @@ extern "C" {
     /// - `pop_eh`: a callback invoked when scopes are popped
     /// - `fresh_eh`: a solver may spawn new solvers internally. This callback
     ///   is used to produce a fresh user_context to be associated with fresh
-    ///   solvers. 
+    ///   solvers.
     pub fn Z3_solver_propagate_init(
         c: Z3_context,
         s: Z3_solver,
         user_context: *mut ::std::ffi::c_void,
         push_eh: Z3_push_eh,
         pop_eh: Z3_pop_eh,
-        fresh_eh: Z3_fresh_eh
+        fresh_eh: Z3_fresh_eh,
     );
 
     /// register an expression to propagate on with the solver. Only expressions
-    /// of type Bool and type Bit-Vector can be registered for propagation. 
-    pub fn Z3_solver_propagate_register(
-        c: Z3_context,
-        s: Z3_solver,
-        e: Z3_ast
-    );
+    /// of type Bool and type Bit-Vector can be registered for propagation.
+    pub fn Z3_solver_propagate_register(c: Z3_context, s: Z3_solver, e: Z3_ast);
 
     /// register an expression to propagate on with the solver. Only expressions
     /// of type Bool and type Bit-Vector can be registered for propagation.
     /// Unlike [Z3_solver_propagate_register], this function takes a solver
     /// callback context as argument. It can be invoked during a callback to
-    /// register new expressions. 
-    pub fn Z3_solver_propagate_register_cb(
-        c: Z3_context,
-        cb: Z3_solver_callback,
-        e: Z3_ast
-    );
+    /// register new expressions.
+    pub fn Z3_solver_propagate_register_cb(c: Z3_context, cb: Z3_solver_callback, e: Z3_ast);
 
     /// register a callback to that retrieves assumed, inferred and deleted clauses during search.
     ///
@@ -8282,7 +8250,7 @@ extern "C" {
         c: Z3_context,
         s: Z3_solver,
         user_context: *mut ::std::ffi::c_void,
-        on_clause_eh: Z3_on_clause_eh
+        on_clause_eh: Z3_on_clause_eh,
     );
 }
 

--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -1552,6 +1552,73 @@ pub enum ErrorCode {
 pub type Z3_error_handler =
     ::std::option::Option<unsafe extern "C" fn(c: Z3_context, e: ErrorCode)>;
 
+#[doc(hidden)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _Z3_solver_callback {
+    _unused: [u8; 0],
+}
+
+/// Type of callback functions for the User Propagator
+pub type Z3_solver_callback = *mut _Z3_solver_callback;
+
+pub type Z3_push_eh = ::std::option::Option<
+    unsafe extern "C" fn(cyx: *mut ::std::ffi::c_void, cd: Z3_solver_callback),
+>;
+pub type Z3_pop_eh = ::std::option::Option<
+    unsafe extern "C" fn(
+        cyx: *mut ::std::ffi::c_void,
+        cd: Z3_solver_callback,
+        num_scopes: ::std::ffi::c_uint,
+    ),
+>;
+pub type Z3_fresh_eh = ::std::option::Option<
+    unsafe extern "C" fn(
+        cyx: *mut ::std::ffi::c_void,
+        new_context: Z3_context,
+    ) -> *mut ::std::ffi::c_void,
+>;
+pub type Z3_fixed_eh = ::std::option::Option<
+    unsafe extern "C" fn(
+        cyx: *mut ::std::ffi::c_void,
+        cd: Z3_solver_callback,
+        t: Z3_ast,
+        value: Z3_ast,
+    ),
+>;
+pub type Z3_eq_eh = ::std::option::Option<
+    unsafe extern "C" fn(
+        cyx: *mut ::std::ffi::c_void,
+        cd: Z3_solver_callback,
+        s: Z3_ast,
+        t: Z3_ast,
+    ),
+>;
+pub type Z3_final_eh = ::std::option::Option<
+    unsafe extern "C" fn(cyx: *mut ::std::ffi::c_void, cd: Z3_solver_callback),
+>;
+pub type Z3_created_eh = ::std::option::Option<
+    unsafe extern "C" fn(cyx: *mut ::std::ffi::c_void, cd: Z3_solver_callback, t: Z3_ast),
+>;
+pub type Z3_decide_eh = ::std::option::Option<
+    unsafe extern "C" fn(
+        cyx: *mut ::std::ffi::c_void,
+        cd: Z3_solver_callback,
+        t: Z3_ast,
+        idx: ::std::ffi::c_uint,
+        phase: bool,
+    ),
+>;
+pub type Z3_on_clause_eh = ::std::option::Option<
+    unsafe extern "C" fn(
+        cyx: *mut ::std::ffi::c_void,
+        proof_hint: Z3_ast,
+        n: ::std::ffi::c_uint,
+        deps: *const ::std::ffi::c_uint,
+        literals: Z3_ast_vector,
+    ),
+>;
+
 /// Precision of a given goal. Some goals can be transformed using over/under approximations.
 ///
 /// This corresponds to `Z3_goal_prec` in the C API.
@@ -8034,6 +8101,189 @@ extern "C" {
 
     /// Best-effort quantifier elimination
     pub fn Z3_qe_lite(c: Z3_context, vars: Z3_ast_vector, body: Z3_ast) -> Z3_ast;
+
+    /// Sets the next (registered) expression to split on. The function returns
+    /// false and ignores the given expression in case the expression is already
+    /// assigned internally (due to relevancy propagation, this assignments
+    /// might not have been reported yet by the fixed callback). In case the
+    /// function is called in the decide callback, it overrides the currently
+    /// selected variable and phase.
+    pub fn Z3_solver_next_split(
+        c: Z3_context,
+        cb: Z3_solver_callback,
+        t: Z3_ast,
+        idx: ::std::os::raw::c_uint,
+        phase: Z3_lbool,
+    ) -> bool;
+
+    /// propagate a consequence based on fixed values and equalities. A client
+    /// may invoke it during the `propagate_fixed`, `propagate_eq`, `propagate_diseq`,
+    /// and `propagate_final` callbacks. The callback adds a propagation
+    /// consequence based on the fixed values passed ids and equalities eqs
+    /// based on parameters lhs, rhs.
+    ///
+    /// The solver might discard the propagation in case it is true in the
+    /// current state. The function returns false in this case; otw. the
+    /// function returns true. At least one propagation in the final callback
+    /// has to return true in order to prevent the solver from finishing.
+    ///
+    /// - `c`: context
+    /// - `solver_cb`: solver callback
+    /// - `num_ids`: number of fixed terms used as premise to propagation
+    /// - `ids`: array of length num_ids containing terms that are fixed in the current scope
+    /// - `num_eqs`: number of equalities used as premise to propagation
+    /// - `lhs`: left side of equalities
+    /// - `rhs`: right side of equalities
+    /// - `consequence`: consequence to propagate. It is typically an atomic formula, but 
+    ///                  it can be an arbitrary formula.
+    ///
+    /// Assume the callback has the signature:
+    ///     `propagate_consequence_eh(context, solver_cb, num_ids, ids, num_eqs, lhs, rhs, consequence)`.
+    pub fn Z3_solver_propagate_consequence(
+        c: Z3_context,
+        cb: Z3_solver_callback,
+        num_fixed: ::std::os::raw::c_uint,
+        fixed: *const Z3_ast,
+        num_eqs: ::std::os::raw::c_uint,
+        eq_lhs: *const Z3_ast,
+        eq_rhs: *const Z3_ast,
+        conseq: Z3_ast,
+    ) -> bool;
+
+    /// register a callback when a new expression with a registered function is
+    /// used by the solver The registered function appears at the top level and
+    /// is created using [Z3_solver_propagate_declare]. 
+    pub fn Z3_solver_propagete_created(
+        c: Z3_context,
+        s: Z3_solver,
+        created_eh: Z3_created_eh
+    );
+
+    /// register a callback when the solver decides to split on a registered
+    /// expression. The callback may change the arguments by providing other
+    /// values by calling [Z3_solver_next_split].
+    pub fn Z3_solver_propagate_decide(
+        c: Z3_context,
+        s: Z3_solver,
+        decide_eh: Z3_decide_eh
+    );
+
+    /// Create uninterpreted function declaration for the user propagator. When
+    /// expressions using the function are created by the solver invoke a
+    /// callback to [Z3_solver_propagate_created] with arguments
+    ///
+    /// 1. context and callback solve
+    /// 2. declared_expr: expression using function that was used as the
+    ///    top-level symbol
+    /// 3. declared_id: a unique identifier (unique within the current scope) to
+    ///    track the expression.
+    pub fn Z3_solver_propagate_declare(
+        c: Z3_context,
+        name: Z3_symbol,
+        n: ::std::ffi::c_uint,
+        domain: *const Z3_sort,
+        range: Z3_sort
+    ) -> Z3_func_decl;
+
+    /// register a callback on expression dis-equalities. 
+    pub fn Z3_solver_propaget_diseq(
+        c: Z3_context,
+        s: Z3_solver,
+        eq_eh: Z3_eq_eh
+    );
+
+    /// register a callback on expression equalities.
+    pub fn Z3_solver_propagate_eq(
+        c: Z3_context,
+        s: Z3_solver,
+        eq_eh: Z3_eq_eh
+    );
+
+    /// register a callback on final check. This provides freedom to the
+    /// propagator to delay actions or implement a branch-and bound solver. The
+    /// final check is invoked when all decision variables have been assigned by
+    /// the solver.
+    /// 
+    /// The final_eh callback takes as argument the original user_context that
+    /// was used when calling [Z3_solver_propagate_init], and it takes a callback
+    /// context with the opaque type [Z3_solver_callback]. The callback context is
+    /// passed as argument to invoke the [Z3_solver_propagate_consequence]
+    /// function. The callback context can only be accessed (for propagation and
+    /// for dynamically registering expressions) within a callback. If the
+    /// callback context gets used for propagation or conflicts, those
+    /// propagations take effect and may trigger new decision variables to be
+    /// set. 
+    pub fn Z3_solver_propagate_final(
+        c: Z3_context,
+        s: Z3_solver,
+        final_eh: Z3_final_eh
+    );
+
+    /// register a callback for when an expression is bound to a fixed value.
+    /// The supported expression types are:
+    ///
+    /// - Booleans
+    /// - Bit-vectors
+    pub fn Z3_solver_propagate_fixed(
+        c: Z3_context,
+        s: Z3_solver,
+        fixed_eh: Z3_fixed_eh
+    );
+
+    /// register a user-propagator with the solver.
+    ///
+    /// -`c`: context.
+    /// - `s`: solver object.
+    /// - `user_context`: a context used to maintain state for callbacks.
+    /// - `push_eh`: a callback invoked when scopes are pushed
+    /// - `pop_eh`: a callback invoked when scopes are popped
+    /// - `fresh_eh`: a solver may spawn new solvers internally. This callback
+    ///   is used to produce a fresh user_context to be associated with fresh
+    ///   solvers. 
+    pub fn Z3_solver_propagate_init(
+        c: Z3_context,
+        s: Z3_solver,
+        user_context: *mut ::std::ffi::c_void,
+        push_eh: Z3_push_eh,
+        pop_eh: Z3_pop_eh,
+        fresh_eh: Z3_fresh_eh
+    );
+
+    /// register an expression to propagate on with the solver. Only expressions
+    /// of type Bool and type Bit-Vector can be registered for propagation. 
+    pub fn Z3_solver_propagate_register(
+        c: Z3_context,
+        s: Z3_solver,
+        e: Z3_ast
+    );
+
+    /// register an expression to propagate on with the solver. Only expressions
+    /// of type Bool and type Bit-Vector can be registered for propagation.
+    /// Unlike [Z3_solver_propagate_register], this function takes a solver
+    /// callback context as argument. It can be invoked during a callback to
+    /// register new expressions. 
+    pub fn Z3_solver_propagate_register_cb(
+        c: Z3_context,
+        cb: Z3_solver_callback,
+        e: Z3_ast
+    );
+
+    /// register a callback to that retrieves assumed, inferred and deleted clauses during search.
+    ///
+    ///
+    /// - `c`: context.
+    /// - `s`: solver object.
+    /// - `user_context`: a context used to maintain state for callbacks.
+    /// - `on_clause_eh`: a callback that is invoked by when a clause is
+    ///    * asserted to the CDCL engine (corresponding to an input clause after pre-processing)
+    ///    * inferred by CDCL(T) using either a SAT or theory conflict/propagation
+    ///    * deleted by the CDCL(T) engine
+    pub fn Z3_solver_register_on_clause(
+        c: Z3_context,
+        s: Z3_solver,
+        user_context: *mut ::std::ffi::c_void,
+        on_clause_eh: Z3_on_clause_eh
+    );
 }
 
 #[cfg(not(windows))]

--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -1567,38 +1567,38 @@ pub type Z3_push_eh = ::std::option::Option<
 >;
 pub type Z3_pop_eh = ::std::option::Option<
     unsafe extern "C" fn(
-        cyx: *mut ::std::ffi::c_void,
-        cd: Z3_solver_callback,
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
         num_scopes: ::std::ffi::c_uint,
     ),
 >;
 pub type Z3_fresh_eh = ::std::option::Option<
     unsafe extern "C" fn(
-        cyx: *mut ::std::ffi::c_void,
+        ctx: *mut ::std::ffi::c_void,
         new_context: Z3_context,
     ) -> *mut ::std::ffi::c_void,
 >;
 pub type Z3_fixed_eh = ::std::option::Option<
     unsafe extern "C" fn(
-        cyx: *mut ::std::ffi::c_void,
-        cd: Z3_solver_callback,
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
         t: Z3_ast,
         value: Z3_ast,
     ),
 >;
 pub type Z3_eq_eh = ::std::option::Option<
     unsafe extern "C" fn(
-        cyx: *mut ::std::ffi::c_void,
-        cd: Z3_solver_callback,
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
         s: Z3_ast,
         t: Z3_ast,
     ),
 >;
 pub type Z3_final_eh = ::std::option::Option<
-    unsafe extern "C" fn(cyx: *mut ::std::ffi::c_void, cd: Z3_solver_callback),
+    unsafe extern "C" fn(cyx: *mut ::std::ffi::c_void, cb: Z3_solver_callback),
 >;
 pub type Z3_created_eh = ::std::option::Option<
-    unsafe extern "C" fn(cyx: *mut ::std::ffi::c_void, cd: Z3_solver_callback, t: Z3_ast),
+    unsafe extern "C" fn(cyx: *mut ::std::ffi::c_void, cb: Z3_solver_callback, t: Z3_ast),
 >;
 pub type Z3_decide_eh = ::std::option::Option<
     unsafe extern "C" fn(
@@ -8153,7 +8153,7 @@ extern "C" {
     /// register a callback when a new expression with a registered function is
     /// used by the solver The registered function appears at the top level and
     /// is created using [Z3_solver_propagate_declare]. 
-    pub fn Z3_solver_propagete_created(
+    pub fn Z3_solver_propagate_created(
         c: Z3_context,
         s: Z3_solver,
         created_eh: Z3_created_eh
@@ -8180,13 +8180,13 @@ extern "C" {
     pub fn Z3_solver_propagate_declare(
         c: Z3_context,
         name: Z3_symbol,
-        n: ::std::ffi::c_uint,
+        n: ::std::os::raw::c_uint,
         domain: *const Z3_sort,
         range: Z3_sort
     ) -> Z3_func_decl;
 
     /// register a callback on expression dis-equalities. 
-    pub fn Z3_solver_propaget_diseq(
+    pub fn Z3_solver_propagate_diseq(
         c: Z3_context,
         s: Z3_solver,
         eq_eh: Z3_eq_eh

--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -1611,7 +1611,7 @@ pub type Z3_decide_eh = ::std::option::Option<
 >;
 pub type Z3_on_clause_eh = ::std::option::Option<
     unsafe extern "C" fn(
-        cyx: *mut ::std::ffi::c_void,
+        ctx: *mut ::std::ffi::c_void,
         proof_hint: Z3_ast,
         n: ::std::ffi::c_uint,
         deps: *const ::std::ffi::c_uint,

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(missing_debug_implementations)]
 
 use std::ffi::CString;
+use user_propagator::UPHandle;
 use z3_sys::*;
 pub use z3_sys::{AstKind, GoalPrec, SortKind};
 
@@ -31,6 +32,7 @@ mod statistics;
 mod symbol;
 mod tactic;
 mod version;
+pub mod user_propagator;
 
 pub use crate::params::{get_global_param, reset_all_global_params, set_global_param};
 pub use crate::statistics::{StatisticsEntry, StatisticsValue};

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -7,7 +7,6 @@
 #![deny(missing_debug_implementations)]
 
 use std::ffi::CString;
-use user_propagator::UPHandle;
 use z3_sys::*;
 pub use z3_sys::{AstKind, GoalPrec, SortKind};
 
@@ -31,8 +30,8 @@ mod sort;
 mod statistics;
 mod symbol;
 mod tactic;
-mod version;
 pub mod user_propagator;
+mod version;
 
 pub use crate::params::{get_global_param, reset_all_global_params, set_global_param};
 pub use crate::statistics::{StatisticsEntry, StatisticsValue};

--- a/z3/src/user_propagator.rs
+++ b/z3/src/user_propagator.rs
@@ -2,104 +2,520 @@
 
 // I am following quite closly this: https://z3prover.github.io/api/html/classz3_1_1user__propagator__base.html
 
-use std::{convert::TryInto, fmt::Debug, pin::Pin, ptr::NonNull, usize};
+use std::{fmt::Debug, marker::PhantomData, pin::Pin};
 
-use crate::{
-    ast::{self, Ast, Dynamic},
-    Context, FuncDecl, Solver, Sort, Symbol,
-};
-use log::debug;
+use crate::{ast::Ast, Solver};
 use z3_sys::*;
 
-/// Interface to build a custom [User
-/// Propagator](https://microsoft.github.io/z3guide/programming/Example%20Programs/User%20Propagator/)
-///
-/// All function fowllow their C++ counterparts in the
-/// [`user_propagator_base`](https://z3prover.github.io/api/html/classz3_1_1user__propagator__base.html).
-/// Callbacks can be made though the `upw` paramter. Those callbacks my panic if
-/// called from a wrong place.
-///
-/// By default all function are implemented and do nothing
-#[allow(unused_variables)]
-pub trait UserPropagator<'ctx>: Debug {
-    /// Called when z3 case splits
-    fn push(&self, upw: &UPHandle<'ctx, '_>) {}
-    /// Called when z3 backtracks `num_scopes` times
-    fn pop(&self, upw: &UPHandle<'ctx, '_>, num_scopes: u32) {}
-    /// Called when `id` is fixed to value `e`
-    fn fixed(&self, upw: &UPHandle<'ctx, '_>, id: &Dynamic<'ctx>, e: &Dynamic<'ctx>) {}
-    /// Called when `x` and `y` are equated.
-    ///
-    /// This can be somewhat unreliable as z3 may call this less time than you'd
-    /// expect.
-    ///
-    /// See:
-    /// https://microsoft.github.io/z3guide/programming/Example%20Programs/User%20Propagator/#equality-callbacks
-    fn eq(&self, upw: &UPHandle<'ctx, '_>, x: &Dynamic<'ctx>, y: &Dynamic<'ctx>) {}
-    /// Same as [eq] be on negated equalities
-    fn neq(&self, upw: &UPHandle<'ctx, '_>, x: &Dynamic<'ctx>, y: &Dynamic<'ctx>) {}
+pub use user_propagator::{declare_up_function, CallBack, UserPropagator};
+mod user_propagator {
+    use std::{convert::TryInto, fmt::Debug, pin::Pin};
 
-    /// During the final check stage, all propagations have been processed. This
-    /// is an opportunity for the user-propagator to delay some analysis that
-    /// could be expensive to perform incrementally. It is also an opportunity
-    /// for the propagator to implement branch and bound optimization.
-    fn final_(&self, upw: &UPHandle<'ctx, '_>) {}
-    /// `e` was created using one of the function declared with
-    /// [declare_up_function].
+    use crate::{
+        ast::{self, Ast, Dynamic},
+        Context, FuncDecl, Sort, Symbol,
+    };
+    use log::debug;
+    use z3_sys::*;
+
+    /// Interface to build a custom [User
+    /// Propagator](https://microsoft.github.io/z3guide/programming/Example%20Programs/User%20Propagator/)
     ///
-    /// Remeber to register those expressions! (using [UPHandle::add] or
-    /// [UPSolver::add] depending on the calling location)
+    /// All function fowllow their C++ counterparts in the
+    /// [`user_propagator_base`](https://z3prover.github.io/api/html/classz3_1_1user__propagator__base.html).
+    /// Callbacks can be made though the `upw` paramter. Those callbacks my panic if
+    /// called from a wrong place.
     ///
-    /// **NB**: there is no way to declare a function for specific
-    /// [UserPropagator].
-    fn created(&self, upw: &UPHandle<'ctx, '_>, e: &Dynamic<'ctx>) {}
-    fn decide(&self, upw: &UPHandle<'ctx, '_>, val: &Dynamic<'ctx>, bit: u32, is_pos: bool) {}
+    /// By default all function are implemented and do nothing
+    #[allow(unused_variables)]
+    pub trait UserPropagator<'ctx>: Debug {
+        fn get_context(&self) -> &'ctx Context;
 
-    // TODO: figure out how to make fresh work
-    // fn fresh<'a>(
-    //     upw: &'a UserPropagatorWrapper<'ctx>,
-    //     ctx: &'a Context,
-    // ) -> Option<&'a dyn UserPropagator<'a>> {
-    //     None
-    // }
-}
+        /// Called when z3 case splits
+        fn push(&self, cb: &CallBack<'ctx>) {}
 
-/// see [`user_propagator_base::scoped_cb`](https://z3prover.github.io/api/html/z3_09_09_8h_source.html#l04310)
-#[derive(Debug)]
-struct CallBackTracker {
-    /// can be null
-    cb: Z3_solver_callback,
-    depth: usize,
-}
+        /// Called when z3 backtracks `num_scopes` times
+        fn pop(&self, cb: &CallBack<'ctx>, num_scopes: u32) {}
 
-impl Default for CallBackTracker {
-    fn default() -> Self {
-        Self {
-            cb: ::std::ptr::null_mut(),
-            depth: 0,
+        /// Called when `id` is fixed to value `e`
+        fn fixed(&self, cb: &CallBack<'ctx>, id: &Dynamic<'ctx>, e: &Dynamic<'ctx>) {}
+
+        /// Called when `x` and `y` are equated.
+        ///
+        /// This can be somewhat unreliable as z3 may call this less time than you'd
+        /// expect.
+        ///
+        /// See:
+        /// https://microsoft.github.io/z3guide/programming/Example%20Programs/User%20Propagator/#equality-callbacks
+        fn eq(&self, cb: &CallBack<'ctx>, x: &Dynamic<'ctx>, y: &Dynamic<'ctx>) {}
+
+        /// Same as [eq] be on negated equalities
+        fn neq(&self, cb: &CallBack<'ctx>, x: &Dynamic<'ctx>, y: &Dynamic<'ctx>) {}
+
+        /// During the final check stage, all propagations have been processed. This
+        /// is an opportunity for the user-propagator to delay some analysis that
+        /// could be expensive to perform incrementally. It is also an opportunity
+        /// for the propagator to implement branch and bound optimization.
+        fn final_(&self, cb: &CallBack<'ctx>) {}
+
+        /// `e` was created using one of the function declared with
+        /// [declare_up_function].
+        ///
+        /// Remeber to register those expressions! (using [CallBack::add] or
+        /// [UPSolver::add] depending on the calling location)
+        ///
+        /// **NB**: there is no way to declare a function for specific
+        /// [UserPropagator].
+        ///
+        /// [UPSolver::add]: super::UPSolver::add
+        fn created(&self, cb: &CallBack<'ctx>, e: &Dynamic<'ctx>) {}
+
+        fn decide(&self, cb: &CallBack<'ctx>, val: &Dynamic<'ctx>, bit: u32, is_pos: bool) {}
+
+        // TODO: figure out how to make fresh work
+        // fn fresh<'a>(
+        //     upw: &'a UserPropagatorWrapper<'ctx>,
+        //     ctx: &'a Context,
+        // ) -> Option<&'a dyn UserPropagator<'a>> {
+        //     None
+        // }
+    }
+
+    #[derive(Debug)]
+    pub struct CallBack<'ctx> {
+        cb: Z3_solver_callback,
+        ctx: &'ctx Context,
+    }
+
+    impl<'ctx> CallBack<'ctx> {
+        pub fn new(cb: Z3_solver_callback, ctx: &'ctx Context) -> Self {
+            Self { cb, ctx }
+        }
+
+        /// Sets the next (registered) expression to split on. The function returns
+        /// false and ignores the given expression in case the expression is already
+        /// assigned internally (due to relevancy propagation, this assignments
+        /// might not have been reported yet by the fixed callback). In case the
+        /// function is called in the decide callback, it overrides the currently
+        /// selected variable and phase.
+        ///
+        /// panics if not called from a callback
+        ///
+        /// see [Z3_solver_next_split]
+        pub fn next_split(&self, expr: &ast::Bool<'ctx>, idx: u32, phase: Option<bool>) -> bool {
+            debug_assert_eq!(self.get_ctx(), expr.get_ctx());
+            let phase = match phase {
+                Some(true) => Z3_L_TRUE,
+                Some(false) => Z3_L_FALSE,
+                None => Z3_L_UNDEF,
+            };
+            unsafe { Z3_solver_next_split(self.z3_ctx(), self.cb, expr.get_z3_ast(), idx, phase) }
+        }
+
+        /// Tracks `expr` with ([UserPropagator::fixed()] or [UserPropagator::eq()])
+        ///
+        /// If `expr` is a Boolean or Bit-vector, the [UserPropagator::fixed()]
+        /// callback gets invoked when `expr` is bound to a value.a Equalities
+        /// between registered expressions  are reported thought
+        /// [UserPropagator::eq()]. A consumer can use the [Self::propagate] or
+        /// [Self::conflict] functions to invoke propagations or conflicts as a
+        /// consequence of these callbacks. These functions take a list of
+        /// identifiers for registered expressions that have been fixed. The list of
+        /// identifiers must correspond to already fixed values. Similarly, a list
+        /// of propagated equalities can be supplied. These must correspond to
+        /// equalities that have been registered during a callback.
+        ///
+        /// see [Z3_solver_propagate_register_cb] and [Z3_solver_propagate_register]
+        pub fn add(&self, expr: &impl Ast<'ctx>) {
+            debug_assert_eq!(self.get_ctx(), expr.get_ctx());
+            unsafe { Z3_solver_propagate_register_cb(self.z3_ctx(), self.cb, expr.get_z3_ast()) };
+        }
+
+        /// Propagate a consequence based on fixed values and equalities.
+        ///
+        /// A client may invoke it during the `propagate_fixed`, `propagate_eq`,
+        /// `propagate_diseq`, and `propagate_final` callbacks. The callback adds a
+        /// propagation consequence based on the fixed values passed ids and
+        /// equalities eqs based on parameters lhs, rhs.
+        ///
+        /// The solver might discard the propagation in case it is true in the
+        /// current state. The function returns false in this case; otw. the
+        /// function returns true. At least one propagation in the final callback
+        /// has to return true in order to prevent the solver from finishing.
+        ///
+        /// - `fixed`: iterator containing terms that are fixed in the current scope
+        /// - `lhs`: left side of equalities
+        /// - `rhs`: right side of equalities
+        /// - `conseq`: consequence to propagate. It is typically an atomic formula,
+        ///             but it can be an arbitrary formula.
+        ///
+        /// panics if not called from a callback or if `lhs` and `rhs` don't have the same
+        /// length.
+        ///
+        /// see [Z3_solver_propagate_consequence]
+        pub fn propagate<'b, I, J, A>(
+            &'b self,
+            fixed: I,
+            lhs: J,
+            rhs: J,
+            conseq: &'b ast::Bool<'ctx>,
+        ) -> bool
+        where
+            I: IntoIterator<Item = &'b ast::Bool<'ctx>>,
+            J: IntoIterator<Item = &'b A>,
+            A: Ast<'ctx> + 'b,
+        {
+            /* using generics because I need to map on the arguments anyway and it will turn
+            the other functions defined from `propagate` into the same things as the C++
+            API this is based on */
+            fn into_vec_and_check<'ctx, 'b, A: Ast<'ctx> + 'b>(
+                ctx: &'ctx Context,
+                iter: impl IntoIterator<Item = &'b A>,
+            ) -> Vec<Z3_ast> {
+                iter.into_iter()
+                    .inspect(|e| debug_assert_eq!(ctx, e.get_ctx()))
+                    .map(|e| e.get_z3_ast())
+                    .collect()
+            }
+            debug_assert_eq!(self.get_ctx(), conseq.get_ctx());
+            let fixed = into_vec_and_check(self.get_ctx(), fixed);
+            let lhs = into_vec_and_check(self.get_ctx(), lhs);
+            let rhs = into_vec_and_check(self.get_ctx(), rhs);
+            let conseq = conseq.get_z3_ast();
+            assert_eq!(lhs.len(), rhs.len());
+
+            // not sure what the API does exactly, but it probably expects null pointers
+            // rather than dangling ones in case of empty vecs
+            let to_ptr = |v: Vec<_>| {
+                if v.is_empty() {
+                    ::std::ptr::null()
+                } else {
+                    v.as_ptr()
+                }
+            };
+
+            unsafe {
+                Z3_solver_propagate_consequence(
+                    self.z3_ctx(),
+                    self.cb,
+                    fixed.len().try_into().unwrap(),
+                    to_ptr(fixed),
+                    lhs.len().try_into().unwrap(),
+                    to_ptr(lhs),
+                    to_ptr(rhs),
+                    conseq,
+                )
+            }
+        }
+
+        /// triggers a confict on `fixed`
+        ///
+        /// Equivalent to [`self.propagate(fixed, [] , [], FALSE)`](Self::propagate)
+        ///
+        /// panics if not called from a callback.
+        pub fn conflict_on(&self, fixed: &[&ast::Bool<'ctx>]) -> bool {
+            self.propagate::<_, _, ast::Bool<'ctx>>(
+                fixed.iter().copied(),
+                [],
+                [],
+                &ast::Bool::from_bool(self.get_ctx(), false),
+            )
+        }
+
+        /// triggers a confict on `fixed` and `lhs == rhs`
+        ///
+        /// Equivalent to [`self.propagate(fixed, lhs, rhs, FALSE)`](Self::propagate)
+        ///
+        /// panics if not called from a callback or if `lhs` and `rhs` don't have the same
+        /// length.
+        pub fn conflict(
+            &self,
+            fixed: &[&ast::Bool<'ctx>],
+            lhs: &[&ast::Dynamic<'ctx>],
+            rhs: &[&ast::Dynamic<'ctx>],
+        ) -> bool {
+            self.propagate(
+                fixed.iter().copied(),
+                lhs.iter().copied(),
+                rhs.iter().copied(),
+                &ast::Bool::from_bool(self.get_ctx(), false),
+            )
+        }
+
+        /// Propagate `conseq`
+        ///
+        /// Equivalent to [`self.propagate(fixed, [], [], conseq)`](Self::propagate)
+        ///
+        /// panics if not called from a callback.
+        pub fn propagate_one(&self, fixed: &[&ast::Bool<'ctx>], conseq: &ast::Bool<'ctx>) -> bool {
+            self.propagate::<_, _, ast::Bool>(fixed.iter().copied(), [], [], conseq)
+        }
+
+        pub fn get_ctx(&self) -> &'ctx Context {
+            self.ctx
+        }
+
+        fn z3_ctx(&self) -> Z3_context {
+            self.get_ctx().z3_ctx
         }
     }
+
+    /// Declare a function to be propagated to all the [UserPropagator]s
+    pub fn declare_up_function<'ctx, S: Into<Symbol>>(
+        ctx: &'ctx Context,
+        name: S,
+        domain: &[&Sort<'ctx>],
+        range: &Sort<'ctx>,
+    ) -> FuncDecl<'ctx> {
+        assert!(domain.iter().all(|s| s.ctx.z3_ctx == ctx.z3_ctx));
+        assert_eq!(ctx.z3_ctx, range.ctx.z3_ctx);
+
+        let domain: Vec<_> = domain.iter().map(|s| s.z3_sort).collect();
+
+        unsafe {
+            FuncDecl::wrap(
+                ctx,
+                Z3_solver_propagate_declare(
+                    ctx.z3_ctx,
+                    name.into().as_z3_symbol(ctx),
+                    domain.len().try_into().unwrap(),
+                    domain.as_ptr(),
+                    range.z3_sort,
+                ),
+            )
+        }
+    }
+
+    // =========================================================
+    // =============== implementation details ==================
+    // =========================================================
+
+    /// Turns `self` into a `void*` for FFI
+    fn get_user_context<'ctx, U: UserPropagator<'ctx>>(ptr: &U) -> *mut ::std::ffi::c_void {
+        ptr as *const _ as *mut ::std::ffi::c_void
+    }
+
+    /// Turns a `void*` into a `&mut Self`.
+    ///
+    /// This is highly unsafe! It panics if the pointer is `null`, no other checks are made!
+    unsafe fn mut_from_user_context<'ctx, 'b, U: UserPropagator<'ctx>>(
+        ptr: *mut ::std::ffi::c_void,
+    ) -> &'b mut U {
+        (ptr as *mut U).as_mut().unwrap()
+    }
+
+    // callbacks
+
+    pub(crate) extern "C" fn push_eh<'ctx, U: UserPropagator<'ctx>>(
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
+    ) {
+        debug!("push_eh");
+        let up = unsafe { mut_from_user_context::<U>(ctx) };
+        up.push(&CallBack::new(cb, up.get_context()));
+    }
+
+    pub(crate) extern "C" fn pop_eh<'ctx, U: UserPropagator<'ctx>>(
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
+        num_scopes: ::std::ffi::c_uint,
+    ) {
+        debug!("pop_eh");
+        let up = unsafe { mut_from_user_context::<U>(ctx) };
+        up.pop(&CallBack::new(cb, up.get_context()), num_scopes);
+    }
+
+    // TODO: figure out how to make this work
+    #[allow(unused_variables)]
+    pub(crate) extern "C" fn fresh_eh<'ctx, U: UserPropagator<'ctx>>(
+        ctx: *mut ::std::ffi::c_void,
+        new_context: Z3_context,
+    ) -> *mut ::std::ffi::c_void {
+        ::std::ptr::null_mut()
+    }
+
+    pub(crate) extern "C" fn fixed_eh<'ctx, U: UserPropagator<'ctx>>(
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
+        var: Z3_ast,
+        value: Z3_ast,
+    ) {
+        debug!("fixed_eh");
+        let up = unsafe { mut_from_user_context::<U>(ctx) };
+        let var = unsafe { Dynamic::wrap(up.get_context(), var) };
+        let value = unsafe { Dynamic::wrap(up.get_context(), value) };
+        up.fixed(&CallBack::new(cb, up.get_context()), &var, &value);
+    }
+
+    pub(crate) extern "C" fn eq_eh<'ctx, U: UserPropagator<'ctx>>(
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
+        x: Z3_ast,
+        y: Z3_ast,
+    ) {
+        debug!("eq_eh");
+        let up = unsafe { mut_from_user_context::<U>(ctx) };
+        let x = unsafe { Dynamic::wrap(up.get_context(), x) };
+        let y = unsafe { Dynamic::wrap(up.get_context(), y) };
+        up.eq(&CallBack::new(cb, up.get_context()), &x, &y);
+    }
+
+    pub(crate) extern "C" fn neq_eh<'ctx, U: UserPropagator<'ctx>>(
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
+        x: Z3_ast,
+        y: Z3_ast,
+    ) {
+        debug!("neq_eh");
+        let up = unsafe { mut_from_user_context::<U>(ctx) };
+        let x = unsafe { Dynamic::wrap(up.get_context(), x) };
+        let y = unsafe { Dynamic::wrap(up.get_context(), y) };
+        up.neq(&CallBack::new(cb, up.get_context()), &x, &y);
+    }
+
+    pub(crate) extern "C" fn final_eh<'ctx, U: UserPropagator<'ctx>>(
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
+    ) {
+        debug!("final_eh");
+        let up = unsafe { mut_from_user_context::<U>(ctx) };
+        up.final_(&CallBack::new(cb, up.get_context()));
+    }
+
+    pub(crate) extern "C" fn created_eh<'ctx, U: UserPropagator<'ctx>>(
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
+        e: Z3_ast,
+    ) {
+        debug!("created_eh");
+        let up = unsafe { mut_from_user_context::<U>(ctx) };
+        let e = unsafe { Dynamic::wrap(up.get_context(), e) };
+        up.created(&CallBack::new(cb, up.get_context()), &e);
+    }
+
+    pub(crate) extern "C" fn decide_eh<'ctx, U: UserPropagator<'ctx>>(
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
+        val: Z3_ast,
+        bit: ::std::ffi::c_uint,
+        is_pos: bool,
+    ) {
+        debug!("decide_eh");
+        let up = unsafe { mut_from_user_context::<U>(ctx) };
+        let val = unsafe { Dynamic::wrap(up.get_context(), val) };
+        up.decide(&CallBack::new(cb, up.get_context()), &val, bit, is_pos);
+    }
+
+    /// Does all the z3 calls to register a new [UserPropagator].
+    ///
+    /// At this point `z3_slv` effectively borrows `up`. I need
+    /// [super::UPSolver] to solver the liftetime problems, hence why to
+    /// function is `unsafe`.
+    pub(crate) unsafe fn z3_up_init<'ctx, U: UserPropagator<'ctx>>(up: Pin<&U>, z3_slv: Z3_solver) {
+        let z3_ctx = up.get_context().z3_ctx;
+        debug!("Z3_solver_propagate_init");
+        Z3_solver_propagate_init(
+            z3_ctx,
+            z3_slv,
+            get_user_context(up.get_ref()),
+            Some(push_eh::<U>),
+            Some(pop_eh::<U>),
+            Some(fresh_eh::<U>),
+        );
+        // we register all callbacks
+        // fixed
+        debug!("Z3_solver_propagate_fixed");
+        Z3_solver_propagate_fixed(z3_ctx, z3_slv, Some(fixed_eh::<U>));
+        // eq
+        debug!("Z3_solver_propagate_eq");
+        Z3_solver_propagate_eq(z3_ctx, z3_slv, Some(eq_eh::<U>));
+        // eq
+        debug!("Z3_solver_propagate_diseq");
+        Z3_solver_propagate_diseq(z3_ctx, z3_slv, Some(neq_eh::<U>));
+        // final
+        debug!("Z3_solver_propagate_final");
+        Z3_solver_propagate_final(z3_ctx, z3_slv, Some(final_eh::<U>));
+        // created
+        debug!("Z3_solver_propagate_created");
+        Z3_solver_propagate_created(z3_ctx, z3_slv, Some(created_eh::<U>));
+        // decide
+        debug!("Z3_solver_propagate_decide");
+        Z3_solver_propagate_decide(z3_ctx, z3_slv, Some(decide_eh::<U>));
+    }
 }
 
-impl CallBackTracker {
-    pub fn incr(&mut self, cb: Z3_solver_callback) {
-        self.cb = cb;
-        self.depth += 1;
-    }
+// mod on_clause {
+//     use crate::ast::{Ast, Dynamic};
+//     use log::debug;
+//     use std::fmt::Debug;
+//     use z3_sys::*;
 
-    pub fn decr(&mut self) {
-        self.depth -= 1;
-    }
+//     pub trait OnClause<'ctx>: Debug {
+//         fn on_clause(
+//             &self,
+//             proof_hints: &Dynamic<'ctx>,
+//             n: u32,
+//             deps: &[u32],
+//             litterals: &[&Dynamic<'ctx>],
+//         );
+//     }
 
-    pub fn is_null(&self) -> bool {
-        self.cb.is_null()
-    }
-}
+//     pub(crate) unsafe extern "C" fn clause_eh<'ctx, U: OnClause<'ctx>>(
+//         ctx: *mut ::std::ffi::c_void,
+//         proof_hint: Z3_ast,
+//         n: ::std::ffi::c_uint,
+//         deps: *const ::std::ffi::c_uint,
+//         literals: Z3_ast_vector,
+//     ) {
+//         let oc = (ptr as *mut U).as_mut().unwrap();
+//     }
+// }
+// pub use on_clause::OnClause;
 
+/// Wrapper around a solver to ensure the [UserPropagator]s live long enough
+///
+/// `'ctx` is the liftime of the [Context] and `'a` the commun liftime of the
+/// [UserPropagator]s
+///
+/// [Context]: crate::Context
 #[derive(Debug)]
 pub struct UPSolver<'ctx, 'a> {
     solver: Solver<'ctx>,
-    handles: Vec<Pin<Box<UPHandle<'ctx, 'a>>>>,
+    ups: PhantomData<Pin<&'a dyn UserPropagator<'ctx>>>,
+}
+
+impl<'ctx, 'a> UPSolver<'ctx, 'a> {
+    pub fn new(solver: Solver<'ctx>) -> Self {
+        Self {
+            solver,
+            ups: Default::default(),
+        }
+    }
+
+    pub fn solver(&self) -> &Solver<'ctx> {
+        &self.solver
+    }
+
+    /// Add an expression to be tracked by all [UserPropagator]s registered to this solver
+    pub fn add(&self, expr: &impl Ast<'ctx>) {
+        let z3_ctx = self.solver().get_context().z3_ctx;
+        let z3_slv = self.solver().z3_slv;
+        unsafe { Z3_solver_propagate_register(z3_ctx, z3_slv, expr.get_z3_ast()) }
+    }
+
+    /// Registers a [UserPropagator] to [Self::solver]
+    ///
+    /// We need `up` to be pined because it will be passed auround to z3. See
+    /// [std::pin] to get to know how to use [Pin].
+    pub fn register_user_propagator<U: UserPropagator<'ctx>>(&mut self, up: Pin<&'a U>) {
+        unsafe { user_propagator::z3_up_init(up, self.solver().z3_slv) }
+    }
+}
+
+impl<'ctx, 'a> From<Solver<'ctx>> for UPSolver<'ctx, 'a> {
+    fn from(solver: Solver<'ctx>) -> Self {
+        Self::new(solver)
+    }
 }
 
 impl<'ctx, 'a> std::ops::Deref for UPSolver<'ctx, 'a> {
@@ -110,471 +526,15 @@ impl<'ctx, 'a> std::ops::Deref for UPSolver<'ctx, 'a> {
     }
 }
 
-impl<'ctx, 'a> UPSolver<'ctx, 'a> {
-    pub fn new(solver: Solver<'ctx>) -> Self {
-        Self {
-            solver,
-            handles: vec![],
-        }
-    }
-
-    pub fn solver(&self) -> &Solver<'ctx> {
-        &self.solver
-    }
-
-    pub fn add(&self, expr: &impl Ast<'ctx>) {
-        let z3_ctx = self.solver().get_context().z3_ctx;
-        let z3_slv = self.solver().z3_slv;
-        unsafe { Z3_solver_propagate_register(z3_ctx, z3_slv, expr.get_z3_ast()) }
-    }
-
-    pub fn register_up<U: UserPropagator<'ctx>>(&mut self, up: &'a U) -> usize {
-        let up_handle = UPHandle::new(up, self.solver());
-        let i = self.handles.len();
-        self.handles.push(up_handle);
-        return i;
-    }
-
-    pub fn len(&self) -> usize {
-        self.handles.len()
-    }
-
-    pub fn get(&self, i: usize) -> &dyn UserPropagator<'ctx> {
-        self.handles[i].inner()
-    }
-}
-
-/// This is the handle passed around to z3.
-///
-/// It abstracts away the boiler plate state tracking that must be made. This is basically [`user_propagator_base`](https://z3prover.github.io/api/html/classz3_1_1user__propagator__base.html).
-///
-/// A few intersting points:
-/// - `'ctx` is the liftime of the [Context], `'a` is the lifetime of the [UserPropagator]
-/// - it registers **all** callbacks (by default they are no-ops)
-/// - it can only be created through a [UPSolver] (because of liftime constrains)
-/// - all callbacks to z3 are to be made through it you implementation of [UserPropagator]
-#[derive(Debug)]
-pub struct UPHandle<'ctx, 'a> {
-    /// using dynamic dyspach because I need to store the handles in [UPSolver]
-    inner: &'a dyn UserPropagator<'ctx>,
-    ctx: &'ctx Context,
-    cb: CallBackTracker,
-}
-
-impl<'ctx, 'a> UPHandle<'ctx, 'a> {
-    /// Builds a new [UPHandle]
-    pub(crate) fn new(up: &'a impl UserPropagator<'ctx>, solver: &Solver<'ctx>) -> Pin<Box<Self>> {
-        let upw = Box::pin(Self {
-            inner: up,
-            ctx: solver.get_context(),
-            // subcontexts: vec![],
-            cb: Default::default(),
-        });
-        upw.init_z3(solver);
-        upw
-    }
-
-    fn init_z3(&self, solver: &Solver<'ctx>) {
-        let z3_slv = solver.z3_slv;
-        unsafe {
-            debug!("Z3_solver_propagate_init");
-            Z3_solver_propagate_init(
-                self.context().get_z3_context(),
-                z3_slv,
-                self.get_user_context(),
-                Some(Self::push_eh),
-                Some(Self::pop_eh),
-                Some(Self::fresh_eh),
-            );
-        }
-        // we register all callbacks
-        unsafe {
-            // fixed
-            debug!("Z3_solver_propagate_fixed");
-            Z3_solver_propagate_fixed(self.z3_ctx(), z3_slv, Some(Self::fixed_eh));
-        }
-        unsafe {
-            // eq
-            debug!("Z3_solver_propagate_eq");
-            Z3_solver_propagate_eq(self.z3_ctx(), z3_slv, Some(Self::eq_eh));
-        }
-        unsafe {
-            // eq
-            debug!("Z3_solver_propagate_diseq");
-            Z3_solver_propagate_diseq(self.z3_ctx(), z3_slv, Some(Self::neq_eh));
-        }
-        unsafe {
-            // final
-            debug!("Z3_solver_propagate_final");
-            Z3_solver_propagate_final(self.z3_ctx(), z3_slv, Some(Self::final_eh));
-        }
-        unsafe {
-            // created
-            debug!("Z3_solver_propagate_created");
-            Z3_solver_propagate_created(self.z3_ctx(), z3_slv, Some(Self::created_eh));
-        }
-        unsafe {
-            // decide
-            debug!("Z3_solver_propagate_decide");
-            Z3_solver_propagate_decide(self.z3_ctx(), z3_slv, Some(Self::decide_eh));
-        }
-    }
-
-    // callbacks
-
-    extern "C" fn push_eh(ctx: *mut ::std::ffi::c_void, cb: Z3_solver_callback) {
-        debug!("push_eh");
-        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |s| {
-            s.inner();
-        });
-    }
-
-    extern "C" fn pop_eh(
-        ctx: *mut ::std::ffi::c_void,
-        cb: Z3_solver_callback,
-        num_scopes: ::std::ffi::c_uint,
-    ) {
-        debug!("pop_eh");
-        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |s| {
-            s.inner().pop(s, num_scopes);
-        });
-    }
-
-    // TODO: figure out how to make this work
-    #[allow(unused_variables)]
-    extern "C" fn fresh_eh(
-        ctx: *mut ::std::ffi::c_void,
-        new_context: Z3_context,
-    ) -> *mut ::std::ffi::c_void {
-        ::std::ptr::null_mut()
-    }
-
-    extern "C" fn fixed_eh(
-        ctx: *mut ::std::ffi::c_void,
-        cb: Z3_solver_callback,
-        var: Z3_ast,
-        value: Z3_ast,
-    ) {
-        debug!("fixed_eh");
-        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |upw| {
-            upw.inner()
-                .fixed(upw, &upw.mk_dynamic(var), &upw.mk_dynamic(value));
-        })
-    }
-
-    extern "C" fn eq_eh(
-        ctx: *mut ::std::ffi::c_void,
-        cb: Z3_solver_callback,
-        x: Z3_ast,
-        y: Z3_ast,
-    ) {
-        debug!("eq_eh");
-        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |upw| {
-            upw.inner().eq(upw, &upw.mk_dynamic(x), &upw.mk_dynamic(y));
-        })
-    }
-
-    extern "C" fn neq_eh(
-        ctx: *mut ::std::ffi::c_void,
-        cb: Z3_solver_callback,
-        x: Z3_ast,
-        y: Z3_ast,
-    ) {
-        debug!("neq_eh");
-        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |upw| {
-            upw.inner().neq(upw, &upw.mk_dynamic(x), &upw.mk_dynamic(y));
-        })
-    }
-
-    extern "C" fn final_eh(ctx: *mut ::std::ffi::c_void, cb: Z3_solver_callback) {
-        debug!("final_eh");
-        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |upw| {
-            upw.inner().final_(upw);
-        })
-    }
-
-    extern "C" fn created_eh(ctx: *mut ::std::ffi::c_void, cb: Z3_solver_callback, e: Z3_ast) {
-        debug!("created_eh");
-        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |upw| {
-            upw.inner().created(upw, &upw.mk_dynamic(e));
-        });
-    }
-
-    extern "C" fn decide_eh(
-        ctx: *mut ::std::ffi::c_void,
-        cb: Z3_solver_callback,
-        val: Z3_ast,
-        bit: ::std::ffi::c_uint,
-        is_pos: bool,
-    ) {
-        debug!("decide_eh");
-        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |upw| {
-            upw.inner().decide(upw, &upw.mk_dynamic(val), bit, is_pos);
-        })
-    }
-    // private usefull stuff
-
-    fn z3_ctx(&self) -> Z3_context {
-        self.context().z3_ctx
-    }
-
-    /// Wraps code to keep track of the current [Z3_solver_callback].
-    ///
-    /// Ideally the user calls the z3 functions from within `f`.
-    fn scoped_do<F, V>(&mut self, cb: Z3_solver_callback, f: F) -> V
-    where
-        F: for<'b> FnOnce(&'b mut Self) -> V,
-    {
-        self.cb.incr(cb);
-        let ret = f(self);
-        self.cb.decr();
-        ret
-    }
-
-    fn mk_dynamic(&self, z3_ast: Z3_ast) -> Dynamic<'ctx> {
-        unsafe { Dynamic::wrap(self.context(), z3_ast) }
-    }
-
-    /// dump `ptr` as hex assuming it has the layout of a [Self]. Usefull for debugging
-    #[allow(dead_code)]
-    unsafe fn dump_self(ptr: *mut Self) {
-        dbg!(ptr);
-        let l = std::alloc::Layout::new::<Self>();
-        let l = std::alloc::Layout::array::<u8>(l.size()).unwrap();
-        let ptr = NonNull::new(ptr).unwrap();
-        let ptr = ptr.cast::<u8>();
-        let ptr = NonNull::slice_from_raw_parts(ptr, l.size());
-        for b in ptr.as_ref() {
-            print!("{b:2x}")
-        }
-        println!("  done")
-    }
-
-    /// Turns `self` into a `void*` for FFI
-    fn get_user_context(&self) -> *mut ::std::ffi::c_void {
-        self as *const _ as *mut ::std::ffi::c_void
-    }
-
-    /// Turns a `void*` into a `&mut Self`.
-    ///
-    /// This is highly unsafe! It panics if the pointer is `null`, no other checks are made!
-    unsafe fn mut_from_user_context<'b>(ptr: *mut ::std::ffi::c_void) -> &'b mut Self {
-        (ptr as *mut Self).as_mut().unwrap()
-    }
-
-    /// returns [None] iff `self.cb.cb` is `null`
-    fn get_cb(&self) -> Option<Z3_solver_callback> {
-        if self.cb.is_null() {
-            None
-        } else {
-            Some(self.cb.cb)
-        }
-    }
-
-    // public API
-
-    pub fn context(&self) -> &'ctx Context {
-        &self.ctx
-    }
-
-    fn inner(&self) -> &'a dyn UserPropagator<'ctx> {
-        self.inner
-    }
-
-    /// Sets the next (registered) expression to split on. The function returns
-    /// false and ignores the given expression in case the expression is already
-    /// assigned internally (due to relevancy propagation, this assignments
-    /// might not have been reported yet by the fixed callback). In case the
-    /// function is called in the decide callback, it overrides the currently
-    /// selected variable and phase.
-    ///
-    /// panics if not called from a callback
-    ///
-    /// see [Z3_solver_next_split]
-    pub fn next_split(&self, expr: &ast::Bool<'ctx>, idx: u32, phase: Option<bool>) -> bool {
-        let cb = self.get_cb().expect("you're not in a callback!");
-        let phase = match phase {
-            Some(true) => Z3_L_TRUE,
-            Some(false) => Z3_L_FALSE,
-            None => Z3_L_UNDEF,
-        };
-        unsafe { Z3_solver_next_split(self.z3_ctx(), cb, expr.get_z3_ast(), idx, phase) }
-    }
-
-    /// Tracks `expr` with ([UserPropagator::fixed()] or [UserPropagator::eq()])
-    ///
-    /// If `expr` is a Boolean or Bit-vector, the [UserPropagator::fixed()]
-    /// callback gets invoked when `expr` is bound to a value.a Equalities
-    /// between registered expressions  are reported thought
-    /// [UserPropagator::eq()]. A consumer can use the [Self::propagate] or
-    /// [Self::conflict] functions to invoke propagations or conflicts as a
-    /// consequence of these callbacks. These functions take a list of
-    /// identifiers for registered expressions that have been fixed. The list of
-    /// identifiers must correspond to already fixed values. Similarly, a list
-    /// of propagated equalities can be supplied. These must correspond to
-    /// equalities that have been registered during a callback.
-    ///
-    /// see [Z3_solver_propagate_register_cb] and [Z3_solver_propagate_register]
-    pub fn add(&self, expr: &impl Ast<'ctx>) {
-        let cb = self
-            .get_cb()
-            .expect("you're not in a callback! Maybe you mean `UPSolver::add`");
-        unsafe { Z3_solver_propagate_register_cb(self.z3_ctx(), cb, expr.get_z3_ast()) };
-
-        // if let Some(cb) = self.get_cb() {
-        //     unsafe {
-        //         Z3_solver_propagate_register_cb(self.z3_ctx(), cb, expr.get_z3_ast());
-        //     }
-        // } else {
-        //     unsafe { Z3_solver_propagate_register(self.z3_ctx(), self.z3_slv(), expr.get_z3_ast()) }
-        // }
-    }
-
-    /// Propagate a consequence based on fixed values and equalities.
-    ///
-    /// A client may invoke it during the `propagate_fixed`, `propagate_eq`,
-    /// `propagate_diseq`, and `propagate_final` callbacks. The callback adds a
-    /// propagation consequence based on the fixed values passed ids and
-    /// equalities eqs based on parameters lhs, rhs.
-    ///
-    /// The solver might discard the propagation in case it is true in the
-    /// current state. The function returns false in this case; otw. the
-    /// function returns true. At least one propagation in the final callback
-    /// has to return true in order to prevent the solver from finishing.
-    ///
-    /// - `fixed`: iterator containing terms that are fixed in the current scope
-    /// - `lhs`: left side of equalities
-    /// - `rhs`: right side of equalities
-    /// - `conseq`: consequence to propagate. It is typically an atomic formula,
-    ///             but it can be an arbitrary formula.
-    ///
-    /// panics if not called from a callback or if `lhs` and `rhs` don't have the same
-    /// length.
-    ///
-    /// see [Z3_solver_propagate_consequence]
-    pub fn propagate<'b, I, J, A>(
-        &'b self,
-        fixed: I,
-        lhs: J,
-        rhs: J,
-        conseq: &'b ast::Bool<'ctx>,
-    ) -> bool
-    where
-        I: IntoIterator<Item = &'b ast::Bool<'ctx>>,
-        J: IntoIterator<Item = &'b A>,
-        A: Ast<'ctx> + 'b,
-    {
-        /* using generics because I need to map on the arguments anyway and it will turn
-        the other functions defined from `propagate` into the same things as the C++
-        API this is based on */
-        let cb = self.get_cb().expect("you're not in a callback!");
-        let fixed: Vec<_> = fixed.into_iter().map(|e| e.get_z3_ast()).collect();
-        let lhs: Vec<_> = lhs.into_iter().map(|e| e.get_z3_ast()).collect();
-        let rhs: Vec<_> = rhs.into_iter().map(|e| e.get_z3_ast()).collect();
-        let conseq = conseq.get_z3_ast();
-        assert_eq!(lhs.len(), rhs.len());
-
-        // not sure what the API does exactly, but it probably expects null pointers
-        // rather than dangling ones in case of empty vecs
-        let to_ptr = |v: Vec<_>| {
-            if v.is_empty() {
-                ::std::ptr::null()
-            } else {
-                v.as_ptr()
-            }
-        };
-
-        unsafe {
-            Z3_solver_propagate_consequence(
-                self.z3_ctx(),
-                cb,
-                fixed.len().try_into().unwrap(),
-                to_ptr(fixed),
-                lhs.len().try_into().unwrap(),
-                to_ptr(lhs),
-                to_ptr(rhs),
-                conseq,
-            )
-        }
-    }
-
-    /// triggers a confict on `fixed`
-    ///
-    /// Equivalent to [`self.propagate(fixed, [] , [], FALSE)`](Self::propagate)
-    ///
-    /// panics if not called from a callback.
-    pub fn conflict_on(&self, fixed: &[&ast::Bool<'ctx>]) -> bool {
-        self.propagate::<_, _, ast::Bool<'ctx>>(
-            fixed.iter().copied(),
-            [],
-            [],
-            &ast::Bool::from_bool(self.context(), false),
-        )
-    }
-
-    /// triggers a confict on `fixed` and `lhs == rhs`
-    ///
-    /// Equivalent to [`self.propagate(fixed, lhs, rhs, FALSE)`](Self::propagate)
-    ///
-    /// panics if not called from a callback or if `lhs` and `rhs` don't have the same
-    /// length.
-    pub fn conflict(
-        &self,
-        fixed: &[&ast::Bool<'ctx>],
-        lhs: &[&ast::Dynamic<'ctx>],
-        rhs: &[&ast::Dynamic<'ctx>],
-    ) -> bool {
-        self.propagate(
-            fixed.iter().copied(),
-            lhs.iter().copied(),
-            rhs.iter().copied(),
-            &ast::Bool::from_bool(self.context(), false),
-        )
-    }
-
-    /// Propagate `conseq`
-    ///
-    /// Equivalent to [`self.propagate(fixed, [], [], conseq)`](Self::propagate)
-    ///
-    /// panics if not called from a callback.
-    pub fn propagate_one(&self, fixed: &[&ast::Bool<'ctx>], conseq: &ast::Bool<'ctx>) -> bool {
-        self.propagate::<_, _, ast::Bool>(fixed.iter().copied(), [], [], conseq)
-    }
-}
-
-/// Declare a function to be propagated to all the [UserPropagator]s
-pub fn declare_up_function<'ctx, S: Into<Symbol>>(
-    ctx: &'ctx Context,
-    name: S,
-    domain: &[&Sort<'ctx>],
-    range: &Sort<'ctx>,
-) -> FuncDecl<'ctx> {
-    assert!(domain.iter().all(|s| s.ctx.z3_ctx == ctx.z3_ctx));
-    assert_eq!(ctx.z3_ctx, range.ctx.z3_ctx);
-
-    let domain: Vec<_> = domain.iter().map(|s| s.z3_sort).collect();
-
-    unsafe {
-        FuncDecl::wrap(
-            ctx,
-            Z3_solver_propagate_declare(
-                ctx.z3_ctx,
-                name.into().as_z3_symbol(ctx),
-                domain.len().try_into().unwrap(),
-                domain.as_ptr(),
-                range.z3_sort,
-            ),
-        )
-    }
-}
-
 #[cfg(test)]
 mod test {
     use std::convert::TryInto;
 
     use crate::{
         ast::{self, Ast, Dynamic},
-        user_propagator::{declare_up_function, UPHandle, UPSolver, UserPropagator},
+        user_propagator::{
+            declare_up_function, user_propagator::CallBack, UPSolver, UserPropagator,
+        },
         Config, Context, FuncDecl, SatResult, Solver, Sort,
     };
 
@@ -592,6 +552,7 @@ mod test {
         #[derive(Debug)]
         struct UP<'ctx> {
             pub f: &'ctx FuncDecl<'ctx>,
+            pub ctx: &'ctx Context,
         }
 
         impl<'ctx> UP<'ctx> {
@@ -610,7 +571,7 @@ mod test {
         }
 
         impl<'ctx> UserPropagator<'ctx> for UP<'ctx> {
-            fn eq(&self, upw: &UPHandle<'ctx, '_>, x: &Dynamic<'ctx>, y: &Dynamic<'ctx>) {
+            fn eq(&self, upw: &CallBack<'ctx>, x: &Dynamic<'ctx>, y: &Dynamic<'ctx>) {
                 println!("eq: {x} = {y}");
                 for e in [x, y] {
                     let Some(nt) = self.gen_nt(e) else {
@@ -620,7 +581,7 @@ mod test {
                 }
             }
 
-            fn neq(&self, upw: &UPHandle<'ctx, '_>, x: &Dynamic<'ctx>, y: &Dynamic<'ctx>) {
+            fn neq(&self, upw: &CallBack<'ctx>, x: &Dynamic<'ctx>, y: &Dynamic<'ctx>) {
                 println!("neq: {x} != {y}");
                 for e in [x, y] {
                     let Some(nt) = self.gen_nt(e) else {
@@ -630,45 +591,38 @@ mod test {
                 }
             }
 
-            fn created(&self, _: &UPHandle<'ctx, '_>, e: &ast::Dynamic<'ctx>) {
+            fn created(&self, _: &CallBack<'ctx>, e: &ast::Dynamic<'ctx>) {
                 println!("created: {e}")
             }
 
-            fn pop(&self, _: &UPHandle<'ctx, '_>, num_scopes: u32) {
+            fn pop(&self, _: &CallBack<'ctx>, num_scopes: u32) {
                 println!("pop: {num_scopes:}")
             }
 
-            fn push(&self, _: &UPHandle<'ctx, '_>) {
+            fn push(&self, _: &CallBack<'ctx>) {
                 println!("push")
             }
 
-            fn decide(
-                &self,
-                _: &UPHandle<'ctx, '_>,
-                val: &ast::Dynamic<'ctx>,
-                bit: u32,
-                is_pos: bool,
-            ) {
+            fn decide(&self, _: &CallBack<'ctx>, val: &ast::Dynamic<'ctx>, bit: u32, is_pos: bool) {
                 println!("decide: {val}, {bit:} {is_pos}")
             }
 
-            fn fixed(
-                &self,
-                _: &UPHandle<'ctx, '_>,
-                id: &ast::Dynamic<'ctx>,
-                e: &ast::Dynamic<'ctx>,
-            ) {
+            fn fixed(&self, _: &CallBack<'ctx>, id: &ast::Dynamic<'ctx>, e: &ast::Dynamic<'ctx>) {
                 println!("fixed: {id} {e}")
             }
 
-            fn final_(&self, _: &UPHandle<'ctx, '_>) {
+            fn final_(&self, _: &CallBack<'ctx>) {
                 println!("final")
+            }
+
+            fn get_context(&self) -> &'ctx Context {
+                self.ctx
             }
         }
 
         let mut s = UPSolver::new(s);
-        let up = UP { f: &f };
-        s.register_up(&up);
+        let up = Box::pin(UP { f: &f, ctx: &ctx });
+        s.register_user_propagator(up.as_ref());
         s.assert(
             &f.apply(&[&f.apply(&[&f.apply(&[&f.apply(&[&x])])])])
                 ._eq(&f.apply(&[&x]))

--- a/z3/src/user_propagator.rs
+++ b/z3/src/user_propagator.rs
@@ -1,0 +1,637 @@
+//! Z3's [User Propagator](https://microsoft.github.io/z3guide/programming/Example%20Programs/User%20Propagator/) API
+
+// I am following quite closly this: https://z3prover.github.io/api/html/classz3_1_1user__propagator__base.html
+
+use std::{convert::TryInto, fmt::Debug, pin::Pin, ptr::NonNull, rc::Rc, usize};
+
+use crate::{
+    ast::{self, Ast, Dynamic},
+    Context, FuncDecl, Solver, Sort, Symbol,
+};
+use log::debug;
+use z3_sys::*;
+
+#[allow(unused_variables)] // default implementation is a no-op, but variable names are usefull for documentation
+pub trait UserPropagator<'ctx>: Debug {
+    fn push(&self, upw: &UPHandle<'ctx>) {}
+    fn pop(&self, upw: &UPHandle<'ctx>, num_scopes: u32) {}
+    fn fixed(&self, upw: &UPHandle<'ctx>, id: &Dynamic<'ctx>, e: &Dynamic<'ctx>) {}
+    fn eq(&self, upw: &UPHandle<'ctx>, x: &Dynamic<'ctx>, y: &Dynamic<'ctx>) {}
+    fn neq(&self, upw: &UPHandle<'ctx>, x: &Dynamic<'ctx>, y: &Dynamic<'ctx>) {}
+
+    /// During the final check stage, all propagations have been processed. This
+    /// is an opportunity for the user-propagator to delay some analysis that
+    /// could be expensive to perform incrementally. It is also an opportunity
+    /// for the propagator to implement branch and bound optimization.
+    fn final_(&self, upw: &UPHandle<'ctx>) {}
+    fn created(&self, upw: &UPHandle<'ctx>, e: &Dynamic<'ctx>) {}
+    fn decide(&self, upw: &UPHandle<'ctx>, val: &Dynamic<'ctx>, bit: u32, is_pos: bool) {}
+
+    // /// `self` is responsible for garbage collecting the sub-solver
+    // fn fresh<'a>(
+    //     upw: &'a UserPropagatorWrapper<'ctx>,
+    //     ctx: &'a Context,
+    // ) -> Option<&'a dyn UserPropagator<'a>> {
+    //     None
+    // }
+}
+
+#[derive(Debug)]
+struct CallBackTracker {
+    /// can be null
+    cb: Z3_solver_callback,
+    depth: usize,
+}
+
+impl Default for CallBackTracker {
+    fn default() -> Self {
+        Self {
+            cb: ::std::ptr::null_mut(),
+            depth: 0,
+        }
+    }
+}
+
+impl CallBackTracker {
+    pub fn incr(&mut self, cb: Z3_solver_callback) {
+        self.cb = cb;
+        self.depth += 1;
+    }
+
+    pub fn decr(&mut self) {
+        self.depth -= 1;
+    }
+
+    pub fn is_null(&self) -> bool {
+        self.cb.is_null()
+    }
+}
+
+#[derive(Debug)]
+pub struct UPSolver<'ctx> {
+    solver: Solver<'ctx>,
+    handles: Vec<Pin<Box<UPHandle<'ctx>>>>,
+}
+
+impl<'ctx> std::ops::Deref for UPSolver<'ctx> {
+    type Target = Solver<'ctx>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.solver
+    }
+}
+
+impl<'ctx> UPSolver<'ctx> {
+    pub fn new(solver: Solver<'ctx>) -> Self {
+        Self {
+            solver,
+            handles: vec![],
+        }
+    }
+
+    pub fn solver(&self) -> &Solver<'ctx> {
+        &self.solver
+    }
+
+    pub fn add(&self, expr: &impl Ast<'ctx>) {
+        let z3_ctx = self.solver().get_context().z3_ctx;
+        let z3_slv = self.solver().z3_slv;
+        unsafe { Z3_solver_propagate_register(z3_ctx, z3_slv, expr.get_z3_ast()) }
+    }
+
+    pub fn register_up<U: UserPropagator<'ctx> + 'ctx>(&mut self, up: U) -> usize {
+        let up_handle = UPHandle::new(up, self.solver());
+        let i = self.handles.len();
+        self.handles.push(up_handle);
+        return i;
+    }
+
+    pub fn len(&self) -> usize {
+        self.handles.len()
+    }
+
+    pub fn get(&self, i: usize) -> &dyn UserPropagator<'ctx> {
+        self.handles[i].inner()
+    }
+}
+
+impl<'ctx> UPSolver<'ctx> {}
+
+#[derive(Debug)]
+pub struct UPHandle<'s> {
+    inner: Box<dyn UserPropagator<'s> + 's>,
+    ctx: &'s Context,
+    cb: CallBackTracker,
+}
+
+impl<'s> UPHandle<'s> {
+    fn new(up: impl UserPropagator<'s> + 's, solver: &Solver<'s>) -> Pin<Box<Self>> {
+        let upw = Box::pin(Self {
+            inner: Box::new(up),
+            ctx: solver.get_context(),
+            // subcontexts: vec![],
+            cb: Default::default(),
+        });
+        upw.init_z3(solver);
+        upw
+    }
+
+    fn init_z3(&self, solver: &Solver<'s>) {
+        let z3_slv = solver.z3_slv;
+        unsafe {
+            debug!("Z3_solver_propagate_init");
+            Z3_solver_propagate_init(
+                self.context().get_z3_context(),
+                z3_slv,
+                self.get_user_context(),
+                Some(Self::push_eh),
+                Some(Self::pop_eh),
+                Some(Self::fresh_eh),
+            );
+        }
+        // we register all callbacks. They do nothing by default
+        unsafe {
+            // fixed
+            debug!("Z3_solver_propagate_fixed");
+            Z3_solver_propagate_fixed(self.z3_ctx(), z3_slv, Some(Self::fixed_eh));
+        }
+        unsafe {
+            // eq
+            debug!("Z3_solver_propagate_eq");
+            Z3_solver_propagate_eq(self.z3_ctx(), z3_slv, Some(Self::eq_eh));
+        }
+        unsafe {
+            // eq
+            debug!("Z3_solver_propagate_diseq");
+            Z3_solver_propagate_diseq(self.z3_ctx(), z3_slv, Some(Self::neq_eh));
+        }
+        unsafe {
+            // final
+            debug!("Z3_solver_propagate_final");
+            Z3_solver_propagate_final(self.z3_ctx(), z3_slv, Some(Self::final_eh));
+        }
+        unsafe {
+            // created
+            debug!("Z3_solver_propagate_created");
+            Z3_solver_propagate_created(self.z3_ctx(), z3_slv, Some(Self::created_eh));
+        }
+        unsafe {
+            // decide
+            debug!("Z3_solver_propagate_decide");
+            Z3_solver_propagate_decide(self.z3_ctx(), z3_slv, Some(Self::decide_eh));
+        }
+    }
+
+    // callbacks
+
+    extern "C" fn push_eh(ctx: *mut ::std::ffi::c_void, cb: Z3_solver_callback) {
+        debug!("push_eh");
+        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |s| {
+            s.inner();
+        });
+    }
+
+    extern "C" fn pop_eh(
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
+        num_scopes: ::std::ffi::c_uint,
+    ) {
+        debug!("pop_eh");
+        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |s| {
+            s.inner().pop(s, num_scopes);
+        });
+    }
+
+    #[allow(unused_variables)]
+    extern "C" fn fresh_eh(
+        ctx: *mut ::std::ffi::c_void,
+        new_context: Z3_context,
+    ) -> *mut ::std::ffi::c_void {
+        // debug!("fresh_eh");
+        // let mself = unsafe { Self::mut_from_user_context(ctx) }; // `ctx` should be a pointer to us
+        // Vec::push(
+        //     &mut mself.subcontexts,
+        //     Context {
+        //         z3_ctx: new_context,
+        //     },
+        // );
+        // let sub_ctx = mself.subcontexts.last().unwrap();
+        // let sub_up = U::fresh(mself, sub_ctx)
+        //     .map(|up| up.get_user_context())
+        //     .unwrap_or(::std::ptr::null_mut());
+        // sub_up
+        ::std::ptr::null_mut()
+    }
+
+    extern "C" fn fixed_eh(
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
+        var: Z3_ast,
+        value: Z3_ast,
+    ) {
+        debug!("fixed_eh");
+        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |upw| {
+            upw.inner()
+                .fixed(upw, &upw.mk_dynamic(var), &upw.mk_dynamic(value));
+        })
+    }
+
+    extern "C" fn eq_eh(
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
+        x: Z3_ast,
+        y: Z3_ast,
+    ) {
+        debug!("eq_eh");
+        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |upw| {
+            upw.inner().eq(upw, &upw.mk_dynamic(x), &upw.mk_dynamic(y));
+        })
+    }
+
+    extern "C" fn neq_eh(
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
+        x: Z3_ast,
+        y: Z3_ast,
+    ) {
+        debug!("neq_eh");
+        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |upw| {
+            upw.inner().neq(upw, &upw.mk_dynamic(x), &upw.mk_dynamic(y));
+        })
+    }
+
+    extern "C" fn final_eh(ctx: *mut ::std::ffi::c_void, cb: Z3_solver_callback) {
+        debug!("final_eh");
+        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |upw| {
+            upw.inner().final_(upw);
+        })
+    }
+
+    extern "C" fn created_eh(ctx: *mut ::std::ffi::c_void, cb: Z3_solver_callback, e: Z3_ast) {
+        debug!("created_eh");
+        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |upw| {
+            upw.inner().created(upw, &upw.mk_dynamic(e));
+        });
+        debug!("exit created")
+    }
+
+    extern "C" fn decide_eh(
+        ctx: *mut ::std::ffi::c_void,
+        cb: Z3_solver_callback,
+        val: Z3_ast,
+        bit: ::std::ffi::c_uint,
+        is_pos: bool,
+    ) {
+        debug!("decide_eh");
+        unsafe { Self::mut_from_user_context(ctx) }.scoped_do(cb, |upw| {
+            upw.inner().decide(upw, &upw.mk_dynamic(val), bit, is_pos);
+        })
+    }
+    // private usefull stuff
+
+    fn z3_ctx(&self) -> Z3_context {
+        self.context().z3_ctx
+    }
+
+    fn scoped_do<F, V>(&mut self, cb: Z3_solver_callback, f: F) -> V
+    where
+        F: for<'a> FnOnce(&'a mut Self) -> V,
+    {
+        self.cb.incr(cb);
+        let ret = f(self);
+        self.cb.decr();
+        ret
+    }
+
+    fn mk_dynamic(&self, z3_ast: Z3_ast) -> Dynamic<'s> {
+        unsafe { Dynamic::wrap(self.context(), z3_ast) }
+    }
+
+    fn get_user_context(&self) -> *mut ::std::ffi::c_void {
+        self as *const _ as *mut ::std::ffi::c_void
+    }
+
+    unsafe fn dump_self(ptr: *mut Self) {
+        dbg!(ptr);
+        let l = std::alloc::Layout::new::<Self>();
+        let l = std::alloc::Layout::array::<u8>(l.size()).unwrap();
+        let ptr = NonNull::new(ptr).unwrap();
+        let ptr = ptr.cast::<u8>();
+        let ptr = NonNull::slice_from_raw_parts(ptr, l.size());
+        for b in ptr.as_ref() {
+            print!("{b:2x}")
+        }
+        println!("  done")
+    }
+
+    unsafe fn mut_from_user_context<'a>(ptr: *mut ::std::ffi::c_void) -> &'a mut Self {
+        (ptr as *mut Self).as_mut().unwrap()
+    }
+
+    /// returns [None] iff `self.cb.cb` is `null`
+    fn get_cb(&self) -> Option<Z3_solver_callback> {
+        if self.cb.is_null() {
+            None
+        } else {
+            Some(self.cb.cb)
+        }
+    }
+
+    // public API
+
+    pub fn context(&self) -> &'s Context {
+        &self.ctx
+    }
+
+    fn inner(&self) -> &dyn UserPropagator<'s> {
+        self.inner.as_ref()
+    }
+
+    /// Sets the next (registered) expression to split on. The function returns
+    /// false and ignores the given expression in case the expression is already
+    /// assigned internally (due to relevancy propagation, this assignments
+    /// might not have been reported yet by the fixed callback). In case the
+    /// function is called in the decide callback, it overrides the currently
+    /// selected variable and phase.
+    ///
+    /// panics if not called from a callback
+    ///
+    /// see [Z3_solver_next_split]
+    pub fn next_split(&self, expr: &ast::Bool<'s>, idx: u32, phase: Option<bool>) -> bool {
+        let cb = self.get_cb().expect("you're not in a callback!");
+        let phase = match phase {
+            Some(true) => Z3_L_TRUE,
+            Some(false) => Z3_L_FALSE,
+            None => Z3_L_UNDEF,
+        };
+        unsafe { Z3_solver_next_split(self.z3_ctx(), cb, expr.get_z3_ast(), idx, phase) }
+    }
+
+    /// Tracks `expr` with ([UserPropagator::fixed()] or [UserPropagator::eq()])
+    ///
+    /// If `expr` is a Boolean or Bit-vector, the [UserPropagator::fixed()]
+    /// callback gets invoked when `expr` is bound to a value.a Equalities
+    /// between registered expressions  are reported thought
+    /// [UserPropagator::eq()]. A consumer can use the [Self::propagate] or
+    /// [Self::conflict] functions to invoke propagations or conflicts as a
+    /// consequence of these callbacks. These functions take a list of
+    /// identifiers for registered expressions that have been fixed. The list of
+    /// identifiers must correspond to already fixed values. Similarly, a list
+    /// of propagated equalities can be supplied. These must correspond to
+    /// equalities that have been registered during a callback.
+    ///
+    /// see [Z3_solver_propagate_register_cb] and [Z3_solver_propagate_register]
+    pub fn add(&self, expr: &impl Ast<'s>) {
+        let cb = self
+            .get_cb()
+            .expect("you're not in a callback! Maybe you mean `UPSolver::add`");
+        unsafe { Z3_solver_propagate_register_cb(self.z3_ctx(), cb, expr.get_z3_ast()) };
+
+        // if let Some(cb) = self.get_cb() {
+        //     unsafe {
+        //         Z3_solver_propagate_register_cb(self.z3_ctx(), cb, expr.get_z3_ast());
+        //     }
+        // } else {
+        //     unsafe { Z3_solver_propagate_register(self.z3_ctx(), self.z3_slv(), expr.get_z3_ast()) }
+        // }
+    }
+
+    /// Propagate a consequence based on fixed values and equalities.
+    ///
+    /// A client may invoke it during the `propagate_fixed`, `propagate_eq`,
+    /// `propagate_diseq`, and `propagate_final` callbacks. The callback adds a
+    /// propagation consequence based on the fixed values passed ids and
+    /// equalities eqs based on parameters lhs, rhs.
+    ///
+    /// The solver might discard the propagation in case it is true in the
+    /// current state. The function returns false in this case; otw. the
+    /// function returns true. At least one propagation in the final callback
+    /// has to return true in order to prevent the solver from finishing.
+    ///
+    /// - `fixed`: iterator containing terms that are fixed in the current scope
+    /// - `lhs`: left side of equalities
+    /// - `rhs`: right side of equalities
+    /// - `conseq`: consequence to propagate. It is typically an atomic formula,
+    ///             but it can be an arbitrary formula.
+    ///
+    /// panics if not called from a callback or if `lhs` and `rhs` don't have the same
+    /// length.
+    ///
+    /// see [Z3_solver_propagate_consequence]
+    pub fn propagate<'a, I, J, A>(
+        &'a self,
+        fixed: I,
+        lhs: J,
+        rhs: J,
+        conseq: &'a ast::Bool<'s>,
+    ) -> bool
+    where
+        I: IntoIterator<Item = &'a ast::Bool<'s>>,
+        J: IntoIterator<Item = &'a A>,
+        A: Ast<'s> + 'a,
+    {
+        /* using generics because I need to map on the arguments anyway and it will turn
+        the other functions defined from `propagate` into the same things as the C++
+        API this is based on */
+        let cb = self.get_cb().expect("you're not in a callback!");
+        let fixed: Vec<_> = fixed.into_iter().map(|e| e.get_z3_ast()).collect();
+        let lhs: Vec<_> = lhs.into_iter().map(|e| e.get_z3_ast()).collect();
+        let rhs: Vec<_> = rhs.into_iter().map(|e| e.get_z3_ast()).collect();
+        let conseq = conseq.get_z3_ast();
+        assert_eq!(lhs.len(), rhs.len());
+
+        // not sure what the API does exactly, but it probably expects null pointers
+        // rather than dangling ones in case of empty vecs
+        let to_ptr = |v: Vec<_>| {
+            if v.is_empty() {
+                ::std::ptr::null()
+            } else {
+                v.as_ptr()
+            }
+        };
+
+        unsafe {
+            Z3_solver_propagate_consequence(
+                self.z3_ctx(),
+                cb,
+                fixed.len().try_into().unwrap(),
+                to_ptr(fixed),
+                lhs.len().try_into().unwrap(),
+                to_ptr(lhs),
+                to_ptr(rhs),
+                conseq,
+            )
+        }
+    }
+
+    /// triggers a confict on `fixed`
+    ///
+    /// Equivalent to [`self.propagate(fixed, [] , [], FALSE)`](Self::propagate)
+    ///
+    /// panics if not called from a callback.
+    pub fn conflict_on(&self, fixed: &[&ast::Bool<'s>]) -> bool {
+        self.propagate::<_, _, ast::Bool<'s>>(
+            fixed.iter().copied(),
+            [],
+            [],
+            &ast::Bool::from_bool(self.context(), false),
+        )
+    }
+
+    /// triggers a confict on `fixed` and `lhs == rhs`
+    ///
+    /// Equivalent to [`self.propagate(fixed, lhs, rhs, FALSE)`](Self::propagate)
+    ///
+    /// panics if not called from a callback or if `lhs` and `rhs` don't have the same
+    /// length.
+    pub fn conflict(
+        &self,
+        fixed: &[&ast::Bool<'s>],
+        lhs: &[&ast::Dynamic<'s>],
+        rhs: &[&ast::Dynamic<'s>],
+    ) -> bool {
+        self.propagate(
+            fixed.iter().copied(),
+            lhs.iter().copied(),
+            rhs.iter().copied(),
+            &ast::Bool::from_bool(self.context(), false),
+        )
+    }
+
+    /// Propagate `conseq`
+    ///
+    /// Equivalent to [`self.propagate(fixed, [], [], conseq)`](Self::propagate)
+    ///
+    /// panics if not called from a callback.
+    pub fn propagate_one(&self, fixed: &[&ast::Bool<'s>], conseq: &ast::Bool<'s>) -> bool {
+        self.propagate::<_, _, ast::Bool>(fixed.iter().copied(), [], [], conseq)
+    }
+}
+
+/// Declare a function to be propagated to all the [UserPropagator]s
+pub fn declare_up_function<'s, S: Into<Symbol>>(
+    ctx: &'s Context,
+    name: S,
+    domain: &[&Sort<'s>],
+    range: &Sort<'s>,
+) -> FuncDecl<'s> {
+    assert!(domain.iter().all(|s| s.ctx.z3_ctx == ctx.z3_ctx));
+    assert_eq!(ctx.z3_ctx, range.ctx.z3_ctx);
+
+    let domain: Vec<_> = domain.iter().map(|s| s.z3_sort).collect();
+
+    unsafe {
+        FuncDecl::wrap(
+            ctx,
+            Z3_solver_propagate_declare(
+                ctx.z3_ctx,
+                name.into().as_z3_symbol(ctx),
+                domain.len().try_into().unwrap(),
+                domain.as_ptr(),
+                range.z3_sort,
+            ),
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryInto;
+
+    use log::debug;
+
+    use crate::{
+        ast::{self, Ast, Bool, Dynamic},
+        user_propagator::{declare_up_function, UPHandle, UPSolver, UserPropagator},
+        Config, Context, FuncDecl, SatResult, Solver, Sort,
+    };
+
+    #[test]
+    fn test_up() {
+        let _ = env_logger::try_init();
+        let mut cfg = Config::default();
+        cfg.set_model_generation(true);
+        let ctx = Context::new(&cfg);
+        let s_sort = Sort::uninterpreted(&ctx, "S".into());
+        let f = declare_up_function(&ctx, "f", &[&s_sort], &s_sort);
+        let x = FuncDecl::new(&ctx, "x", &[], &s_sort).apply(&[]);
+        let s = Solver::new(&ctx);
+
+        #[derive(Debug)]
+        struct UP<'ctx> {
+            pub f: &'ctx FuncDecl<'ctx>,
+        }
+
+        impl<'ctx> UP<'ctx> {
+            fn gen_nt(&self, e: &Dynamic<'ctx>) -> Option<Dynamic<'ctx>> {
+                let f1 = e.safe_decl().ok()?;
+                (f1.name() == self.f.name()).then_some(())?; // exits if f1 != f
+                let [arg1] = e.children().try_into().ok()?;
+                let f2 = e.safe_decl().ok()?;
+                (f2.name() == self.f.name()).then_some(())?;
+                let [arg2] = arg1.children().try_into().ok()?;
+
+                let nt = self.f.apply(&[&arg2]);
+                println!("propagating: {e} = {nt}");
+                Some(nt)
+            }
+        }
+
+        impl<'ctx> UserPropagator<'ctx> for UP<'ctx> {
+            fn eq(&self, upw: &UPHandle<'ctx>, x: &Dynamic<'ctx>, y: &Dynamic<'ctx>) {
+                println!("eq: {x} = {y}");
+                for e in [x, y] {
+                    let Some(nt) = self.gen_nt(e) else {
+                        continue;
+                    };
+                    upw.propagate_one(&[], &e._eq(&nt));
+                }
+            }
+
+            fn neq(&self, upw: &UPHandle<'ctx>, x: &Dynamic<'ctx>, y: &Dynamic<'ctx>) {
+                println!("neq: {x} != {y}");
+                for e in [x, y] {
+                    let Some(nt) = self.gen_nt(e) else {
+                        continue;
+                    };
+                    upw.propagate_one(&[], &e._eq(&nt));
+                }
+            }
+
+            fn created(&self, _: &UPHandle<'ctx>, e: &ast::Dynamic<'ctx>) {
+                println!("created: {e}")
+            }
+
+            fn pop(&self, _: &UPHandle<'ctx>, num_scopes: u32) {
+                println!("pop: {num_scopes:}")
+            }
+
+            fn push(&self, _: &UPHandle<'ctx>) {
+                println!("push")
+            }
+
+            fn decide(&self, _: &UPHandle<'ctx>, val: &ast::Dynamic<'ctx>, bit: u32, is_pos: bool) {
+                println!("decide: {val}, {bit:} {is_pos}")
+            }
+
+            fn fixed(&self, _: &UPHandle<'ctx>, id: &ast::Dynamic<'ctx>, e: &ast::Dynamic<'ctx>) {
+                println!("fixed: {id} {e}")
+            }
+
+            fn final_(&self, _: &UPHandle<'ctx>) {
+                println!("final")
+            }
+        }
+
+        // let u = UPHandle::new(UP { f: &f }, s);
+        // let s = u.solver();
+        let mut s = UPSolver::new(s);
+        s.register_up(UP { f: &f });
+        s.assert(
+            &f.apply(&[&f.apply(&[&f.apply(&[&f.apply(&[&x])])])])
+                ._eq(&f.apply(&[&x]))
+                .not(),
+        );
+        assert_eq!(s.check(), SatResult::Unsat);
+    }
+}


### PR DESCRIPTION
This adds bindings and an API for the user propagator and the `on_clause` callback.

I would consider this still experimental, as I'm not fully sure of what `z3` might do with my objects (e.g., weird lifetimes and thread safety).

This also closes #343 