### PR TITLE
feat: add BV::from_bits 

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1359,10 +1359,9 @@ impl<'ctx> BV<'ctx> {
     /// # use z3::{ast::{Ast, BV}, Config, Context, Solver};
     /// # let cfg = Config::new();
     /// # let ctx = Context::new(&cfg);
-    /// # let solver = Solver::new(&ctx);
     /// // 0b00000010
     /// let bv = BV::from_bits(&ctx, &[false, true, false, false, false, false, false, false]);
-    /// solver.assert(&bv._eq(&BV::from_u64(&ctx, 2, 8)));
+    /// assert_eq!(bv, BV::from_u64(&ctx, 2, 8));
     /// ```
     pub fn from_bits(ctx: &'ctx Context, bits: &[bool]) -> BV<'ctx> {
         unsafe {

--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1353,6 +1353,17 @@ impl<'ctx> BV<'ctx> {
     }
 
     /// Create a BV from an array of bits.
+    ///
+    /// # Examples
+    /// ```
+    /// # use z3::{ast::{Ast, BV}, Config, Context, Solver};
+    /// # let cfg = Config::new();
+    /// # let ctx = Context::new(&cfg);
+    /// # let solver = Solver::new(&ctx);
+    /// // 0b00000010
+    /// let bv = BV::from_bits(&ctx, &[false, true, false, false, false, false, false, false]);
+    /// solver.assert(&bv._eq(&BV::from_u64(&ctx, 2, 8)));
+    /// ```
     pub fn from_bits(ctx: &'ctx Context, bits: &[bool]) -> BV<'ctx> {
         unsafe {
             Self::wrap(ctx, {

--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1352,6 +1352,15 @@ impl<'ctx> BV<'ctx> {
         Some(unsafe { Self::wrap(ctx, ast) })
     }
 
+    /// Create a BV from an array of bits.
+    pub fn from_bits(ctx: &'ctx Context, bits: &[bool]) -> BV<'ctx> {
+        unsafe {
+            Self::wrap(ctx, {
+                Z3_mk_bv_numeral(ctx.z3_ctx, bits.len() as u32, bits.as_ptr())
+            })
+        }
+    }
+
     pub fn new_const<S: Into<Symbol>>(ctx: &'ctx Context, name: S, sz: u32) -> BV<'ctx> {
         let sort = Sort::bitvector(ctx, sz);
         unsafe {


### PR DESCRIPTION
If we have a biginteger type, it is usually implemented as `Vec<u64>` internally. To create a `BV` from such instance, converting to string and then letting Z3 parse it is a bad style for me. The `from_bits` method can avoid such printing and parsing. 