### PR TITLE
Add binding for IEEE-754 bit-vector to FPA 

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1170,7 +1170,6 @@ impl<'ctx> Float<'ctx> {
         }
     }
 
-
     unop! {
         unary_abs(Z3_mk_fpa_abs, Self);
         unary_neg(Z3_mk_fpa_neg, Self);


### PR DESCRIPTION
This PR exposes the `Z3_mk_fpa_to_fp_bv()` API which is useful for interpreter memory model. 