### PR TITLE
chore: add unit tests for rounding modes

### DIFF
--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1987,3 +1987,41 @@ fn test_model_iter() {
         vec![ast::Dynamic::new_const(&ctx, "a", &Sort::int(&ctx))]
     );
 }
+
+#[test]
+fn test_round_towards_nearest_away() {
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+    let solver = Solver::new(&ctx);
+
+    let eps = f64::from_bits(0x3cb0000000000000);
+    let x = z3::ast::Float::from_f64(&ctx, 1.0);
+    let y = z3::ast::Float::from_f64(&ctx, 0.5 * eps);
+
+    let rtna = z3::ast::Float::round_towards_nearest_away(&ctx);
+    let res_rtna = rtna.add(&x, &y);
+
+    let expected = z3::ast::Float::from_f64(&ctx, 1.0000000000000002);
+    solver.assert(&res_rtna._eq(&expected));
+
+    assert_eq!(solver.check(), SatResult::Sat);
+}
+
+#[test]
+fn test_round_towards_nearest_even() {
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+    let solver = Solver::new(&ctx);
+
+    let eps = f64::from_bits(0x3cb0000000000000);
+    let x = z3::ast::Float::from_f64(&ctx, 1.0);
+    let y = z3::ast::Float::from_f64(&ctx, 0.5 * eps);
+
+    let rtne = z3::ast::Float::round_towards_nearest_even(&ctx);
+    let res_rtne = rtne.add(&x, &y);
+
+    let expected = z3::ast::Float::from_f64(&ctx, 1.0);
+    solver.assert(&res_rtne._eq(&expected));
+
+    assert_eq!(solver.check(), SatResult::Sat);
+}

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -2002,7 +2002,7 @@ fn test_round_towards_nearest_away() {
     let res_rtna = x.add_with_rounding_mode(y, &rtna);
 
     let expected = z3::ast::Float::from_f64(&ctx, 1.0000000000000002);
-    solver.assert(&res_rtna._eq(&expected));
+    solver.assert(res_rtna._eq(&expected));
 
     assert_eq!(solver.check(), SatResult::Sat);
 }
@@ -2021,7 +2021,7 @@ fn test_round_towards_nearest_even() {
     let res_rtne = x.add_with_rounding_mode(y, &rtne);
 
     let expected = z3::ast::Float::from_f64(&ctx, 1.0);
-    solver.assert(&res_rtne._eq(&expected));
+    solver.assert(res_rtne._eq(&expected));
 
     assert_eq!(solver.check(), SatResult::Sat);
 }

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1998,8 +1998,8 @@ fn test_round_towards_nearest_away() {
     let x = z3::ast::Float::from_f64(&ctx, 1.0);
     let y = z3::ast::Float::from_f64(&ctx, 0.5 * eps);
 
-    let rtna = z3::ast::Float::round_towards_nearest_away(&ctx);
-    let res_rtna = rtna.add(&x, &y);
+    let rtna = z3::ast::RoundingMode::round_nearest_ties_to_away(&ctx);
+    let res_rtna = x.add_with_rounding_mode(y, &rtna);
 
     let expected = z3::ast::Float::from_f64(&ctx, 1.0000000000000002);
     solver.assert(&res_rtna._eq(&expected));
@@ -2017,8 +2017,8 @@ fn test_round_towards_nearest_even() {
     let x = z3::ast::Float::from_f64(&ctx, 1.0);
     let y = z3::ast::Float::from_f64(&ctx, 0.5 * eps);
 
-    let rtne = z3::ast::Float::round_towards_nearest_even(&ctx);
-    let res_rtne = rtne.add(&x, &y);
+    let rtne = z3::ast::RoundingMode::round_nearest_ties_to_even(&ctx);
+    let res_rtne = x.add_with_rounding_mode(y, &rtne);
 
     let expected = z3::ast::Float::from_f64(&ctx, 1.0);
     solver.assert(&res_rtne._eq(&expected));


### PR DESCRIPTION
## Rounding Modes

This PR adds constructors for two IEEE-754 rounding modes in the `Float<'ctx>` API.

- `round_towards_nearest_away(ctx: &Context) -> Float<'ctx>`  
  Creates a rounding mode corresponding to "round to nearest, ties away from zero".

- `round_towards_nearest_even(ctx: &Context) -> Float<'ctx>`  
  Creates a rounding mode corresponding to "round to nearest, ties to even".

These functions wrap the Z3 FFI:
- `Z3_mk_fpa_round_nearest_ties_to_away`
- `Z3_mk_fpa_round_nearest_ties_to_even`
