### PR TITLE
Bump to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["z3", "z3-sys"]
+resolver = "2"

--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -3,7 +3,7 @@ name = "z3-sys"
 version = "0.9.4"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>"]
 build = "build.rs"
-edition = "2021"
+edition = "2024"
 
 description = "Low-level bindings for the Z3 SMT solver from Microsoft Research"
 license = "MIT"

--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -3,7 +3,7 @@ name = "z3-sys"
 version = "0.9.4"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 description = "Low-level bindings for the Z3 SMT solver from Microsoft Research"
 license = "MIT"

--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -45,7 +45,9 @@ fn main() {
     };
 
     #[cfg(feature = "deprecated-static-link-z3")]
-    println!("cargo:warning=The 'static-link-z3' feature is deprecated. Please use the 'bundled' feature.");
+    println!(
+        "cargo:warning=The 'static-link-z3' feature is deprecated. Please use the 'bundled' feature."
+    );
 
     link_against_cxx_stdlib();
 
@@ -87,9 +89,9 @@ mod gh_release {
 
     use super::*;
     use reqwest::blocking::{Client, ClientBuilder};
-    use reqwest::header::{HeaderMap, AUTHORIZATION};
-    use zip::read::root_dir_common_filter;
+    use reqwest::header::{AUTHORIZATION, HeaderMap};
     use zip::ZipArchive;
+    use zip::read::root_dir_common_filter;
 
     pub(super) fn install_from_gh_release() -> String {
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -1578,7 +1578,7 @@ pub enum GoalPrec {
     UnderOver = generated::Z3_goal_prec::Z3_GOAL_UNDER_OVER as u32,
 }
 
-extern "C" {
+unsafe extern "C" {
     /// Set a global (or module) parameter.
     /// This setting is shared by all Z3 contexts.
     ///
@@ -2325,7 +2325,7 @@ extern "C" {
     ///
     /// NOTE: The number of arguments must be greater than zero.
     pub fn Z3_mk_or(c: Z3_context, num_args: ::std::os::raw::c_uint, args: *const Z3_ast)
-        -> Z3_ast;
+    -> Z3_ast;
 
     /// Create an AST node representing `args[0] + ... + args[num_args-1]`.
     ///
@@ -3011,7 +3011,7 @@ extern "C" {
     ///
     /// - [`Z3_mk_numeral`]
     pub fn Z3_mk_bv_numeral(c: Z3_context, sz: ::std::os::raw::c_uint, bits: *const bool)
-        -> Z3_ast;
+    -> Z3_ast;
 
     /// Create a sequence sort out of the sort for the elements.
     pub fn Z3_mk_seq_sort(c: Z3_context, s: Z3_sort) -> Z3_sort;
@@ -3144,7 +3144,7 @@ extern "C" {
     ///
     /// - `n > 0`
     pub fn Z3_mk_re_concat(c: Z3_context, n: ::std::os::raw::c_uint, args: *const Z3_ast)
-        -> Z3_ast;
+    -> Z3_ast;
 
     /// Create the range regular expression over two sequences of length 1.
     pub fn Z3_mk_re_range(c: Z3_context, lo: Z3_ast, hi: Z3_ast) -> Z3_ast;
@@ -5823,7 +5823,7 @@ extern "C" {
 
     /// Translate the AST vector `v` from context `s` into an AST vector in context `t`.
     pub fn Z3_ast_vector_translate(s: Z3_context, v: Z3_ast_vector, t: Z3_context)
-        -> Z3_ast_vector;
+    -> Z3_ast_vector;
 
     /// Convert AST vector into a string.
     pub fn Z3_ast_vector_to_string(c: Z3_context, v: Z3_ast_vector) -> Z3_string;
@@ -6494,7 +6494,7 @@ pub type Z3_fixedpoint_reduce_app_callback_fptr = ::std::option::Option<
         arg5: *mut Z3_ast,
     ),
 >;
-extern "C" {
+unsafe extern "C" {
     /// Initialize the context with a user-defined state.
     pub fn Z3_fixedpoint_init(c: Z3_context, d: Z3_fixedpoint, state: *mut ::std::os::raw::c_void);
 
@@ -6527,7 +6527,7 @@ pub type Z3_fixedpoint_predecessor_eh =
 pub type Z3_fixedpoint_unfold_eh =
     ::std::option::Option<unsafe extern "C" fn(state: *mut ::std::os::raw::c_void)>;
 
-extern "C" {
+unsafe extern "C" {
     /// Set export callback for lemmas.
     pub fn Z3_fixedpoint_add_callback(
         ctx: Z3_context,
@@ -6603,7 +6603,7 @@ extern "C" {
     ///
     /// - [`Z3_optimize_minimize`]
     pub fn Z3_optimize_maximize(c: Z3_context, o: Z3_optimize, t: Z3_ast)
-        -> ::std::os::raw::c_uint;
+    -> ::std::os::raw::c_uint;
 
     /// Add a minimization constraint.
     /// - `c`: - context
@@ -6614,7 +6614,7 @@ extern "C" {
     ///
     /// - [`Z3_optimize_maximize`]
     pub fn Z3_optimize_minimize(c: Z3_context, o: Z3_optimize, t: Z3_ast)
-        -> ::std::os::raw::c_uint;
+    -> ::std::os::raw::c_uint;
 
     /// Create a backtracking point.
     ///
@@ -8038,8 +8038,8 @@ extern "C" {
 
 #[cfg(not(windows))]
 #[link(name = "z3")]
-extern "C" {}
+unsafe extern "C" {}
 
 #[cfg(windows)]
 #[link(name = "libz3")]
-extern "C" {}
+unsafe extern "C" {}

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 documentation = "https://docs.rs/z3/"
 homepage = "https://github.com/prove-rs/z3.rs"
 repository = "https://github.com/prove-rs/z3.rs.git"
-edition = "2018"
+edition = "2021"
 
 
 [features]

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 documentation = "https://docs.rs/z3/"
 homepage = "https://github.com/prove-rs/z3.rs"
 repository = "https://github.com/prove-rs/z3.rs.git"
-edition = "2021"
+edition = "2024"
 
 
 [features]

--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -421,10 +421,12 @@ macro_rules! impl_ast {
                     z3_ast: {
                         debug!(
                             "new ast: id = {}, pointer = {:p}",
-                            Z3_get_ast_id(ctx.z3_ctx, ast),
+                            unsafe { Z3_get_ast_id(ctx.z3_ctx, ast) },
                             ast
                         );
-                        Z3_inc_ref(ctx.z3_ctx, ast);
+                        unsafe {
+                            Z3_inc_ref(ctx.z3_ctx, ast);
+                        }
                         ast
                     },
                 }

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -8,7 +8,9 @@ use crate::{Context, FuncDecl, Sort, Symbol, ast, ast::Ast};
 
 impl<'ctx> FuncDecl<'ctx> {
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_func_decl: Z3_func_decl) -> Self {
-        Z3_inc_ref(ctx.z3_ctx, Z3_func_decl_to_ast(ctx.z3_ctx, z3_func_decl));
+        unsafe {
+            Z3_inc_ref(ctx.z3_ctx, Z3_func_decl_to_ast(ctx.z3_ctx, z3_func_decl));
+        }
         Self { ctx, z3_func_decl }
     }
 

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use z3_sys::*;
 
-use crate::{ast, ast::Ast, Context, FuncDecl, Sort, Symbol};
+use crate::{Context, FuncDecl, Sort, Symbol, ast, ast::Ast};
 
 impl<'ctx> FuncDecl<'ctx> {
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_func_decl: Z3_func_decl) -> Self {

--- a/z3/src/func_entry.rs
+++ b/z3/src/func_entry.rs
@@ -9,7 +9,9 @@ use crate::{
 
 impl<'ctx> FuncEntry<'ctx> {
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_func_entry: Z3_func_entry) -> Self {
-        Z3_func_entry_inc_ref(ctx.z3_ctx, z3_func_entry);
+        unsafe {
+            Z3_func_entry_inc_ref(ctx.z3_ctx, z3_func_entry);
+        }
         Self { ctx, z3_func_entry }
     }
 

--- a/z3/src/func_entry.rs
+++ b/z3/src/func_entry.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use z3_sys::*;
 
 use crate::{
-    ast::{Ast, Dynamic},
     Context, FuncEntry,
+    ast::{Ast, Dynamic},
 };
 
 impl<'ctx> FuncEntry<'ctx> {

--- a/z3/src/func_interp.rs
+++ b/z3/src/func_interp.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use z3_sys::*;
 
 use crate::{
-    ast::{Ast, Dynamic},
     Context, FuncEntry, FuncInterp,
+    ast::{Ast, Dynamic},
 };
 
 impl<'ctx> FuncInterp<'ctx> {

--- a/z3/src/func_interp.rs
+++ b/z3/src/func_interp.rs
@@ -9,7 +9,9 @@ use crate::{
 
 impl<'ctx> FuncInterp<'ctx> {
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_func_interp: Z3_func_interp) -> Self {
-        Z3_func_interp_inc_ref(ctx.z3_ctx, z3_func_interp);
+        unsafe {
+            Z3_func_interp_inc_ref(ctx.z3_ctx, z3_func_interp);
+        }
 
         Self {
             ctx,

--- a/z3/src/goal.rs
+++ b/z3/src/goal.rs
@@ -16,7 +16,9 @@ impl Clone for Goal<'_> {
 
 impl<'ctx> Goal<'ctx> {
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_goal: Z3_goal) -> Goal<'ctx> {
-        Z3_goal_inc_ref(ctx.z3_ctx, z3_goal);
+        unsafe {
+            Z3_goal_inc_ref(ctx.z3_ctx, z3_goal);
+        }
         Goal { ctx, z3_goal }
     }
 

--- a/z3/src/goal.rs
+++ b/z3/src/goal.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use z3_sys::*;
 
-use crate::{ast, ast::Ast, Context, Goal};
+use crate::{Context, Goal, ast, ast::Ast};
 
 impl Clone for Goal<'_> {
     fn clone(&self) -> Self {

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -34,7 +34,7 @@ mod version;
 
 pub use crate::params::{get_global_param, reset_all_global_params, set_global_param};
 pub use crate::statistics::{StatisticsEntry, StatisticsValue};
-pub use crate::version::{full_version, version, Version};
+pub use crate::version::{Version, full_version, version};
 
 /// Configuration used to initialize [logical contexts](Context).
 ///

--- a/z3/src/model.rs
+++ b/z3/src/model.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use z3_sys::*;
 
-use crate::{ast::Ast, Context, FuncDecl, FuncInterp, Model, Optimize, Solver};
+use crate::{Context, FuncDecl, FuncInterp, Model, Optimize, Solver, ast::Ast};
 
 impl<'ctx> Model<'ctx> {
     unsafe fn wrap(ctx: &'ctx Context, z3_mdl: Z3_model) -> Model<'ctx> {
@@ -218,7 +218,7 @@ impl<'ctx> Iterator for ModelIter<'_, 'ctx> {
 
 #[test]
 fn test_unsat() {
-    use crate::{ast, Config, SatResult};
+    use crate::{Config, SatResult, ast};
     let cfg = Config::new();
     let ctx = Context::new(&cfg);
     let solver = Solver::new(&ctx);

--- a/z3/src/model.rs
+++ b/z3/src/model.rs
@@ -7,7 +7,9 @@ use crate::{Context, FuncDecl, FuncInterp, Model, Optimize, Solver, ast::Ast};
 
 impl<'ctx> Model<'ctx> {
     unsafe fn wrap(ctx: &'ctx Context, z3_mdl: Z3_model) -> Model<'ctx> {
-        Z3_model_inc_ref(ctx.z3_ctx, z3_mdl);
+        unsafe {
+            Z3_model_inc_ref(ctx.z3_ctx, z3_mdl);
+        }
         Model { ctx, z3_mdl }
     }
 

--- a/z3/src/ops.rs
+++ b/z3/src/ops.rs
@@ -3,7 +3,7 @@ use std::ops::{
     Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Sub, SubAssign,
 };
 
-use crate::ast::{Ast, Bool, Float, Int, Real, BV};
+use crate::ast::{Ast, BV, Bool, Float, Int, Real};
 
 macro_rules! mk_const_bv {
     ($constant:expr, $function:ident, $val:expr, $other:expr) => {

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -6,8 +6,8 @@ use std::fmt;
 use z3_sys::*;
 
 use crate::{
-    ast::{Ast, Bool, Dynamic},
     Context, Model, Optimize, Params, SatResult, Statistics, Symbol,
+    ast::{Ast, Bool, Dynamic},
 };
 
 use num::{

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -17,7 +17,9 @@ use num::{
 
 impl<'ctx> Optimize<'ctx> {
     unsafe fn wrap(ctx: &'ctx Context, z3_opt: Z3_optimize) -> Optimize<'ctx> {
-        Z3_optimize_inc_ref(ctx.z3_ctx, z3_opt);
+        unsafe {
+            Z3_optimize_inc_ref(ctx.z3_ctx, z3_opt);
+        }
         Optimize { ctx, z3_opt }
     }
 

--- a/z3/src/params.rs
+++ b/z3/src/params.rs
@@ -7,7 +7,9 @@ use crate::{Context, Params, Symbol};
 
 impl<'ctx> Params<'ctx> {
     unsafe fn wrap(ctx: &'ctx Context, z3_params: Z3_params) -> Params<'ctx> {
-        Z3_params_inc_ref(ctx.z3_ctx, z3_params);
+        unsafe {
+            Z3_params_inc_ref(ctx.z3_ctx, z3_params);
+        }
         Params { ctx, z3_params }
     }
 

--- a/z3/src/pattern.rs
+++ b/z3/src/pattern.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use z3_sys::*;
 
-use crate::{ast::Ast, Context, Pattern};
+use crate::{Context, Pattern, ast::Ast};
 
 impl<'ctx> Pattern<'ctx> {
     /// Create a pattern for quantifier instantiation.

--- a/z3/src/probe.rs
+++ b/z3/src/probe.rs
@@ -9,7 +9,9 @@ use crate::{Context, Goal, Probe};
 
 impl<'ctx> Probe<'ctx> {
     unsafe fn wrap(ctx: &'ctx Context, z3_probe: Z3_probe) -> Probe<'ctx> {
-        Z3_probe_inc_ref(ctx.z3_ctx, z3_probe);
+        unsafe {
+            Z3_probe_inc_ref(ctx.z3_ctx, z3_probe);
+        }
         Probe { ctx, z3_probe }
     }
 

--- a/z3/src/rec_func_decl.rs
+++ b/z3/src/rec_func_decl.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 
 use z3_sys::*;
 
-use crate::{ast, ast::Ast, Context, FuncDecl, RecFuncDecl, Sort, Symbol};
+use crate::{Context, FuncDecl, RecFuncDecl, Sort, Symbol, ast, ast::Ast};
 
 impl<'ctx> RecFuncDecl<'ctx> {
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_func_decl: Z3_func_decl) -> Self {

--- a/z3/src/rec_func_decl.rs
+++ b/z3/src/rec_func_decl.rs
@@ -9,7 +9,9 @@ use crate::{Context, FuncDecl, RecFuncDecl, Sort, Symbol, ast, ast::Ast};
 
 impl<'ctx> RecFuncDecl<'ctx> {
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_func_decl: Z3_func_decl) -> Self {
-        Z3_inc_ref(ctx.z3_ctx, Z3_func_decl_to_ast(ctx.z3_ctx, z3_func_decl));
+        unsafe {
+            Z3_inc_ref(ctx.z3_ctx, Z3_func_decl_to_ast(ctx.z3_ctx, z3_func_decl));
+        }
         Self { ctx, z3_func_decl }
     }
 

--- a/z3/src/solver.rs
+++ b/z3/src/solver.rs
@@ -6,7 +6,7 @@ use z3_sys::*;
 
 use std::ops::AddAssign;
 
-use crate::{ast, ast::Ast, Context, Model, Params, SatResult, Solver, Statistics, Symbol};
+use crate::{Context, Model, Params, SatResult, Solver, Statistics, Symbol, ast, ast::Ast};
 
 impl<'ctx> Solver<'ctx> {
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_slv: Z3_solver) -> Solver<'ctx> {

--- a/z3/src/solver.rs
+++ b/z3/src/solver.rs
@@ -10,7 +10,9 @@ use crate::{Context, Model, Params, SatResult, Solver, Statistics, Symbol, ast, 
 
 impl<'ctx> Solver<'ctx> {
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_slv: Z3_solver) -> Solver<'ctx> {
-        Z3_solver_inc_ref(ctx.z3_ctx, z3_slv);
+        unsafe {
+            Z3_solver_inc_ref(ctx.z3_ctx, z3_slv);
+        }
         Solver { ctx, z3_slv }
     }
 

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -8,7 +8,9 @@ use crate::{Context, FuncDecl, Sort, SortDiffers, Symbol};
 
 impl<'ctx> Sort<'ctx> {
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_sort: Z3_sort) -> Sort<'ctx> {
-        Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, z3_sort));
+        unsafe {
+            Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, z3_sort));
+        }
         Sort { ctx, z3_sort }
     }
 

--- a/z3/src/statistics.rs
+++ b/z3/src/statistics.rs
@@ -31,7 +31,9 @@ pub struct StatisticsEntry {
 impl<'ctx> Statistics<'ctx> {
     /// Wrap a raw [`Z3_stats`], managing refcounts.
     pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_stats: Z3_stats) -> Statistics<'ctx> {
-        Z3_stats_inc_ref(ctx.z3_ctx, z3_stats);
+        unsafe {
+            Z3_stats_inc_ref(ctx.z3_ctx, z3_stats);
+        }
         Statistics { ctx, z3_stats }
     }
 
@@ -41,14 +43,16 @@ impl<'ctx> Statistics<'ctx> {
     ///
     /// This assumes that `idx` is a valid index.
     unsafe fn value_at_idx(&self, idx: u32) -> StatisticsValue {
-        if Z3_stats_is_uint(self.ctx.z3_ctx, self.z3_stats, idx) {
-            StatisticsValue::UInt(Z3_stats_get_uint_value(self.ctx.z3_ctx, self.z3_stats, idx))
-        } else {
-            StatisticsValue::Double(Z3_stats_get_double_value(
-                self.ctx.z3_ctx,
-                self.z3_stats,
-                idx,
-            ))
+        unsafe {
+            if Z3_stats_is_uint(self.ctx.z3_ctx, self.z3_stats, idx) {
+                StatisticsValue::UInt(Z3_stats_get_uint_value(self.ctx.z3_ctx, self.z3_stats, idx))
+            } else {
+                StatisticsValue::Double(Z3_stats_get_double_value(
+                    self.ctx.z3_ctx,
+                    self.z3_stats,
+                    idx,
+                ))
+            }
         }
     }
 

--- a/z3/src/tactic.rs
+++ b/z3/src/tactic.rs
@@ -88,7 +88,7 @@ impl<'ctx> Tactic<'ctx> {
         unsafe {
             let tactic = Z3_mk_tactic(ctx.z3_ctx, tactic_name.as_ptr());
             if tactic.is_null() {
-                panic!("{} is an invalid tactic", name);
+                panic!("{name} is an invalid tactic");
             } else {
                 Self::wrap(ctx, tactic)
             }

--- a/z3/src/tactic.rs
+++ b/z3/src/tactic.rs
@@ -63,7 +63,9 @@ impl<'ctx> Tactic<'ctx> {
     }
 
     unsafe fn wrap(ctx: &'ctx Context, z3_tactic: Z3_tactic) -> Tactic<'ctx> {
-        Z3_tactic_inc_ref(ctx.z3_ctx, z3_tactic);
+        unsafe {
+            Z3_tactic_inc_ref(ctx.z3_ctx, z3_tactic);
+        }
         Tactic { ctx, z3_tactic }
     }
 

--- a/z3/src/tactic.rs
+++ b/z3/src/tactic.rs
@@ -12,7 +12,9 @@ use crate::{ApplyResult, Context, Goal, Params, Probe, Solver, Tactic};
 
 impl<'ctx> ApplyResult<'ctx> {
     unsafe fn wrap(ctx: &'ctx Context, z3_apply_result: Z3_apply_result) -> ApplyResult<'ctx> {
-        Z3_apply_result_inc_ref(ctx.z3_ctx, z3_apply_result);
+        unsafe {
+            Z3_apply_result_inc_ref(ctx.z3_ctx, z3_apply_result);
+        }
         ApplyResult {
             ctx,
             z3_apply_result,

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -2,7 +2,7 @@ use log::info;
 use std::convert::TryInto;
 use std::ops::Add;
 use std::time::Duration;
-use z3::ast::{atleast, atmost, Array, Ast, Bool, Int, BV};
+use z3::ast::{Array, Ast, BV, Bool, Int, atleast, atmost};
 use z3::*;
 
 use num::{bigint::BigInt, rational::BigRational};
@@ -1242,14 +1242,18 @@ fn test_dynamic_as_set() {
     let array_of_sets = ast::Array::new_const(&ctx, "array_of_sets", &Sort::int(&ctx), &set_sort);
     let array_of_arrays =
         ast::Array::new_const(&ctx, "array_of_arrays", &Sort::int(&ctx), &array_sort);
-    assert!(array_of_sets
-        .select(&ast::Int::from_u64(&ctx, 0))
-        .as_set()
-        .is_some());
-    assert!(array_of_arrays
-        .select(&ast::Int::from_u64(&ctx, 0))
-        .as_set()
-        .is_none());
+    assert!(
+        array_of_sets
+            .select(&ast::Int::from_u64(&ctx, 0))
+            .as_set()
+            .is_some()
+    );
+    assert!(
+        array_of_arrays
+            .select(&ast::Int::from_u64(&ctx, 0))
+            .as_set()
+            .is_none()
+    );
 }
 
 #[test]

--- a/z3/tests/ops.rs
+++ b/z3/tests/ops.rs
@@ -1,7 +1,6 @@
 use z3::{
-    ast,
-    ast::{Array, Ast, AstKind, Bool, Dynamic, Float, Int, Real, BV},
-    Config, Context, DeclKind, FuncDecl, SatResult, Solver, Sort,
+    Config, Context, DeclKind, FuncDecl, SatResult, Solver, Sort, ast,
+    ast::{Array, Ast, AstKind, BV, Bool, Dynamic, Float, Int, Real},
 };
 
 #[test]


### PR DESCRIPTION
See [this discussion](https://github.com/prove-rs/z3.rs/discussions/372#discussioncomment-13784382).

I was going to split the bump into two steps as @Pat-Lafon suggested, but I found out that bumping from 2018 to 2021 edition is so smooth that the only thing we need to do is add `resolver = 2` in the workspace `Cargo.toml`. So I think we can just make it one PR.

At least, now we have better fmt :)