### PR TITLE
feat: Use release-plz for painless releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,58 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'prove-rs' }}
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'prove-rs' }}
+    permissions:
+      pull-requests: write
+      contents: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -34,16 +34,3 @@ the meantime.
 
 The only other time to use `z3-sys` directly would be if you are writing your
 own custom high-level API for Z3, instead of using the `z3` crate.
-
-## Release Process
-
-1. Make a version bump commit
-    1. Bump version for the relevant crate in Cargo.toml
-    1. Update version in examples/READMEs
-1. Create a git tag for the commit
-    1. i.e. `git tag z3-v0.10.0`
-1. Push the changes
-    1. `git push`
-    1. `git push --tags`
-1. Publish on crates.io
-    1. `cargo publish`

--- a/z3-sys/README.md
+++ b/z3-sys/README.md
@@ -17,11 +17,10 @@ The API is fully documented with examples:
 
 This crate works with Cargo and is on
 [crates.io](https://crates.io/crates/z3-sys).
-Add it to your `Cargo.toml` like so:
+Add it to your project with `cargo add`:
 
-```toml
-[dependencies]
-z3-sys = "0.8"
+```bash 
+$ cargo add z3-sys
 ```
 
 ### Finding Z3 Libraries

--- a/z3/README.md
+++ b/z3/README.md
@@ -17,11 +17,10 @@ The API is fully documented with examples:
 
 This crate works with Cargo and is on
 [crates.io](https://crates.io/crates/z3).
-Add it to your `Cargo.toml` like so:
+Add it to your project with `cargo add`:
 
-```toml
-[dependencies]
-z3 = "0.12"
+```bash 
+$ cargo add z3
 ```
 
 ### Finding Z3 Libraries
@@ -43,14 +42,14 @@ This might look like:
 
 ```toml
 [dependencies]
-z3 = {version="0.12", features = ["bundled"]}
+z3 = {version="0", features = ["bundled"]}
 ```
 
 or:
 
 ```toml
 [dependencies]
-z3 = {version="0.12", features = ["vcpkg"]}
+z3 = {version="0", features = ["vcpkg"]}
 ```
 
 ## Support and Maintenance


### PR DESCRIPTION
See https://github.com/release-plz/release-plz for details.

TLDR is this allows for using github actions to automatically:

* Determine when/what semantic versioning updates are justified by changes to `master` and make a PR bumping every crate to its new version
* Make tags and github releases upon "release PR" acceptance
* Make crates.io releases upon "release PR" acceptance
* Maintain unmerged release PRs; maintainers are not pushed to make a release every `master` commit under this system

In this PR, I've run the `release-plz init` standard setup and done what I could on the github-side to configure this.

In order for this to actually work, some things need to be set up by @waywardmonkeys:

* I've configured `release-plz` to use "Trusted Publishing" on crates.io. See https://crates.io/docs/trusted-publishing for details. For this setup to work, some configuration needs to be done on the `z3-sys` and `z3` packages on crates.io (as outlined in that link). If you add me to the owners list, I can do this. Or, if you'd rather do it yourself, you can follow the instructions there (using `release-plz.yml` as the workflow file name)
* In accordance with the `release-plz` docs, I've made a request to provision a secret token (`secrets.RELEASE_PLZ_TOKEN`) in the `prove-rs` group capable of reading/writing PRs and reading/writing the repository (commits/tags). This is necessary for the automatic PR and tag creation. If you could approve it, that would be great.
* The Github Actions runs separately need permission to edit the repository (Step 1 here: https://release-plz.dev/docs/github/quickstart#1-change-github-actions-permissions). My permissions on the repository do not seem to be sufficient to see or edit this setting.

Once those three things are in place, if this is merged, making crates.io releases should be as easy as accepting the release PR whenever we feel it's necessary.

I ran a dry-run locally and it looks like for the current suite of changes it would make a bump to `z3.sys 0.8.2` and `z3 0.12.2`