### PR TITLE
ci: only run normal build and vcpkg on forks (fix)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -158,7 +158,7 @@ jobs:
       run: cargo clippy --workspace --all-targets
 
   build_with_gh_release_z3:
-    if: ${{ github.repository_owner == 'prove-rs' }}
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
         build: [linux, macos, windows]


### PR DESCRIPTION
`github.repository_owner` did not work the way I thought