### PR TITLE
docs: Better documentation of z3 installation options

### DIFF
--- a/z3/README.md
+++ b/z3/README.md
@@ -27,26 +27,14 @@ $ cargo add z3
 
 **Note:** This library has a dependency on Z3.
 
-There are 3 ways for this crate to currently find Z3:
-
-* By default, it will look for a system-installed copy of Z3.
-  On Linux, this would be via the package manager. On macOS, this
-  might be via Homebrew (`brew install z3`).
-* Enabling the `bundled` feature will use `cmake` to build a
-  locally bundled copy of Z3. This copy is provided via a git
-  submodule within the repository.
-* Enabling the `vcpkg` feature will use `vcpkg` to build and
-  install a copy of Z3 which is then used.
-* Enabling the `gh-release` feature will download a pre-compiled
-  copy of Z3 from the GitHub release page for the current platform,
-  if available. You may specify the version of Z3 to download via the
-  `Z3_SYS_Z3_VERSION` environment variable.
+There are 4 ways for this crate to currently find Z3, controlled by the feature
+flags `bundled`, `vcpkg` and `gh-release`.
 
 This might look like:
 
 ```toml
 [dependencies]
-z3 = {version="0", features = ["bundled"]}
+z3 = {version="0", features = ["gh-release"]}
 ```
 
 or:
@@ -55,6 +43,49 @@ or:
 [dependencies]
 z3 = {version="0", features = ["vcpkg"]}
 ```
+
+#### 1. Default: System-installed Z3
+
+By default, cargo will look for a system-installed copy of Z3.
+On Linux, this would be via the package manager. On macOS, this
+might be via Homebrew (`brew install z3`).
+
+If installed with Homebrew, cargo may be unable to find the Z3 headers. In this
+case set the `Z3_SYS_Z3_HEADER` environment variable to your copy of the `z3.h`
+file. On Apple Silicon, this will typically be `/opt/homebrew/include/z3.h`:
+
+```bash
+Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h cargo build
+```
+
+You may further have to set `LIBRARY_PATH` to `/opt/homebrew/lib` for the linker
+to find the Z3 library. You can store these settings in the cargo configuration
+file `.cargo/config.toml` of your project as follows: 
+
+```toml
+[env]
+LIBRARY_PATH = "/opt/homebrew/lib"
+Z3_SYS_Z3_HEADER = "/opt/homebrew/include/z3.h"
+```
+
+
+#### 2. Bundled: Use a locally bundled copy of Z3
+
+Enabling the `bundled` feature will use `cmake` to build a
+locally bundled copy of Z3. This copy is provided via a git
+submodule within the repository.
+
+#### 3. VCPKG: Use a copy of Z3 installed via vcpkg
+
+Enabling the `vcpkg` feature will use `vcpkg` to build and
+install a copy of Z3 which is then used.
+
+#### 4. GitHub Release: Use a pre-compiled copy of Z3
+
+Enabling the `gh-release` feature will download a pre-compiled
+copy of Z3 from the GitHub release page for the current platform,
+if available. You may specify the version of Z3 to download via the
+`Z3_SYS_Z3_VERSION` environment variable.
 
 ## Support and Maintenance
 


### PR DESCRIPTION
Hi there!

I've noticed a typo in the main `z3` readme concerning installation options (it said there were 3 instead of 4 installation options). I've fixed that and taken the opportunity to expand the section a bit.

Thanks a lot for the recent flurry of work, it's great to see life in this project!