### PR TITLE
ci: github action updates and caching

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,15 +53,10 @@ jobs:
         source ./emsdk_env.sh
     - name: Install wasm32-unknown-emscripten target
       run: rustup target add wasm32-unknown-emscripten
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.9
     - name: Build z3-sys and z3 with bundled Z3
       run: |
         source ~/emsdk/emsdk_env.sh
         cargo build --target=wasm32-unknown-emscripten --features bundled -vv
-      env:
-        SCCACHE_GHA_ENABLED: "true"
-        RUSTC_WRAPPER: "sccache"
 
   build_with_bundled_z3:
     strategy:
@@ -90,6 +85,11 @@ jobs:
         if: matrix.os == 'windows-latest'
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+         path: "/sccache"
+         key: sccache-${{ runner.os }}-bundled-${{ hashFiles('**/Cargo.toml', '**/build.rs', 'z3-sys/z3/RELEASE_NOTES.md') }}
       - name: Test `z3-sys` and `z3` with bundled linked Z3
         run: cargo test --workspace --features bundled
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,15 +53,15 @@ jobs:
         source ./emsdk_env.sh
     - name: Install wasm32-unknown-emscripten target
       run: rustup target add wasm32-unknown-emscripten
-    - name: Cache target directory
-      uses: actions/cache@v4
-      with:
-          path: target
-          key: ${{ runner.os }}-wasm-bundled-${{ hashFiles('**/Cargo.toml', '**/build.rs', 'z3-sys/z3/RELEASE_NOTES.md') }}
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.9
     - name: Build z3-sys and z3 with bundled Z3
       run: |
         source ~/emsdk/emsdk_env.sh
         cargo build --target=wasm32-unknown-emscripten --features bundled -vv
+      env:
+        SCCACHE_GHA_ENABLED: "true"
+        RUSTC_WRAPPER: "sccache"
 
   build_with_bundled_z3:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,13 +88,13 @@ jobs:
       - name: Set LIBCLANG_PATH
         run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
         if: matrix.os == 'windows-latest'
-      - name: Cache target directory
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-bundled-${{ hashFiles('**/Cargo.toml', '**/build.rs', 'z3-sys/z3/RELEASE_NOTES.md') }}
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Test `z3-sys` and `z3` with bundled linked Z3
         run: cargo test --workspace --features bundled
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
 
   build_with_vcpkg_installed_z3:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,17 +85,13 @@ jobs:
         if: matrix.os == 'windows-latest'
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-         path: "/sccache"
-         key: sccache-${{ runner.os }}-bundled-${{ hashFiles('**/Cargo.toml', '**/build.rs', 'z3-sys/z3/RELEASE_NOTES.md') }}
       - name: Test `z3-sys` and `z3` with bundled linked Z3
         run: cargo test --workspace --features bundled
         env:
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: "sccache"
-
+          CMAKE_C_COMPILER_LAUNCHER: "sccache"
+          CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
   build_with_vcpkg_installed_z3:
     strategy:
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,11 @@ jobs:
         source ./emsdk_env.sh
     - name: Install wasm32-unknown-emscripten target
       run: rustup target add wasm32-unknown-emscripten
+    - name: Cache target directory
+      uses: actions/cache@v4
+      with:
+          path: target
+          key: ${{ runner.os }}-bundled-${{ hashFiles('**/Cargo.toml', '**/build.rs', 'z3-sys/z3/RELEASE_NOTES.md') }}
     - name: Build z3-sys and z3 with bundled Z3
       run: |
         source ~/emsdk/emsdk_env.sh
@@ -83,6 +88,11 @@ jobs:
       - name: Set LIBCLANG_PATH
         run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
         if: matrix.os == 'windows-latest'
+      - name: Cache target directory
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-bundled-${{ hashFiles('**/Cargo.toml', '**/build.rs', 'z3-sys/z3/RELEASE_NOTES.md') }}
       - name: Test `z3-sys` and `z3` with bundled linked Z3
         run: cargo test --workspace --features bundled
 
@@ -155,6 +165,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Cache target directory
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-gh-release-${{ hashFiles('**/Cargo.toml', '**/build.rs') }}
       - name: Test `z3-sys` and `z3` with gh-release linked Z3
         run: cargo test --workspace --features gh-release
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,8 +62,8 @@ jobs:
       env:
         SCCACHE_GHA_ENABLED: "true"
         RUSTC_WRAPPER: "sccache"
-        CMAKE_C_COMPILER: "sccache emcc"
-        CMAKE_CXX_COMPILER: "sccache em++"
+        _EM_CCACHE: "true"
+        EM_COMPILER_WRAPPER: "sccache"
 
   build_with_bundled_z3:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,9 +62,8 @@ jobs:
       env:
         SCCACHE_GHA_ENABLED: "true"
         RUSTC_WRAPPER: "sccache"
