### PR TITLE
chore: release

### DIFF
--- a/z3-sys/CHANGELOG.md
+++ b/z3-sys/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.9.2...z3-sys-v0.9.3) - 2025-07-14
+
+### Fixed
+
+- narrow build flag impact of wasm fix ([#362](https://github.com/prove-rs/z3.rs/pull/362)) (by @toolCHAINZ) - #362
+
+### Other
+
+- github action updates and caching ([#368](https://github.com/prove-rs/z3.rs/pull/368)) (by @toolCHAINZ) - #368
+
+### Contributors
+
+* @toolCHAINZ
+
 ## [0.9.2](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.9.1...z3-sys-v0.9.2) - 2025-07-12
 
 ### Fixed

--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "z3-sys"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>"]
 build = "build.rs"
 edition = "2018"

--- a/z3/CHANGELOG.md
+++ b/z3/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2](https://github.com/prove-rs/z3.rs/compare/z3-v0.13.1...z3-v0.13.2) - 2025-07-14
+
+### Fixed
+
+- Make translate 'dst lifetime independent of 'ctx ([#365](https://github.com/prove-rs/z3.rs/pull/365)) (by @toolCHAINZ) - #365
+
+### Other
+
+- Better documentation of z3 installation options ([#364](https://github.com/prove-rs/z3.rs/pull/364)) (by @lmondada) - #364
+
+### Contributors
+
+* @toolCHAINZ
+* @lmondada
+
 ## [0.13.1](https://github.com/prove-rs/z3.rs/compare/z3-v0.13.0...z3-v0.13.1) - 2025-07-10
 
 ### Added

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "z3"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>"]
 
 description = "High-level rust bindings for the Z3 SMT solver from Microsoft Research"


### PR DESCRIPTION



## 🤖 New release

* `z3-sys`: 0.9.2 -> 0.9.3 (✓ API compatible changes)
* `z3`: 0.13.1 -> 0.13.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `z3-sys`

<blockquote>

## [0.9.3](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.9.2...z3-sys-v0.9.3) - 2025-07-14

### Fixed

- narrow build flag impact of wasm fix ([#362](https://github.com/prove-rs/z3.rs/pull/362)) (by @toolCHAINZ) - #362

### Other

- github action updates and caching ([#368](https://github.com/prove-rs/z3.rs/pull/368)) (by @toolCHAINZ) - #368

### Contributors

* @toolCHAINZ
</blockquote>

## `z3`

<blockquote>

## [0.13.2](https://github.com/prove-rs/z3.rs/compare/z3-v0.13.1...z3-v0.13.2) - 2025-07-14

### Fixed

- Make translate 'dst lifetime independent of 'ctx ([#365](https://github.com/prove-rs/z3.rs/pull/365)) (by @toolCHAINZ) - #365

### Other

- Better documentation of z3 installation options ([#364](https://github.com/prove-rs/z3.rs/pull/364)) (by @lmondada) - #364

### Contributors

* @toolCHAINZ
* @lmondada
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).