### PR TITLE
fix: make BV::from_bits return Option

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1361,8 +1361,9 @@ impl<'ctx> BV<'ctx> {
     /// # let ctx = Context::new(&cfg);
     /// // 0b00000010
     /// let bv = BV::from_bits(&ctx, &[false, true, false, false, false, false, false, false]).unwrap();
+    /// let bv_none = BV::from_bits(&ctx, &[]);
     /// assert_eq!(bv, BV::from_u64(&ctx, 2, 8));
-    /// assert_eq!(None, BV::from_bits(&ctx, &[]));
+    /// assert_eq!(bv_none, None);
     /// ```
     pub fn from_bits(ctx: &'ctx Context, bits: &[bool]) -> Option<BV<'ctx>> {
         let ast = unsafe { Z3_mk_bv_numeral(ctx.z3_ctx, bits.len() as u32, bits.as_ptr()) };

--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -1360,14 +1360,16 @@ impl<'ctx> BV<'ctx> {
     /// # let cfg = Config::new();
     /// # let ctx = Context::new(&cfg);
     /// // 0b00000010
-    /// let bv = BV::from_bits(&ctx, &[false, true, false, false, false, false, false, false]);
+    /// let bv = BV::from_bits(&ctx, &[false, true, false, false, false, false, false, false]).unwrap();
     /// assert_eq!(bv, BV::from_u64(&ctx, 2, 8));
+    /// assert_eq!(None, BV::from_bits(&ctx, &[]));
     /// ```
-    pub fn from_bits(ctx: &'ctx Context, bits: &[bool]) -> BV<'ctx> {
-        unsafe {
-            Self::wrap(ctx, {
-                Z3_mk_bv_numeral(ctx.z3_ctx, bits.len() as u32, bits.as_ptr())
-            })
+    pub fn from_bits(ctx: &'ctx Context, bits: &[bool]) -> Option<BV<'ctx>> {
+        let ast = unsafe { Z3_mk_bv_numeral(ctx.z3_ctx, bits.len() as u32, bits.as_ptr()) };
+        if ast.is_null() {
+            None
+        } else {
+            Some(unsafe { Self::wrap(ctx, ast) })
         }
     }
 


### PR DESCRIPTION
Follow-up to @Evian-Zhang's #398.

Playing around with this API more, I found that `Z3_mk_bv_numeral` returns `null` if an empty bit slice is provided. Since this call does seem to be fallible, it's preferable to wrap this in `Option` like the  other fallible BV APIs (e.g. `from_str`).

