### PR TITLE
fix: Make translate 'dst lifetime independent of 'ctx

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -409,17 +409,6 @@ pub trait Ast<'ctx>: fmt::Debug {
             Ok(unsafe { FuncDecl::wrap(ctx, func_decl) })
         }
     }
-
-    fn translate<'src_ctx>(&'src_ctx self, dest: &'ctx Context) -> Self
-    where
-        Self: Sized,
-    {
-        unsafe {
-            Self::wrap(dest, {
-                Z3_translate(self.get_ctx().z3_ctx, self.get_z3_ast(), dest.z3_ctx)
-            })
-        }
-    }
 }
 
 macro_rules! impl_ast {
@@ -447,6 +436,16 @@ macro_rules! impl_ast {
 
             fn get_z3_ast(&self) -> Z3_ast {
                 self.z3_ast
+            }
+        }
+
+        impl<'ctx> $ast<'ctx> {
+            pub fn translate<'dst_ctx>(&self, dest: &'dst_ctx Context) -> $ast<'dst_ctx> {
+                unsafe {
+                    $ast::wrap(dest, {
+                        Z3_translate(self.get_ctx().z3_ctx, self.get_z3_ast(), dest.z3_ctx)
+                    })
+                }
             }
         }
 

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -297,6 +297,20 @@ fn test_solver_translate() {
 }
 
 #[test]
+fn test_solver_lifetimes() {
+    let cfg = Config::new();
+    let ctx1 = Context::new(&cfg);
+    let bv1;
+    {
+        let ctx2 = Context::new(&cfg);
+        let bv2 = BV::from_u64(&ctx2, 0, 8);
+        bv1 = bv2.translate(&ctx1);
+    }
+    // The actual test here is that this test even compiles.
+    assert_eq!(bv1.as_u64(), Some(0));
+}
+
+#[test]
 fn test_model_translate() {
     let cfg = Config::new();
     let source = Context::new(&cfg);

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -297,7 +297,7 @@ fn test_solver_translate() {
 }
 
 #[test]
-fn test_solver_lifetimes() {
+fn test_translate_lifetimes() {
     let cfg = Config::new();
     let ctx1 = Context::new(&cfg);
     let bv1;


### PR DESCRIPTION
Follow-up to #346 

The old definition of `translate` had a subtle bug in which the lifetime of the destination context was constrained to be at least as narrow as the source context (when they should be completely independent).

This is because `translate` was defined in `impl<'ctx> Ast<'ctx>`, so it could only refer to the implementing type as `Self`, which implicitly has a `'ctx` lifetime.

Correctly implementing this function requires that it returns the same concrete type, but with a different lifetime. This is fixed by moving the definition out of the `Ast` trait and into an `impl` block directly on the implementing type.