### PR TITLE
Upgrade dependencies and z3 version

### DIFF
--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -20,8 +20,8 @@ bindgen = { version = "0.70", default-features = false, features = ["runtime"] }
 # Temporarily pinning cc to 1.1 as 1.2 and later use -fno-exceptions, which
 # breaks the z3 build. See https://github.com/prove-rs/z3.rs/issues/328
 cc = "~1.1"
-cmake = { version = "0.1.49", optional = true }
-pkg-config = "0.3.27"
+cmake = { version = "0.1.54", optional = true }
+pkg-config = "0.3.32"
 vcpkg = { version = "0.2.15", optional = true }
 
 [features]


### PR DESCRIPTION
This commit upgrades the `cmake` and `pkg-config` packages. Additionally, it upgrades the z3 submodule to the current version `z3-4.15.1`