### PR TITLE
Add feature to use manually-built Z3 library

### DIFF
--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -28,6 +28,7 @@ vcpkg = { version = "0.2.15", optional = true }
 bundled = ["dep:cmake"] # Build Z3 via our bundled submodule.
 vcpkg = ["dep:vcpkg"] # Build Z3 via vcpkg.
 gh-release = ["dep:reqwest", "dep:serde_json", "dep:zip-extract"] # Download pre-compiled Z3 lib from GitHub release for supported platforms.
+manual = [] # Use Z3 built in advance manually
 
 # Legacy feature for short term compatibility
 static-link-z3 = ["bundled", "deprecated-static-link-z3"]

--- a/z3-sys/README.md
+++ b/z3-sys/README.md
@@ -27,7 +27,7 @@ $ cargo add z3-sys
 
 **Note:** This library has a dependency on Z3.
 
-There are 4 ways for this crate to currently find Z3:
+There are 5 ways for this crate to currently find Z3:
 
 * By default, it will look for a system-installed copy of Z3.
   On Linux, this would be via the package manager. On macOS, this
@@ -51,6 +51,9 @@ There are 4 ways for this crate to currently find Z3:
     provide it to the `READ_ONLY_GITHUB_TOKEN` environment variable. The
     `build.rs` step will automatically use this token (if present) to prevent
     throttling.
+* Enabling the `manual` feature requires user provide a pre-built Z3.
+  * Users should specify both `Z3_SYS_Z3_INCLUDE` and `Z3_SYS_Z3_LIB` environment
+  variables indicating the header search path and library search path to find Z3.
 
 **Note:** This crate requires a `z3.h` during build time.
 
@@ -63,6 +66,9 @@ There are 4 ways for this crate to currently find Z3:
 * Enabling the `vcpkg` or `gh-release` feature will cause the copy of
   `z3.h` provided by that version to be used. In this case, there is
   no override via the environment variable.
+* Enabling the `manual` feature will use the `z3.h` under `Z3_SYS_Z3_INCLUDE`
+  directory by default, and this could be overriden by `Z3_SYS_Z3_HEADER`
+  environment variable.
 
 ## Support and Maintenance
 

--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -53,7 +53,7 @@ fn main() {
                 println!("cargo:rustc-link-lib=static=z3");
             }
 
-            (z3_header, vec![PathBuf::from(include_dir)])
+            (z3_header, vec![include_dir])
         }
         _ => {
             let search_paths = if let Ok(lib) = pkg_config::Config::new().probe("z3") {

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -19,6 +19,7 @@ default = []
 bundled = ["z3-sys/bundled"]
 vcpkg = ["z3-sys/vcpkg"]
 gh-release = ["z3-sys/gh-release"]
+manual = ["z3-sys/manual"]
 
 # This is a legacy feature here for short term compatibility.
 static-link-z3 = ["z3-sys/bundled", "z3-sys/deprecated-static-link-z3"]

--- a/z3/README.md
+++ b/z3/README.md
@@ -27,8 +27,8 @@ $ cargo add z3
 
 **Note:** This library has a dependency on Z3.
 
-There are 4 ways for this crate to currently find Z3, controlled by the feature
-flags `bundled`, `vcpkg` and `gh-release`.
+There are 5 ways for this crate to currently find Z3, controlled by the feature
+flags `bundled`, `vcpkg`, `gh-release` and `manual`.
 
 This might look like:
 
@@ -58,13 +58,11 @@ file. On Apple Silicon, this will typically be `/opt/homebrew/include/z3.h`:
 Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h cargo build
 ```
 
-You may further have to set `LIBRARY_PATH` to `/opt/homebrew/lib` for the linker
-to find the Z3 library. You can store these settings in the cargo configuration
+You can store these settings in the cargo configuration
 file `.cargo/config.toml` of your project as follows: 
 
 ```toml
 [env]
-LIBRARY_PATH = "/opt/homebrew/lib"
 Z3_SYS_Z3_HEADER = "/opt/homebrew/include/z3.h"
 ```
 
@@ -86,6 +84,12 @@ Enabling the `gh-release` feature will download a pre-compiled
 copy of Z3 from the GitHub release page for the current platform,
 if available. You may specify the version of Z3 to download via the
 `Z3_SYS_Z3_VERSION` environment variable.
+
+#### 5. Manual: Use a user's manually pre-built Z3
+
+Enabling the `manual` feature will use user's pre-built Z3. User
+should provide the header search path and library search path
+via environment variable `Z3_SYS_Z3_INCLUDE` and `Z3_SYS_Z3_LIB`.
 
 ## Support and Maintenance
 


### PR DESCRIPTION
The `LIBRARY_PATH` environment variable mentioned in README has no effect. In fact, we could provide a manual feature for users to provide their own Z3 library for us to link to.