### PR TITLE
ci: only run normal build and vcpkg on forks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -158,6 +158,7 @@ jobs:
       run: cargo clippy --workspace --all-targets
 
   build_with_gh_release_z3:
+    if: ${{ github.repository_owner == 'prove-rs' }}
     strategy:
       matrix:
         build: [linux, macos, windows]


### PR DESCRIPTION
After consideration, following conversation with @lmondada I think this is a good balance:

* All CI jobs get run on `master` and tags (40ish minutes due to caching issues on `wasm` and `windows`)
* Normal build, `gh-release`, `vcpkg` run on PRs inside this repository (3ish minutes)
* Normal build and `vcpkg` runs on forks. (3ish minutes)

Running `vcpkg` on forks is convenient because ubuntu tends to lag far behind on `z3` releases; having `vckpg` builds is a quick way to spot check whether a contribution is running into an actual build failure or whether it's an ubuntu packaging issue.

Almost contributions to `z3.rs` nowadays are in the higher interface and not `z3-sys` and so don't have link-time implications, so I think it's less vital to run those different build flavors on forks. Contributions that effect `build.rs`, `bindgen` or other build-y/link-y stuff can just be an exception we can deal with.