-        EM_COMPILER_WRAPPER: "sccache"
-        CMAKE_C_COMPILER_LAUNCHER: "sccache"
-        CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
+        CMAKE_C_COMPILER: "sccache emcc"
+        CMAKE_CXX_COMPILER: "sccache em++"
 
   build_with_bundled_z3:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/cache@v4
       with:
           path: target
-          key: ${{ runner.os }}-bundled-${{ hashFiles('**/Cargo.toml', '**/build.rs', 'z3-sys/z3/RELEASE_NOTES.md') }}
+          key: ${{ runner.os }}-wasm-bundled-${{ hashFiles('**/Cargo.toml', '**/build.rs', 'z3-sys/z3/RELEASE_NOTES.md') }}
     - name: Build z3-sys and z3 with bundled Z3
       run: |
         source ~/emsdk/emsdk_env.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,10 +53,17 @@ jobs:
         source ./emsdk_env.sh
     - name: Install wasm32-unknown-emscripten target
       run: rustup target add wasm32-unknown-emscripten
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.9
     - name: Build z3-sys and z3 with bundled Z3
       run: |
         source ~/emsdk/emsdk_env.sh
         cargo build --target=wasm32-unknown-emscripten --features bundled -vv
+      env:
+        SCCACHE_GHA_ENABLED: "true"
+        RUSTC_WRAPPER: "sccache"
+        CMAKE_C_COMPILER_LAUNCHER: "sccache"
+        CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
 
   build_with_bundled_z3:
     strategy:
@@ -92,6 +99,7 @@ jobs:
           RUSTC_WRAPPER: "sccache"
           CMAKE_C_COMPILER_LAUNCHER: "sccache"
           CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
+
   build_with_vcpkg_installed_z3:
     strategy:
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Build z3-sys and z3 with bundled Z3
       run: |
         source ~/emsdk/emsdk_env.sh
-        cargo build --target=wasm32-unknown-emscripten --features bundled
+        cargo build --target=wasm32-unknown-emscripten --features bundled -vv
 
   build_with_bundled_z3:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -165,11 +165,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Cache target directory
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-gh-release-${{ hashFiles('**/Cargo.toml', '**/build.rs') }}
       - name: Test `z3-sys` and `z3` with gh-release linked Z3
         run: cargo test --workspace --features gh-release
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,7 @@ jobs:
       run: cargo test --workspace
 
   build_on_wasm:
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -66,6 +67,7 @@ jobs:
         EM_COMPILER_WRAPPER: "sccache"
 
   build_with_bundled_z3:
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
         build: [linux, macos, windows]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,7 +118,7 @@ jobs:
         if: matrix.os == 'windows-latest'
       - run: echo  Instaling z3:${{ matrix.vcpkg_triplet }} on ${{ matrix.os }}.
       - name: vcpkg build z3
-        uses: johnwason/vcpkg-action@v6
+        uses: johnwason/vcpkg-action@v7
         id: vcpkg
         with:
           pkgs: z3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,7 @@ jobs:
       env:
         SCCACHE_GHA_ENABLED: "true"
         RUSTC_WRAPPER: "sccache"
+        EM_COMPILER_WRAPPER: "sccache"
         CMAKE_C_COMPILER_LAUNCHER: "sccache"
         CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Build z3-sys and z3 with bundled Z3
       run: |
         source ~/emsdk/emsdk_env.sh
-        cargo build --target=wasm32-unknown-emscripten --features bundled -vv
+        cargo build --target=wasm32-unknown-emscripten --features bundled
       env:
         SCCACHE_GHA_ENABLED: "true"
         RUSTC_WRAPPER: "sccache"

--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -16,9 +16,7 @@ homepage = "https://github.com/prove-rs/z3.rs"
 repository = "https://github.com/prove-rs/z3.rs.git"
 
 [build-dependencies]
-bindgen = { version = "0.70", default-features = false, features = ["runtime"] }
-# Temporarily pinning cc to 1.1 as 1.2 and later use -fno-exceptions, which
-# breaks the z3 build. See https://github.com/prove-rs/z3.rs/issues/328
+bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
 cmake = { version = "0.1.54", optional = true }
 zip-extract = { version = "0.4.0", optional = true }
 pkg-config = "0.3.32"


### PR DESCRIPTION
A couple CI changes to reduce the pain of development:

* `vcpkg` builds are updated to v7 of the `vcpkg` action, and are correctly cached now. They now run in a couple minutes instead of 40 minutes.
* Bundled builds on linux and macos use sccache and complete in 3 minutes instead of 7 and 15. Windows will take more work and still takes 40 minutes. I've been unable to get sccache to fully work with the emscripten build so far. Just caching the rust parts gets it down from 50 minutes to 38 minutes, but I suspect more is possible. However I'm not an expert in emscripten or sccache so it's probably not the best use of my time.
* Bundled builds (linux, macos, windows, wasm) only run on tags and on master now. Most contributions to this library are not ones that will break things at link time, so I think this is fine. In the future, we may want to refactor the CI into multiple actions, to allow manually triggering them on PRs (and/or conditionally enabling if a PR touches build.rs or bindgen stuff?).