### PR TITLE
chore: release

### DIFF
--- a/z3-sys/CHANGELOG.md
+++ b/z3-sys/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.8.2](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.8.1...z3-sys-v0.8.2) - 2025-07-10
+
+### Other
+
+- Update crate READMEs to use `cargo add` and update example to not require updating for every version change
+- upgrade packages and z3 version ([#349](https://github.com/prove-rs/z3.rs/pull/349))
+- Fix CI ([#329](https://github.com/prove-rs/z3.rs/pull/329))
+- Update bundled sources to Z3 4.13.3 ([#315](https://github.com/prove-rs/z3.rs/pull/315))
+- Expose sequence sort and AST ([#310](https://github.com/prove-rs/z3.rs/pull/310))
+- Update to bindgen 0.70 ([#312](https://github.com/prove-rs/z3.rs/pull/312))
+- Add some missing backticks to some comments.
+- Update Z3 to 4.13.2 and update emscripten to `latest` ([#309](https://github.com/prove-rs/z3.rs/pull/309))
+- Support for more regular expression operations ([#275](https://github.com/prove-rs/z3.rs/pull/275))
+- Fix windows debug builds ([#295](https://github.com/prove-rs/z3.rs/pull/295))
+- Update bundled Z3 to z3 4.13.0.
+- Improve markdown formatting.
+- Fix `doc_markdown` lint.
+- Update a test to be less specific.
+- Fix two typos.
+- Use `pkg-config` when using system libs.
+- Update `bindgen` from `0.68` to `0.69`.
+- Add more recent regular expression func bindings.
+- Bind `Z3_optimize_assert_and_track`.
+- Add doc comment to Z3_solver_get_unsat_core.
+- Add a warning when `static-link-z3` is used.
+- Rename `static-link-z3` to `bundled`.
+- Minor tweaks.
+- Update to bindgen 0.68 from 0.66
+- Link against C++ std lib.
+- Improve `Z3_fpa_*` intradoc linking.
+- Remove usage of `extern crate`.
+- Missing "See also" header.
+- Inline format args.
+- Add vcpkg support and corresponding CI. ([#251](https://github.com/prove-rs/z3.rs/pull/251))
+- Enable `doc_markdown` lint.

--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "z3-sys"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>"]
 build = "build.rs"
 edition = "2018"

--- a/z3/CHANGELOG.md
+++ b/z3/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.12.2](https://github.com/prove-rs/z3.rs/compare/z3-v0.12.1...z3-v0.12.2) - 2025-07-10
+
+### Added
+
+- atmost and atleast ([#320](https://github.com/prove-rs/z3.rs/pull/320))
+
+### Other
+
+- Update crate READMEs to use `cargo add` and update example to not require updating for every version change
+- Fix `mismatched_lifetime_syntaxes` lints ([#354](https://github.com/prove-rs/z3.rs/pull/354))
+- Fix some `clippy::uninlined_format_args` lints ([#353](https://github.com/prove-rs/z3.rs/pull/353))
+- Panic through rust if provided an invalid tactic str to prevent SIGSEGV ([#339](https://github.com/prove-rs/z3.rs/pull/339))
+- Add is_infinite, is_normal, is_subnormal, is_zero, is_nan to Float ([#336](https://github.com/prove-rs/z3.rs/pull/336))
+- Make `z3_ctx` `pub` ([#341](https://github.com/prove-rs/z3.rs/pull/341))
+- Fix CI ([#329](https://github.com/prove-rs/z3.rs/pull/329))
+- Add high-level binding for quantifier creation with additional attributes ([#326](https://github.com/prove-rs/z3.rs/pull/326))
+- Add bindings for seq.++ and seq.unit ([#323](https://github.com/prove-rs/z3.rs/pull/323))
+- Adjust lifetimes on `ModelIter` to make them more permissive ([#324](https://github.com/prove-rs/z3.rs/pull/324))
+- Add binding for FPA to IEEE-754 bit-vector ([#322](https://github.com/prove-rs/z3.rs/pull/322))
+- Add binding for str.substr ([#321](https://github.com/prove-rs/z3.rs/pull/321))
+- Add binding to get unit string at index ([#319](https://github.com/prove-rs/z3.rs/pull/319))
+- Add high-level binding for string length ([#318](https://github.com/prove-rs/z3.rs/pull/318))
+- Expose sequence sort and AST ([#310](https://github.com/prove-rs/z3.rs/pull/310))
+- Add high-level binding to create lambda consts ([#311](https://github.com/prove-rs/z3.rs/pull/311))
+- Support consequences API ([#302](https://github.com/prove-rs/z3.rs/pull/302)) ([#308](https://github.com/prove-rs/z3.rs/pull/308))
+- Real approx functions ([#304](https://github.com/prove-rs/z3.rs/pull/304))
+- Z3 Optimize: add `assert_and_track` and `get_unsat_core` ([#300](https://github.com/prove-rs/z3.rs/pull/300))
+- Support for more regular expression operations ([#275](https://github.com/prove-rs/z3.rs/pull/275))
+- Expose underlying Z3_context and Z3_sort ([#298](https://github.com/prove-rs/z3.rs/pull/298))
+- Expose Z3_get_version in the high-level interface
+- [deps] Bump env_logger to 0.11
+- add parameter configuration API
+- add new_const and fresh_const functions to Dynamic
+- fix array_range and array_domain lifetimes
+- Fix doc comment typo.
+- Implement += for Solver
+- Expose API to convert solver into SMT-LIB2 format ([#267](https://github.com/prove-rs/z3.rs/pull/267))
+- Add doc comment to Z3_solver_get_unsat_core.
+- Add a warning when `static-link-z3` is used.
+- Rename `static-link-z3` to `bundled`.
+- Fix `semicolon_if_nothing_returned` lints.
+- Fix lifetime on `Solver::get_assertions()` result.
+- Implement `ast::Float::as_f64`
+- Remove usage of `extern crate`.
+- Always use `num`, remove `arbitrary-size-numeral` feature.
+- Update to Rust edition 2018. Collapse some imports.
+- Inline format args.
+- Add vcpkg support and corresponding CI. ([#251](https://github.com/prove-rs/z3.rs/pull/251))
+- Enable `doc_markdown` lint.
+- Fix typo: "sufix" -> "suffix"
+- Add backticks around logic expression.
+- Add is_const_array
+- Have distinct take impl Borrow
+- Fix clippy::doc_markdown warnings.
+- Fix redundant_pattern_matching warning.
+- Add comment
+- Use Borrow in varop arrays
+- Check Kind for optimize maximize

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "z3"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>"]
 
 description = "High-level rust bindings for the Z3 SMT solver from Microsoft Research"


### PR DESCRIPTION



## 🤖 New release

* `z3-sys`: 0.8.1 -> 0.8.2 (✓ API compatible changes)
* `z3`: 0.12.1 -> 0.12.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `z3-sys`

<blockquote>

## [0.8.2](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.8.1...z3-sys-v0.8.2) - 2025-07-10

### Other

- Update crate READMEs to use `cargo add` and update example to not require updating for every version change
- upgrade packages and z3 version ([#349](https://github.com/prove-rs/z3.rs/pull/349))
- Fix CI ([#329](https://github.com/prove-rs/z3.rs/pull/329))
- Update bundled sources to Z3 4.13.3 ([#315](https://github.com/prove-rs/z3.rs/pull/315))
- Expose sequence sort and AST ([#310](https://github.com/prove-rs/z3.rs/pull/310))
- Update to bindgen 0.70 ([#312](https://github.com/prove-rs/z3.rs/pull/312))
- Add some missing backticks to some comments.
- Update Z3 to 4.13.2 and update emscripten to `latest` ([#309](https://github.com/prove-rs/z3.rs/pull/309))
- Support for more regular expression operations ([#275](https://github.com/prove-rs/z3.rs/pull/275))
- Fix windows debug builds ([#295](https://github.com/prove-rs/z3.rs/pull/295))
- Update bundled Z3 to z3 4.13.0.
- Improve markdown formatting.
- Fix `doc_markdown` lint.
- Update a test to be less specific.
- Fix two typos.
- Use `pkg-config` when using system libs.
- Update `bindgen` from `0.68` to `0.69`.
- Add more recent regular expression func bindings.
- Bind `Z3_optimize_assert_and_track`.
- Add doc comment to Z3_solver_get_unsat_core.
- Add a warning when `static-link-z3` is used.
- Rename `static-link-z3` to `bundled`.
- Minor tweaks.
- Update to bindgen 0.68 from 0.66
- Link against C++ std lib.
- Improve `Z3_fpa_*` intradoc linking.
- Remove usage of `extern crate`.
- Missing "See also" header.
- Inline format args.
- Add vcpkg support and corresponding CI. ([#251](https://github.com/prove-rs/z3.rs/pull/251))
- Enable `doc_markdown` lint.
</blockquote>

## `z3`

<blockquote>

## [0.12.2](https://github.com/prove-rs/z3.rs/compare/z3-v0.12.1...z3-v0.12.2) - 2025-07-10

### Added

- atmost and atleast ([#320](https://github.com/prove-rs/z3.rs/pull/320))

### Other

- Update crate READMEs to use `cargo add` and update example to not require updating for every version change
- Fix `mismatched_lifetime_syntaxes` lints ([#354](https://github.com/prove-rs/z3.rs/pull/354))
- Fix some `clippy::uninlined_format_args` lints ([#353](https://github.com/prove-rs/z3.rs/pull/353))
- Panic through rust if provided an invalid tactic str to prevent SIGSEGV ([#339](https://github.com/prove-rs/z3.rs/pull/339))
- Add is_infinite, is_normal, is_subnormal, is_zero, is_nan to Float ([#336](https://github.com/prove-rs/z3.rs/pull/336))
- Make `z3_ctx` `pub` ([#341](https://github.com/prove-rs/z3.rs/pull/341))
- Fix CI ([#329](https://github.com/prove-rs/z3.rs/pull/329))
- Add high-level binding for quantifier creation with additional attributes ([#326](https://github.com/prove-rs/z3.rs/pull/326))
- Add bindings for seq.++ and seq.unit ([#323](https://github.com/prove-rs/z3.rs/pull/323))
- Adjust lifetimes on `ModelIter` to make them more permissive ([#324](https://github.com/prove-rs/z3.rs/pull/324))
- Add binding for FPA to IEEE-754 bit-vector ([#322](https://github.com/prove-rs/z3.rs/pull/322))
- Add binding for str.substr ([#321](https://github.com/prove-rs/z3.rs/pull/321))
- Add binding to get unit string at index ([#319](https://github.com/prove-rs/z3.rs/pull/319))
- Add high-level binding for string length ([#318](https://github.com/prove-rs/z3.rs/pull/318))
- Expose sequence sort and AST ([#310](https://github.com/prove-rs/z3.rs/pull/310))
- Add high-level binding to create lambda consts ([#311](https://github.com/prove-rs/z3.rs/pull/311))
- Support consequences API ([#302](https://github.com/prove-rs/z3.rs/pull/302)) ([#308](https://github.com/prove-rs/z3.rs/pull/308))
- Real approx functions ([#304](https://github.com/prove-rs/z3.rs/pull/304))
- Z3 Optimize: add `assert_and_track` and `get_unsat_core` ([#300](https://github.com/prove-rs/z3.rs/pull/300))
- Support for more regular expression operations ([#275](https://github.com/prove-rs/z3.rs/pull/275))
- Expose underlying Z3_context and Z3_sort ([#298](https://github.com/prove-rs/z3.rs/pull/298))
- Expose Z3_get_version in the high-level interface
- [deps] Bump env_logger to 0.11
- add parameter configuration API
- add new_const and fresh_const functions to Dynamic
- fix array_range and array_domain lifetimes
- Fix doc comment typo.
- Implement += for Solver
- Expose API to convert solver into SMT-LIB2 format ([#267](https://github.com/prove-rs/z3.rs/pull/267))
- Add doc comment to Z3_solver_get_unsat_core.
- Add a warning when `static-link-z3` is used.
- Rename `static-link-z3` to `bundled`.
- Fix `semicolon_if_nothing_returned` lints.
- Fix lifetime on `Solver::get_assertions()` result.
- Implement `ast::Float::as_f64`
- Remove usage of `extern crate`.
- Always use `num`, remove `arbitrary-size-numeral` feature.
- Update to Rust edition 2018. Collapse some imports.
- Inline format args.
- Add vcpkg support and corresponding CI. ([#251](https://github.com/prove-rs/z3.rs/pull/251))
- Enable `doc_markdown` lint.
- Fix typo: "sufix" -> "suffix"
- Add backticks around logic expression.
- Add is_const_array
- Have distinct take impl Borrow
- Fix clippy::doc_markdown warnings.
- Fix redundant_pattern_matching warning.
- Add comment
- Use Borrow in varop arrays
- Check Kind for optimize maximize
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).