### PR TITLE
Fix Probe::lt to Receive Reference Argument

### DIFF
--- a/z3/src/probe.rs
+++ b/z3/src/probe.rs
@@ -84,7 +84,7 @@ impl<'ctx> Probe<'ctx> {
     /// by `self` is less than the value returned by `p`.
     ///
     /// NOTE: For probes, "true" is any value different from 0.0.
-    pub fn lt(&self, p: Probe) -> Probe<'ctx> {
+    pub fn lt(&self, p: &Probe) -> Probe<'ctx> {
         unsafe {
             Self::wrap(
                 self.ctx,


### PR DESCRIPTION
## Fix `Probe::lt` to Accept Reference Argument

This PR updates the `Probe::lt` method to take a reference to its argument instead of consuming it to make it consistent with other comparison operators of `Probe`.