### PR TITLE
Warn When Attempting to Set 'ctrl_c' via Config

### DIFF
--- a/z3/src/config.rs
+++ b/z3/src/config.rs
@@ -39,6 +39,12 @@ impl Config {
     ///
     /// - [`Config::set_bool_param_value()`]
     pub fn set_param_value(&mut self, k: &str, v: &str) {
+        if k == "ctrl_c" {
+            eprintln!(
+                "WARNING: Parameter 'ctrl_c' is global-only; use `z3::set_global_param` instead."
+            );
+            return;
+        }
         let ks = CString::new(k).unwrap();
         let vs = CString::new(v).unwrap();
         self.kvs.push((ks, vs));


### PR DESCRIPTION
When setting `cfg.set_param_value("ctrl_c", "true");` We receive the following message:

```
WARNING: unknown parameter 'ctrl_c'
Legal parameters are:
  auto_config (bool) (default: true)
  ctrl_c (bool) (default: true)
  debug_ref_count (bool) (default: false)
  dot_proof_file (string) (default: proof.dot)
  dump_models (bool) (default: false)
  encoding (string) (default: unicode)
  model (bool) (default: true)
  model_validate (bool) (default: false)
  proof (bool) (default: false)
  rlimit (unsigned int) (default: 0)
  smtlib2_compliant (bool) (default: false)
  stats (bool) (default: false)
  timeout (unsigned int) (default: 4294967295)
  trace (bool) (default: false)
  trace_file_name (string) (default: z3.log)
  type_check (bool) (default: true)
  unsat_core (bool) (default: false)
  well_sorted_check (bool) (default: false)
```

It says `unknown parameter 'ctrl_c'` and then continues with `Legal parameters are: ...ctrl_c...`. The parameter should be set using `z3::set_global_param("ctrl_c", "true");`. For the time being this temporary fix at least prevents the ocntradictory warning message.
