### PR TITLE
changed!: refcount z3 context

### DIFF
--- a/z3/src/ast.rs
+++ b/z3/src/ast.rs
@@ -16,69 +16,69 @@ use crate::{Context, FuncDecl, IsNotApp, Pattern, Sort, SortDiffers, Symbol};
 use num::{bigint::BigInt, rational::BigRational};
 
 /// [`Ast`] node representing a boolean value.
-pub struct Bool<'ctx> {
-    pub(crate) ctx: &'ctx Context,
+pub struct Bool {
+    pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
 }
 
 /// [`Ast`] node representing an integer value.
-pub struct Int<'ctx> {
-    pub(crate) ctx: &'ctx Context,
+pub struct Int {
+    pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
 }
 
 /// [`Ast`] node representing a real value.
-pub struct Real<'ctx> {
-    pub(crate) ctx: &'ctx Context,
+pub struct Real {
+    pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
 }
 
 /// [`Ast`] node representing a float value.
-pub struct Float<'ctx> {
-    pub(crate) ctx: &'ctx Context,
+pub struct Float {
+    pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
 }
 
 /// [`Ast`] node representing a string value.
-pub struct String<'ctx> {
-    pub(crate) ctx: &'ctx Context,
+pub struct String {
+    pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
 }
 
 /// [`Ast`] node representing a bitvector value.
-pub struct BV<'ctx> {
-    pub(crate) ctx: &'ctx Context,
+pub struct BV {
+    pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
 }
 
 /// [`Ast`] node representing an array value.
 /// An array in Z3 is a mapping from indices to values.
-pub struct Array<'ctx> {
-    pub(crate) ctx: &'ctx Context,
+pub struct Array {
+    pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
 }
 
 /// [`Ast`] node representing a set value.
-pub struct Set<'ctx> {
-    pub(crate) ctx: &'ctx Context,
+pub struct Set {
+    pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
 }
 
 /// [`Ast`] node representing a sequence value.
-pub struct Seq<'ctx> {
-    pub(crate) ctx: &'ctx Context,
+pub struct Seq {
+    pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
 }
 
 /// [`Ast`] node representing a datatype or enumeration value.
-pub struct Datatype<'ctx> {
-    pub(crate) ctx: &'ctx Context,
+pub struct Datatype {
+    pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
 }
 
 /// A dynamically typed [`Ast`] node.
-pub struct Dynamic<'ctx> {
-    pub(crate) ctx: &'ctx Context,
+pub struct Dynamic {
+    pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
 }
 
@@ -102,10 +102,10 @@ pub struct Dynamic<'ctx> {
 /// // intersection of a and b is non-empty
 /// let intersect = ast::Regexp::intersect(ctx, &[&a, &b]);
 /// solver.assert(&s.regex_matches(&intersect));
-/// assert!(solver.check() == SatResult::Sat);
+/// assert_eq!(solver.check(), SatResult::Sat);
 /// ```
-pub struct Regexp<'ctx> {
-    pub(crate) ctx: &'ctx Context,
+pub struct Regexp {
+    pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
 }
 
@@ -119,8 +119,8 @@ macro_rules! unop {
             $( #[ $attr ] )*
             pub fn $f(&self) -> $retty {
                 unsafe {
-                    <$retty>::wrap(self.ctx, {
-                        $z3fn(self.ctx.z3_ctx, self.z3_ast)
+                    <$retty>::wrap(&self.ctx, {
+                        $z3fn(self.ctx.z3_ctx.0, self.z3_ast)
                     })
                 }
             }
@@ -139,8 +139,8 @@ macro_rules! binop {
             pub fn $f(&self, other: &Self) -> $retty {
                 assert!(self.ctx == other.ctx);
                 unsafe {
-                    <$retty>::wrap(self.ctx, {
-                        $z3fn(self.ctx.z3_ctx, self.z3_ast, other.z3_ast)
+                    <$retty>::wrap(&self.ctx, {
+                        $z3fn(self.ctx.z3_ctx.0, self.z3_ast, other.z3_ast)
                     })
                 }
             }
@@ -159,8 +159,8 @@ macro_rules! trinop {
             pub fn $f(&self, a: &Self, b: &Self) -> $retty {
                 assert!((self.ctx == a.ctx) && (a.ctx == b.ctx));
                 unsafe {
-                    <$retty>::wrap(self.ctx, {
-                        $z3fn(self.ctx.z3_ctx, self.z3_ast, a.z3_ast, b.z3_ast)
+                    <$retty>::wrap(&self.ctx, {
+                        $z3fn(self.ctx.z3_ctx.0, self.z3_ast, a.z3_ast, b.z3_ast)
                     })
                 }
             }
@@ -176,13 +176,13 @@ macro_rules! varop {
     ) => {
         $(
             $( #[ $attr ] )*
-            pub fn $f(ctx: &'ctx Context, values: &[impl Borrow<Self>]) -> $retty {
+            pub fn $f(ctx: &Context, values: &[impl Borrow<Self>]) -> $retty {
                 assert!(values.iter().all(|v| v.borrow().get_ctx().z3_ctx == ctx.z3_ctx));
                 unsafe {
                     <$retty>::wrap(ctx, {
                         let tmp: Vec<_> = values.iter().map(|x| x.borrow().z3_ast).collect();
                         assert!(tmp.len() <= 0xffff_ffff);
-                        $z3fn(ctx.z3_ctx, tmp.len() as u32, tmp.as_ptr())
+                        $z3fn(ctx.z3_ctx.0, tmp.len() as u32, tmp.as_ptr())
                     })
                 }
             }
@@ -192,8 +192,8 @@ macro_rules! varop {
 
 /// Abstract syntax tree (AST) nodes represent terms, constants, or expressions.
 /// The `Ast` trait contains methods common to all AST subtypes.
-pub trait Ast<'ctx>: fmt::Debug {
-    fn get_ctx(&self) -> &'ctx Context;
+pub trait Ast: fmt::Debug {
+    fn get_ctx(&self) -> &Context;
     fn get_z3_ast(&self) -> Z3_ast;
 
     // This would be great, but gives error E0071 "expected struct, variant or union type, found Self"
@@ -201,13 +201,13 @@ pub trait Ast<'ctx>: fmt::Debug {
     // Instead we just require the method, and use the impl_ast! macro defined below to implement it
     // on each Ast subtype.
     /*
-    fn wrap(ctx: &'ctx Context, ast: Z3_ast) -> Self {
+    fn wrap(ctx: &Context, ast: Z3_ast) -> Self {
         assert!(!ast.is_null());
         Self {
             ctx,
             z3_ast: unsafe {
                 debug!("new ast {:p}", ast);
-                Z3_inc_ref(ctx.z3_ctx, ast);
+                Z3_inc_ref(ctx.z3_ctx.0, ast);
                 ast
             },
         }
@@ -218,7 +218,7 @@ pub trait Ast<'ctx>: fmt::Debug {
     /// # Safety
     ///
     /// The `ast` must be a valid pointer to a [`Z3_ast`].
-    unsafe fn wrap(ctx: &'ctx Context, ast: Z3_ast) -> Self
+    unsafe fn wrap(ctx: &Context, ast: Z3_ast) -> Self
     where
         Self: Sized;
 
@@ -229,7 +229,7 @@ pub trait Ast<'ctx>: fmt::Debug {
     /// `Ast`s being compared must be the same type.
     //
     // Note that we can't use the binop! macro because of the `pub` keyword on it
-    fn _eq(&self, other: &Self) -> Bool<'ctx>
+    fn _eq(&self, other: &Self) -> Bool
     where
         Self: Sized,
     {
@@ -238,7 +238,7 @@ pub trait Ast<'ctx>: fmt::Debug {
 
     /// Compare this `Ast` with another `Ast`, and get a Result.  Errors if the sort does not
     /// match for the two values.
-    fn _safe_eq(&self, other: &Self) -> Result<Bool<'ctx>, SortDiffers<'ctx>>
+    fn _safe_eq(&self, other: &Self) -> Result<Bool, SortDiffers>
     where
         Self: Sized,
     {
@@ -249,7 +249,7 @@ pub trait Ast<'ctx>: fmt::Debug {
         match left_sort == right_sort {
             true => Ok(unsafe {
                 Bool::wrap(self.get_ctx(), {
-                    Z3_mk_eq(self.get_ctx().z3_ctx, self.get_z3_ast(), other.get_z3_ast())
+                    Z3_mk_eq(self.get_ctx().z3_ctx.0, self.get_z3_ast(), other.get_z3_ast())
                 })
             }),
             false => Err(SortDiffers::new(left_sort, right_sort)),
@@ -263,7 +263,7 @@ pub trait Ast<'ctx>: fmt::Debug {
     /// `Ast`s being compared must all be the same type.
     //
     // Note that we can't use the varop! macro because of the `pub` keyword on it
-    fn distinct(ctx: &'ctx Context, values: &[impl Borrow<Self>]) -> Bool<'ctx>
+    fn distinct(ctx: &Context, values: &[impl Borrow<Self>]) -> Bool
     where
         Self: Sized,
     {
@@ -274,17 +274,17 @@ pub trait Ast<'ctx>: fmt::Debug {
                     .iter()
                     .map(|nodes| nodes.borrow().get_z3_ast())
                     .collect();
-                Z3_mk_distinct(ctx.z3_ctx, values.len() as u32, values.as_ptr())
+                Z3_mk_distinct(ctx.z3_ctx.0, values.len() as u32, values.as_ptr())
             })
         }
     }
 
     /// Get the [`Sort`] of the `Ast`.
-    fn get_sort(&self) -> Sort<'ctx> {
+    fn get_sort(&self) -> Sort {
         unsafe {
             Sort::wrap(
                 self.get_ctx(),
-                Z3_get_sort(self.get_ctx().z3_ctx, self.get_z3_ast()),
+                Z3_get_sort(self.get_ctx().z3_ctx.0, self.get_z3_ast()),
             )
         }
     }
@@ -298,14 +298,14 @@ pub trait Ast<'ctx>: fmt::Debug {
     {
         unsafe {
             Self::wrap(self.get_ctx(), {
-                Z3_simplify(self.get_ctx().z3_ctx, self.get_z3_ast())
+                Z3_simplify(self.get_ctx().z3_ctx.0, self.get_z3_ast())
             })
         }
     }
 
     /// Performs substitution on the `Ast`. The slice `substitutions` contains a
     /// list of pairs with a "from" `Ast` that will be substituted by a "to" `Ast`.
-    fn substitute<T: Ast<'ctx>>(&self, substitutions: &[(&T, &T)]) -> Self
+    fn substitute<T: Ast>(&self, substitutions: &[(&T, &T)]) -> Self
     where
         Self: Sized,
     {
@@ -322,7 +322,7 @@ pub trait Ast<'ctx>: fmt::Debug {
                 }
 
                 Z3_substitute(
-                    self.get_ctx().z3_ctx,
+                    self.get_ctx().z3_ctx.0,
                     this_ast,
                     num_exprs,
                     froms.as_ptr(),
@@ -336,7 +336,7 @@ pub trait Ast<'ctx>: fmt::Debug {
     ///
     /// Leaf nodes (eg `Bool` consts) will return 0.
     fn num_children(&self) -> usize {
-        let this_ctx = self.get_ctx().z3_ctx;
+        let this_ctx = self.get_ctx().z3_ctx.0;
         unsafe {
             let this_app = Z3_to_app(this_ctx, self.get_z3_ast());
             Z3_get_app_num_args(this_ctx, this_app) as usize
@@ -346,12 +346,12 @@ pub trait Ast<'ctx>: fmt::Debug {
     /// Return the `n`th child of this `Ast`.
     ///
     /// Out-of-bound indices will return `None`.
-    fn nth_child(&self, idx: usize) -> Option<Dynamic<'ctx>> {
+    fn nth_child(&self, idx: usize) -> Option<Dynamic> {
         if idx >= self.num_children() {
             None
         } else {
             let idx = u32::try_from(idx).unwrap();
-            let this_ctx = self.get_ctx().z3_ctx;
+            let this_ctx = self.get_ctx().z3_ctx.0;
             let child_ast = unsafe {
                 let this_app = Z3_to_app(this_ctx, self.get_z3_ast());
                 Z3_get_app_arg(this_ctx, this_app, idx)
@@ -361,7 +361,7 @@ pub trait Ast<'ctx>: fmt::Debug {
     }
 
     /// Return the children of this node as a `Vec<Dynamic>`.
-    fn children(&self) -> Vec<Dynamic<'ctx>> {
+    fn children(&self) -> Vec<Dynamic> {
         let n = self.num_children();
         (0..n).map(|i| self.nth_child(i).unwrap()).collect()
     }
@@ -369,7 +369,7 @@ pub trait Ast<'ctx>: fmt::Debug {
     /// Return the `AstKind` for this `Ast`.
     fn kind(&self) -> AstKind {
         unsafe {
-            let z3_ctx = self.get_ctx().z3_ctx;
+            let z3_ctx = self.get_ctx().z3_ctx.0;
             Z3_get_ast_kind(z3_ctx, self.get_z3_ast())
         }
     }
@@ -393,18 +393,18 @@ pub trait Ast<'ctx>: fmt::Debug {
     ///
     /// This will panic if the `Ast` is not an app, i.e. if [`AstKind`] is not
     /// [`AstKind::App`] or [`AstKind::Numeral`].
-    fn decl(&self) -> FuncDecl<'ctx> {
+    fn decl(&self) -> FuncDecl {
         self.safe_decl().expect("Ast is not an app")
     }
 
-    fn safe_decl(&self) -> Result<FuncDecl<'ctx>, IsNotApp> {
+    fn safe_decl(&self) -> Result<FuncDecl, IsNotApp> {
         if !self.is_app() {
             Err(IsNotApp::new(self.kind()))
         } else {
             let ctx = self.get_ctx();
             let func_decl = unsafe {
-                let app = Z3_to_app(ctx.z3_ctx, self.get_z3_ast());
-                Z3_get_app_decl(ctx.z3_ctx, app)
+                let app = Z3_to_app(ctx.z3_ctx.0, self.get_z3_ast());
+                Z3_get_app_decl(ctx.z3_ctx.0, app)
             };
             Ok(unsafe { FuncDecl::wrap(ctx, func_decl) })
         }
@@ -413,27 +413,27 @@ pub trait Ast<'ctx>: fmt::Debug {
 
 macro_rules! impl_ast {
     ($ast:ident) => {
-        impl<'ctx> Ast<'ctx> for $ast<'ctx> {
-            unsafe fn wrap(ctx: &'ctx Context, ast: Z3_ast) -> Self {
+        impl Ast for $ast {
+            unsafe fn wrap(ctx: &Context, ast: Z3_ast) -> Self {
                 assert!(!ast.is_null());
                 Self {
-                    ctx,
+                    ctx: ctx.clone(),
                     z3_ast: {
                         debug!(
                             "new ast: id = {}, pointer = {:p}",
-                            unsafe { Z3_get_ast_id(ctx.z3_ctx, ast) },
+                            unsafe { Z3_get_ast_id(ctx.z3_ctx.0, ast) },
                             ast
                         );
                         unsafe {
-                            Z3_inc_ref(ctx.z3_ctx, ast);
+                            Z3_inc_ref(ctx.z3_ctx.0, ast);
                         }
                         ast
                     },
                 }
             }
 
-            fn get_ctx(&self) -> &'ctx Context {
-                self.ctx
+            fn get_ctx(&self) -> &Context {
+                &self.ctx
             }
 
             fn get_z3_ast(&self) -> Z3_ast {
@@ -441,67 +441,67 @@ macro_rules! impl_ast {
             }
         }
 
-        impl<'ctx> $ast<'ctx> {
-            pub fn translate<'dst_ctx>(&self, dest: &'dst_ctx Context) -> $ast<'dst_ctx> {
+        impl $ast {
+            pub fn translate(&self, dest: &Context) -> $ast {
                 unsafe {
                     $ast::wrap(dest, {
-                        Z3_translate(self.get_ctx().z3_ctx, self.get_z3_ast(), dest.z3_ctx)
+                        Z3_translate(self.get_ctx().z3_ctx.0, self.get_z3_ast(), dest.z3_ctx.0)
                     })
                 }
             }
         }
 
-        impl<'ctx> From<$ast<'ctx>> for Z3_ast {
-            fn from(ast: $ast<'ctx>) -> Self {
+        impl From<$ast> for Z3_ast {
+            fn from(ast: $ast) -> Self {
                 ast.z3_ast
             }
         }
 
-        impl<'ctx> PartialEq for $ast<'ctx> {
-            fn eq(&self, other: &$ast<'ctx>) -> bool {
+        impl PartialEq for $ast {
+            fn eq(&self, other: &$ast) -> bool {
                 assert_eq!(self.ctx, other.ctx);
-                unsafe { Z3_is_eq_ast(self.ctx.z3_ctx, self.z3_ast, other.z3_ast) }
+                unsafe { Z3_is_eq_ast(self.ctx.z3_ctx.0, self.z3_ast, other.z3_ast) }
             }
         }
 
-        impl<'ctx> Eq for $ast<'ctx> {}
+        impl Eq for $ast {}
 
-        impl<'ctx> Clone for $ast<'ctx> {
+        impl Clone for $ast {
             fn clone(&self) -> Self {
                 debug!(
                     "clone ast: id = {}, pointer = {:p}",
-                    unsafe { Z3_get_ast_id(self.ctx.z3_ctx, self.z3_ast) },
+                    unsafe { Z3_get_ast_id(self.ctx.z3_ctx.0, self.z3_ast) },
                     self.z3_ast
                 );
-                unsafe { Self::wrap(self.ctx, self.z3_ast) }
+                unsafe { Self::wrap(&self.ctx, self.z3_ast) }
             }
         }
 
-        impl<'ctx> Drop for $ast<'ctx> {
+        impl Drop for $ast {
             fn drop(&mut self) {
                 debug!(
                     "drop ast: id = {}, pointer = {:p}",
-                    unsafe { Z3_get_ast_id(self.ctx.z3_ctx, self.z3_ast) },
+                    unsafe { Z3_get_ast_id(self.ctx.z3_ctx.0, self.z3_ast) },
                     self.z3_ast
                 );
                 unsafe {
-                    Z3_dec_ref(self.ctx.z3_ctx, self.z3_ast);
+                    Z3_dec_ref(self.ctx.z3_ctx.0, self.z3_ast);
                 }
             }
         }
 
-        impl<'ctx> Hash for $ast<'ctx> {
+        impl Hash for $ast {
             fn hash<H: Hasher>(&self, state: &mut H) {
                 unsafe {
-                    let u = Z3_get_ast_hash(self.ctx.z3_ctx, self.z3_ast);
+                    let u = Z3_get_ast_hash(self.ctx.z3_ctx.0, self.z3_ast);
                     u.hash(state);
                 }
             }
         }
 
-        impl<'ctx> fmt::Debug for $ast<'ctx> {
+        impl fmt::Debug for $ast {
             fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-                let p = unsafe { Z3_ast_to_string(self.ctx.z3_ctx, self.z3_ast) };
+                let p = unsafe { Z3_ast_to_string(self.ctx.z3_ctx.0, self.z3_ast) };
                 if p.is_null() {
                     return Result::Err(fmt::Error);
                 }
@@ -512,7 +512,7 @@ macro_rules! impl_ast {
             }
         }
 
-        impl<'ctx> fmt::Display for $ast<'ctx> {
+        impl fmt::Display for $ast {
             fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
                 <Self as fmt::Debug>::fmt(self, f)
             }
@@ -522,21 +522,21 @@ macro_rules! impl_ast {
 
 macro_rules! impl_from_try_into_dynamic {
     ($ast:ident, $as_ast:ident) => {
-        impl<'ctx> From<$ast<'ctx>> for Dynamic<'ctx> {
-            fn from(ast: $ast<'ctx>) -> Self {
-                unsafe { Dynamic::wrap(ast.ctx, ast.z3_ast) }
+        impl From<$ast> for Dynamic {
+            fn from(ast: $ast) -> Self {
+                unsafe { Dynamic::wrap(&ast.ctx, ast.z3_ast) }
             }
         }
 
-        impl<'ctx> From<&$ast<'ctx>> for Dynamic<'ctx> {
-            fn from(ast: &$ast<'ctx>) -> Self {
-                unsafe { Dynamic::wrap(ast.ctx, ast.z3_ast) }
+        impl From<&$ast> for Dynamic {
+            fn from(ast: &$ast) -> Self {
+                unsafe { Dynamic::wrap(&ast.ctx, ast.z3_ast) }
             }
         }
 
-        impl<'ctx> TryFrom<Dynamic<'ctx>> for $ast<'ctx> {
+        impl TryFrom<Dynamic> for $ast {
             type Error = std::string::String;
-            fn try_from(ast: Dynamic<'ctx>) -> Result<Self, std::string::String> {
+            fn try_from(ast: Dynamic) -> Result<Self, std::string::String> {
                 ast.$as_ast()
                     .ok_or_else(|| format!("Dynamic is not of requested type: {:?}", ast))
             }
@@ -564,16 +564,16 @@ impl_ast!(Seq);
 impl_from_try_into_dynamic!(Seq, as_seq);
 impl_ast!(Regexp);
 
-impl<'ctx> Int<'ctx> {
-    pub fn from_big_int(ctx: &'ctx Context, value: &BigInt) -> Int<'ctx> {
+impl Int {
+    pub fn from_big_int(ctx: &Context, value: &BigInt) -> Int {
         Int::from_str(ctx, &value.to_str_radix(10)).unwrap()
     }
 
-    pub fn from_str(ctx: &'ctx Context, value: &str) -> Option<Int<'ctx>> {
+    pub fn from_str(ctx: &Context, value: &str) -> Option<Int> {
         let sort = Sort::int(ctx);
         let ast = unsafe {
             let int_cstring = CString::new(value).unwrap();
-            let numeral_ptr = Z3_mk_numeral(ctx.z3_ctx, int_cstring.as_ptr(), sort.z3_sort);
+            let numeral_ptr = Z3_mk_numeral(ctx.z3_ctx.0, int_cstring.as_ptr(), sort.z3_sort);
             if numeral_ptr.is_null() {
                 return None;
             }
@@ -584,18 +584,18 @@ impl<'ctx> Int<'ctx> {
     }
 }
 
-impl<'ctx> Real<'ctx> {
-    pub fn from_big_rational(ctx: &'ctx Context, value: &BigRational) -> Real<'ctx> {
+impl Real {
+    pub fn from_big_rational(ctx: &Context, value: &BigRational) -> Real {
         let num = value.numer();
         let den = value.denom();
         Real::from_real_str(ctx, &num.to_str_radix(10), &den.to_str_radix(10)).unwrap()
     }
 
-    pub fn from_real_str(ctx: &'ctx Context, num: &str, den: &str) -> Option<Real<'ctx>> {
+    pub fn from_real_str(ctx: &Context, num: &str, den: &str) -> Option<Real> {
         let sort = Sort::real(ctx);
         let ast = unsafe {
             let fraction_cstring = CString::new(format!("{num:} / {den:}")).unwrap();
-            let numeral_ptr = Z3_mk_numeral(ctx.z3_ctx, fraction_cstring.as_ptr(), sort.z3_sort);
+            let numeral_ptr = Z3_mk_numeral(ctx.z3_ctx.0, fraction_cstring.as_ptr(), sort.z3_sort);
             if numeral_ptr.is_null() {
                 return None;
             }
@@ -606,29 +606,29 @@ impl<'ctx> Real<'ctx> {
     }
 }
 
-impl<'ctx> Float<'ctx> {
+impl Float {
     // Create a 32-bit (IEEE-754) Float [`Ast`] from a rust f32
-    pub fn from_f32(ctx: &'ctx Context, value: f32) -> Float<'ctx> {
+    pub fn from_f32(ctx: &Context, value: f32) -> Float {
         let sort = Sort::float32(ctx);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_fpa_numeral_float(ctx.z3_ctx, value, sort.z3_sort)
+                Z3_mk_fpa_numeral_float(ctx.z3_ctx.0, value, sort.z3_sort)
             })
         }
     }
 
     // Create a 364-bit (IEEE-754) Float [`Ast`] from a rust f64
-    pub fn from_f64(ctx: &'ctx Context, value: f64) -> Float<'ctx> {
+    pub fn from_f64(ctx: &Context, value: f64) -> Float {
         let sort = Sort::double(ctx);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_fpa_numeral_double(ctx.z3_ctx, value, sort.z3_sort)
+                Z3_mk_fpa_numeral_double(ctx.z3_ctx.0, value, sort.z3_sort)
             })
         }
     }
 
     pub fn as_f64(&self) -> f64 {
-        unsafe { Z3_get_numeral_double(self.ctx.z3_ctx, self.z3_ast) }
+        unsafe { Z3_get_numeral_double(self.ctx.z3_ctx.0, self.z3_ast) }
     }
 }
 
@@ -637,34 +637,34 @@ impl_from_try_into_dynamic!(Datatype, as_datatype);
 
 impl_ast!(Dynamic);
 
-impl<'ctx> Bool<'ctx> {
-    pub fn new_const<S: Into<Symbol>>(ctx: &'ctx Context, name: S) -> Bool<'ctx> {
+impl Bool {
+    pub fn new_const<S: Into<Symbol>>(ctx: &Context, name: S) -> Bool {
         let sort = Sort::bool(ctx);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx, name.into().as_z3_symbol(ctx), sort.z3_sort)
+                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(ctx), sort.z3_sort)
             })
         }
     }
 
-    pub fn fresh_const(ctx: &'ctx Context, prefix: &str) -> Bool<'ctx> {
+    pub fn fresh_const(ctx: &Context, prefix: &str) -> Bool {
         let sort = Sort::bool(ctx);
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx, p, sort.z3_sort)
+                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort)
             })
         }
     }
 
-    pub fn from_bool(ctx: &'ctx Context, b: bool) -> Bool<'ctx> {
+    pub fn from_bool(ctx: &Context, b: bool) -> Bool {
         unsafe {
             Self::wrap(ctx, {
                 if b {
-                    Z3_mk_true(ctx.z3_ctx)
+                    Z3_mk_true(ctx.z3_ctx.0)
                 } else {
-                    Z3_mk_false(ctx.z3_ctx)
+                    Z3_mk_false(ctx.z3_ctx.0)
                 }
             })
         }
@@ -672,7 +672,7 @@ impl<'ctx> Bool<'ctx> {
 
     pub fn as_bool(&self) -> Option<bool> {
         unsafe {
-            match Z3_get_bool_value(self.ctx.z3_ctx, self.z3_ast) {
+            match Z3_get_bool_value(self.ctx.z3_ctx.0, self.z3_ast) {
                 Z3_L_TRUE => Some(true),
                 Z3_L_FALSE => Some(false),
                 _ => None,
@@ -683,11 +683,11 @@ impl<'ctx> Bool<'ctx> {
     // This doesn't quite fit the trinop! macro because of the generic argty
     pub fn ite<T>(&self, a: &T, b: &T) -> T
     where
-        T: Ast<'ctx>,
+        T: Ast,
     {
         unsafe {
-            T::wrap(self.ctx, {
-                Z3_mk_ite(self.ctx.z3_ctx, self.z3_ast, a.get_z3_ast(), b.get_z3_ast())
+            T::wrap(&self.ctx, {
+                Z3_mk_ite(self.ctx.z3_ctx.0, self.z3_ast, a.get_z3_ast(), b.get_z3_ast())
             })
         }
     }
@@ -705,7 +705,7 @@ impl<'ctx> Bool<'ctx> {
         not(Z3_mk_not, Self);
     }
 
-    pub fn pb_le(ctx: &'ctx Context, values: &[(&Bool<'ctx>, i32)], k: i32) -> Bool<'ctx> {
+    pub fn pb_le(ctx: &Context, values: &[(&Bool, i32)], k: i32) -> Bool {
         unsafe {
             Bool::wrap(ctx, {
                 assert!(values.len() <= 0xffffffff);
@@ -714,7 +714,7 @@ impl<'ctx> Bool<'ctx> {
                     .map(|(boolean, coefficient)| (boolean.z3_ast, coefficient))
                     .unzip();
                 Z3_mk_pble(
-                    ctx.z3_ctx,
+                    ctx.z3_ctx.0,
                     values.len() as u32,
                     values.as_ptr(),
                     coefficients.as_ptr(),
@@ -723,7 +723,7 @@ impl<'ctx> Bool<'ctx> {
             })
         }
     }
-    pub fn pb_ge(ctx: &'ctx Context, values: &[(&Bool<'ctx>, i32)], k: i32) -> Bool<'ctx> {
+    pub fn pb_ge(ctx: &Context, values: &[(&Bool, i32)], k: i32) -> Bool {
         unsafe {
             Bool::wrap(ctx, {
                 assert!(values.len() <= 0xffffffff);
@@ -732,7 +732,7 @@ impl<'ctx> Bool<'ctx> {
                     .map(|(boolean, coefficient)| (boolean.z3_ast, coefficient))
                     .unzip();
                 Z3_mk_pbge(
-                    ctx.z3_ctx,
+                    ctx.z3_ctx.0,
                     values.len() as u32,
                     values.as_ptr(),
                     coefficients.as_ptr(),
@@ -741,7 +741,7 @@ impl<'ctx> Bool<'ctx> {
             })
         }
     }
-    pub fn pb_eq(ctx: &'ctx Context, values: &[(&Bool<'ctx>, i32)], k: i32) -> Bool<'ctx> {
+    pub fn pb_eq(ctx: &Context, values: &[(&Bool, i32)], k: i32) -> Bool {
         unsafe {
             Bool::wrap(ctx, {
                 assert!(values.len() <= 0xffffffff);
@@ -750,7 +750,7 @@ impl<'ctx> Bool<'ctx> {
                     .map(|(boolean, coefficient)| (boolean.z3_ast, coefficient))
                     .unzip();
                 Z3_mk_pbeq(
-                    ctx.z3_ctx,
+                    ctx.z3_ctx.0,
                     values.len() as u32,
                     values.as_ptr(),
                     coefficients.as_ptr(),
@@ -761,83 +761,79 @@ impl<'ctx> Bool<'ctx> {
     }
 }
 
-pub fn atmost<'a, 'ctx, I: IntoIterator<Item = &'a Bool<'ctx>>>(
-    ctx: &'ctx Context,
+pub fn atmost<'a, I: IntoIterator<Item = &'a Bool>>(
+    ctx: &Context,
     args: I,
     k: u32,
-) -> Bool<'ctx>
-where
-    'ctx: 'a,
+) -> Bool
 {
     let args: Vec<_> = args.into_iter().map(|f| f.z3_ast).collect();
     _atmost(ctx, args.as_ref(), k)
 }
 
-fn _atmost<'ctx>(ctx: &'ctx Context, args: &[Z3_ast], k: u32) -> Bool<'ctx> {
+fn _atmost(ctx: &Context, args: &[Z3_ast], k: u32) -> Bool {
     unsafe {
         Bool::wrap(
             ctx,
-            Z3_mk_atmost(ctx.z3_ctx, args.len().try_into().unwrap(), args.as_ptr(), k),
+            Z3_mk_atmost(ctx.z3_ctx.0, args.len().try_into().unwrap(), args.as_ptr(), k),
         )
     }
 }
 
-pub fn atleast<'a, 'ctx, I: IntoIterator<Item = &'a Bool<'ctx>>>(
-    ctx: &'ctx Context,
+pub fn atleast<'a, I: IntoIterator<Item = &'a Bool>>(
+    ctx: &Context,
     args: I,
     k: u32,
-) -> Bool<'ctx>
-where
-    'ctx: 'a,
+) -> Bool
 {
     let args: Vec<_> = args.into_iter().map(|f| f.z3_ast).collect();
     _atleast(ctx, args.as_ref(), k)
 }
 
-fn _atleast<'ctx>(ctx: &'ctx Context, args: &[Z3_ast], k: u32) -> Bool<'ctx> {
+fn _atleast(ctx: &Context, args: &[Z3_ast], k: u32) -> Bool {
     unsafe {
         Bool::wrap(
             ctx,
-            Z3_mk_atleast(ctx.z3_ctx, args.len().try_into().unwrap(), args.as_ptr(), k),
+            Z3_mk_atleast(ctx.z3_ctx.0, args.len().try_into().unwrap(), args.as_ptr(), k),
         )
     }
 }
 
-impl<'ctx> Int<'ctx> {
-    pub fn new_const<S: Into<Symbol>>(ctx: &'ctx Context, name: S) -> Int<'ctx> {
+impl Int {
+    pub fn new_const<S: Into<Symbol>>(ctx: &Context, name: S) -> Int {
         let sort = Sort::int(ctx);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx, name.into().as_z3_symbol(ctx), sort.z3_sort)
+                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(ctx), sort.z3_sort)
             })
         }
     }
 
-    pub fn fresh_const(ctx: &'ctx Context, prefix: &str) -> Int<'ctx> {
+    pub fn fresh_const(ctx: &Context, prefix: &str) -> Int {
         let sort = Sort::int(ctx);
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx, p, sort.z3_sort)
+                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort)
             })
         }
     }
 
-    pub fn from_i64(ctx: &'ctx Context, i: i64) -> Int<'ctx> {
+    pub fn from_i64(ctx: &Context, i: i64) -> Int {
         let sort = Sort::int(ctx);
-        unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx, i, sort.z3_sort)) }
+        unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx.0, i, sort.z3_sort)) }
     }
 
-    pub fn from_u64(ctx: &'ctx Context, u: u64) -> Int<'ctx> {
+    pub fn from_u64(ctx: &Context, u: u64) -> Int {
         let sort = Sort::int(ctx);
-        unsafe { Self::wrap(ctx, Z3_mk_unsigned_int64(ctx.z3_ctx, u, sort.z3_sort)) }
+        unsafe { Self::wrap(ctx, Z3_mk_unsigned_int64(ctx.z3_ctx.0, u, sort.z3_sort)) }
     }
 
     pub fn as_i64(&self) -> Option<i64> {
         unsafe {
             let mut tmp: ::std::os::raw::c_longlong = 0;
-            if Z3_get_numeral_int64(self.ctx.z3_ctx, self.z3_ast, &mut tmp) {
+            if Z3_get_numeral_int64(self.ctx.z3_ctx.0, self.z3_ast, &mut tmp) {
                 Some(tmp)
             } else {
                 None
@@ -848,7 +844,7 @@ impl<'ctx> Int<'ctx> {
     pub fn as_u64(&self) -> Option<u64> {
         unsafe {
             let mut tmp: ::std::os::raw::c_ulonglong = 0;
-            if Z3_get_numeral_uint64(self.ctx.z3_ctx, self.z3_ast, &mut tmp) {
+            if Z3_get_numeral_uint64(self.ctx.z3_ctx.0, self.z3_ast, &mut tmp) {
                 Some(tmp)
             } else {
                 None
@@ -856,14 +852,14 @@ impl<'ctx> Int<'ctx> {
         }
     }
 
-    pub fn from_real(ast: &Real<'ctx>) -> Int<'ctx> {
-        unsafe { Self::wrap(ast.ctx, Z3_mk_real2int(ast.ctx.z3_ctx, ast.z3_ast)) }
+    pub fn from_real(ast: &Real) -> Int {
+        unsafe { Self::wrap(&ast.ctx, Z3_mk_real2int(ast.ctx.z3_ctx.0, ast.z3_ast)) }
     }
 
     /// Create a real from an integer.
     /// This is just a convenience wrapper around
     /// [`Real::from_int()`]; see notes there.
-    pub fn to_real(&self) -> Real<'ctx> {
+    pub fn to_real(&self) -> Real {
         Real::from_int(self)
     }
 
@@ -888,10 +884,10 @@ impl<'ctx> Int<'ctx> {
     ///
     /// assert_eq!(-3, model.eval(&x, true).unwrap().as_i64().unwrap());
     /// ```
-    pub fn from_bv(ast: &BV<'ctx>, signed: bool) -> Int<'ctx> {
+    pub fn from_bv(ast: &BV, signed: bool) -> Int {
         unsafe {
-            Self::wrap(ast.ctx, {
-                Z3_mk_bv2int(ast.ctx.z3_ctx, ast.z3_ast, signed)
+            Self::wrap(&ast.ctx, {
+                Z3_mk_bv2int(ast.ctx.z3_ctx.0, ast.z3_ast, signed)
             })
         }
     }
@@ -899,7 +895,7 @@ impl<'ctx> Int<'ctx> {
     /// Create a bitvector from an integer.
     /// This is just a convenience wrapper around
     /// [`BV::from_int()`]; see notes there.
-    pub fn to_ast(&self, sz: u32) -> BV<'ctx> {
+    pub fn to_ast(&self, sz: u32) -> BV {
         BV::from_int(self, sz)
     }
 
@@ -915,53 +911,53 @@ impl<'ctx> Int<'ctx> {
         div(Z3_mk_div, Self);
         rem(Z3_mk_rem, Self);
         modulo(Z3_mk_mod, Self);
-        power(Z3_mk_power, Real<'ctx>);
-        lt(Z3_mk_lt, Bool<'ctx>);
-        le(Z3_mk_le, Bool<'ctx>);
-        gt(Z3_mk_gt, Bool<'ctx>);
-        ge(Z3_mk_ge, Bool<'ctx>);
+        power(Z3_mk_power, Real);
+        lt(Z3_mk_lt, Bool);
+        le(Z3_mk_le, Bool);
+        gt(Z3_mk_gt, Bool);
+        ge(Z3_mk_ge, Bool);
     }
     // Z3 does support mixing ints and reals in add(), sub(), mul(), div(), and power()
     //   (but not rem(), modulo(), lt(), le(), gt(), or ge()).
     // TODO: we could consider expressing this by having a Numeric trait with these methods.
     //    Int and Real would have the Numeric trait, but not the other Asts.
     // For example:
-    //   fn add(&self, other: &impl Numeric<'ctx>) -> Dynamic<'ctx> { ... }
+    //   fn add(&self, other: &impl Numeric) -> Dynamic { ... }
     // Note the return type would have to be Dynamic I think (?), as the exact result type
     //   depends on the particular types of the inputs.
     // Alternately, we could just have
-    //   Int::add_real(&self, other: &Real<'ctx>) -> Real<'ctx>
+    //   Int::add_real(&self, other: &Real) -> Real
     // and
-    //   Real::add_int(&self, other: &Int<'ctx>) -> Real<'ctx>
+    //   Real::add_int(&self, other: &Int) -> Real
     // This might be cleaner because we know exactly what the output type will be for these methods.
 }
 
-impl<'ctx> Real<'ctx> {
-    pub fn new_const<S: Into<Symbol>>(ctx: &'ctx Context, name: S) -> Real<'ctx> {
+impl Real {
+    pub fn new_const<S: Into<Symbol>>(ctx: &Context, name: S) -> Real {
         let sort = Sort::real(ctx);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx, name.into().as_z3_symbol(ctx), sort.z3_sort)
+                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(ctx), sort.z3_sort)
             })
         }
     }
 
-    pub fn fresh_const(ctx: &'ctx Context, prefix: &str) -> Real<'ctx> {
+    pub fn fresh_const(ctx: &Context, prefix: &str) -> Real {
         let sort = Sort::real(ctx);
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx, p, sort.z3_sort)
+                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort)
             })
         }
     }
 
-    pub fn from_real(ctx: &'ctx Context, num: i32, den: i32) -> Real<'ctx> {
+    pub fn from_real(ctx: &Context, num: i32, den: i32) -> Real {
         unsafe {
             Self::wrap(ctx, {
                 Z3_mk_real(
-                    ctx.z3_ctx,
+                    ctx.z3_ctx.0,
                     num as ::std::os::raw::c_int,
                     den as ::std::os::raw::c_int,
                 )
@@ -973,7 +969,7 @@ impl<'ctx> Real<'ctx> {
         unsafe {
             let mut num: i64 = 0;
             let mut den: i64 = 0;
-            if Z3_get_numeral_small(self.ctx.z3_ctx, self.z3_ast, &mut num, &mut den) {
+            if Z3_get_numeral_small(self.ctx.z3_ctx.0, self.z3_ast, &mut num, &mut den) {
                 Some((num, den))
             } else {
                 None
@@ -984,7 +980,7 @@ impl<'ctx> Real<'ctx> {
     pub fn approx(&self, precision: usize) -> ::std::string::String {
         let s = unsafe {
             CStr::from_ptr(Z3_get_numeral_decimal_string(
-                self.ctx.z3_ctx,
+                self.ctx.z3_ctx.0,
                 self.z3_ast,
                 precision as _,
             ))
@@ -997,19 +993,19 @@ impl<'ctx> Real<'ctx> {
         self.approx(17).parse().unwrap() // 17 decimal digits needed to get full f64 precision
     }
 
-    pub fn from_int(ast: &Int<'ctx>) -> Real<'ctx> {
-        unsafe { Self::wrap(ast.ctx, Z3_mk_int2real(ast.ctx.z3_ctx, ast.z3_ast)) }
+    pub fn from_int(ast: &Int) -> Real {
+        unsafe { Self::wrap(&ast.ctx, Z3_mk_int2real(ast.ctx.z3_ctx.0, ast.z3_ast)) }
     }
 
     /// Create an integer from a real.
     /// This is just a convenience wrapper around
     /// [`Int::from_real()`]; see notes there.
-    pub fn to_int(&self) -> Int<'ctx> {
+    pub fn to_int(&self) -> Int {
         Int::from_real(self)
     }
 
     unop! {
-        is_int(Z3_mk_is_int, Bool<'ctx>);
+        is_int(Z3_mk_is_int, Bool);
     }
 
     varop! {
@@ -1023,135 +1019,135 @@ impl<'ctx> Real<'ctx> {
     binop! {
         div(Z3_mk_div, Self);
         power(Z3_mk_power, Self);
-        lt(Z3_mk_lt, Bool<'ctx>);
-        le(Z3_mk_le, Bool<'ctx>);
-        gt(Z3_mk_gt, Bool<'ctx>);
-        ge(Z3_mk_ge, Bool<'ctx>);
+        lt(Z3_mk_lt, Bool);
+        le(Z3_mk_le, Bool);
+        gt(Z3_mk_gt, Bool);
+        ge(Z3_mk_ge, Bool);
     }
 }
 
-impl<'ctx> Float<'ctx> {
+impl Float {
     pub fn new_const<S: Into<Symbol>>(
-        ctx: &'ctx Context,
+        ctx: &Context,
         name: S,
         ebits: u32,
         sbits: u32,
-    ) -> Float<'ctx> {
+    ) -> Float {
         let sort = Sort::float(ctx, ebits, sbits);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx, name.into().as_z3_symbol(ctx), sort.z3_sort)
+                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(ctx), sort.z3_sort)
             })
         }
     }
 
     /// Create a 32-bit (IEEE-754) Float [`Ast`].
-    pub fn new_const_float32<S: Into<Symbol>>(ctx: &'ctx Context, name: S) -> Float<'ctx> {
+    pub fn new_const_float32<S: Into<Symbol>>(ctx: &Context, name: S) -> Float {
         let sort = Sort::float32(ctx);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx, name.into().as_z3_symbol(ctx), sort.z3_sort)
+                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(ctx), sort.z3_sort)
             })
         }
     }
 
     /// Create a 64-bit (IEEE-754) Float [`Ast`].
-    pub fn new_const_double<S: Into<Symbol>>(ctx: &'ctx Context, name: S) -> Float<'ctx> {
+    pub fn new_const_double<S: Into<Symbol>>(ctx: &Context, name: S) -> Float {
         let sort = Sort::double(ctx);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx, name.into().as_z3_symbol(ctx), sort.z3_sort)
+                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(ctx), sort.z3_sort)
             })
         }
     }
 
-    pub fn fresh_const(ctx: &'ctx Context, prefix: &str, ebits: u32, sbits: u32) -> Float<'ctx> {
+    pub fn fresh_const(ctx: &Context, prefix: &str, ebits: u32, sbits: u32) -> Float {
         let sort = Sort::float(ctx, ebits, sbits);
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx, p, sort.z3_sort)
+                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort)
             })
         }
     }
 
-    pub fn fresh_const_float32(ctx: &'ctx Context, prefix: &str) -> Float<'ctx> {
+    pub fn fresh_const_float32(ctx: &Context, prefix: &str) -> Float {
         let sort = Sort::float32(ctx);
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx, p, sort.z3_sort)
+                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort)
             })
         }
     }
 
-    pub fn fresh_const_double(ctx: &'ctx Context, prefix: &str) -> Float<'ctx> {
+    pub fn fresh_const_double(ctx: &Context, prefix: &str) -> Float {
         let sort = Sort::double(ctx);
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx, p, sort.z3_sort)
+                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort)
             })
         }
     }
 
     // returns RoundingMode towards zero
-    pub fn round_towards_zero(ctx: &'ctx Context) -> Float<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_fpa_round_toward_zero(ctx.z3_ctx)) }
+    pub fn round_towards_zero(ctx: &Context) -> Float {
+        unsafe { Self::wrap(ctx, Z3_mk_fpa_round_toward_zero(ctx.z3_ctx.0)) }
     }
 
     // returns RoundingMode towards negative
-    pub fn round_towards_negative(ctx: &'ctx Context) -> Float<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_fpa_round_toward_negative(ctx.z3_ctx)) }
+    pub fn round_towards_negative(ctx: &Context) -> Float {
+        unsafe { Self::wrap(ctx, Z3_mk_fpa_round_toward_negative(ctx.z3_ctx.0)) }
     }
 
     // returns RoundingMode towards positive
-    pub fn round_towards_positive(ctx: &'ctx Context) -> Float<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_fpa_round_toward_positive(ctx.z3_ctx)) }
+    pub fn round_towards_positive(ctx: &Context) -> Float {
+        unsafe { Self::wrap(ctx, Z3_mk_fpa_round_toward_positive(ctx.z3_ctx.0)) }
     }
 
     // Add two floats of the same size, rounding towards zero
-    pub fn add_towards_zero(&self, other: &Self) -> Float<'ctx> {
-        Self::round_towards_zero(self.ctx).add(self, other)
+    pub fn add_towards_zero(&self, other: &Self) -> Float {
+        Self::round_towards_zero(&self.ctx).add(self, other)
     }
 
     // Subtract two floats of the same size, rounding towards zero
-    pub fn sub_towards_zero(&self, other: &Self) -> Float<'ctx> {
-        Self::round_towards_zero(self.ctx).sub(self, other)
+    pub fn sub_towards_zero(&self, other: &Self) -> Float {
+        Self::round_towards_zero(&self.ctx).sub(self, other)
     }
 
     // Multiply two floats of the same size, rounding towards zero
-    pub fn mul_towards_zero(&self, other: &Self) -> Float<'ctx> {
-        Self::round_towards_zero(self.ctx).mul(self, other)
+    pub fn mul_towards_zero(&self, other: &Self) -> Float {
+        Self::round_towards_zero(&self.ctx).mul(self, other)
     }
 
     // Divide two floats of the same size, rounding towards zero
-    pub fn div_towards_zero(&self, other: &Self) -> Float<'ctx> {
-        Self::round_towards_zero(self.ctx).div(self, other)
+    pub fn div_towards_zero(&self, other: &Self) -> Float {
+        Self::round_towards_zero(&self.ctx).div(self, other)
     }
 
     // Convert to IEEE-754 bit-vector
-    pub fn to_ieee_bv(&self) -> BV<'ctx> {
-        unsafe { BV::wrap(self.ctx, Z3_mk_fpa_to_ieee_bv(self.ctx.z3_ctx, self.z3_ast)) }
+    pub fn to_ieee_bv(&self) -> BV {
+        unsafe { BV::wrap(&self.ctx, Z3_mk_fpa_to_ieee_bv(self.ctx.z3_ctx.0, self.z3_ast)) }
     }
 
     unop! {
         unary_abs(Z3_mk_fpa_abs, Self);
         unary_neg(Z3_mk_fpa_neg, Self);
-        is_infinite(Z3_mk_fpa_is_infinite, Bool<'ctx>);
-        is_normal(Z3_mk_fpa_is_normal, Bool<'ctx>);
-        is_subnormal(Z3_mk_fpa_is_subnormal, Bool<'ctx>);
-        is_zero(Z3_mk_fpa_is_zero, Bool<'ctx>);
-        is_nan(Z3_mk_fpa_is_nan, Bool<'ctx>);
+        is_infinite(Z3_mk_fpa_is_infinite, Bool);
+        is_normal(Z3_mk_fpa_is_normal, Bool);
+        is_subnormal(Z3_mk_fpa_is_subnormal, Bool);
+        is_zero(Z3_mk_fpa_is_zero, Bool);
+        is_nan(Z3_mk_fpa_is_nan, Bool);
     }
     binop! {
-        lt(Z3_mk_fpa_lt, Bool<'ctx>);
-        le(Z3_mk_fpa_leq, Bool<'ctx>);
-        gt(Z3_mk_fpa_gt, Bool<'ctx>);
-        ge(Z3_mk_fpa_geq, Bool<'ctx>);
+        lt(Z3_mk_fpa_lt, Bool);
+        le(Z3_mk_fpa_leq, Bool);
+        gt(Z3_mk_fpa_gt, Bool);
+        ge(Z3_mk_fpa_geq, Bool);
     }
     trinop! {
         add(Z3_mk_fpa_add, Self);
@@ -1161,35 +1157,35 @@ impl<'ctx> Float<'ctx> {
     }
 }
 
-impl<'ctx> String<'ctx> {
+impl String {
     /// Creates a new constant using the built-in string sort
-    pub fn new_const<S: Into<Symbol>>(ctx: &'ctx Context, name: S) -> String<'ctx> {
+    pub fn new_const<S: Into<Symbol>>(ctx: &Context, name: S) -> String {
         let sort = Sort::string(ctx);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx, name.into().as_z3_symbol(ctx), sort.z3_sort)
+                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(ctx), sort.z3_sort)
             })
         }
     }
 
     /// Creates a fresh constant using the built-in string sort
-    pub fn fresh_const(ctx: &'ctx Context, prefix: &str) -> String<'ctx> {
+    pub fn fresh_const(ctx: &Context, prefix: &str) -> String {
         let sort = Sort::string(ctx);
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx, p, sort.z3_sort)
+                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort)
             })
         }
     }
 
     /// Creates a Z3 constant string from a `&str`
-    pub fn from_str(ctx: &'ctx Context, string: &str) -> Result<String<'ctx>, std::ffi::NulError> {
+    pub fn from_str(ctx: &Context, string: &str) -> Result<String, std::ffi::NulError> {
         let string = CString::new(string)?;
         Ok(unsafe {
             Self::wrap(ctx, {
-                Z3_mk_string(ctx.z3_ctx, string.as_c_str().as_ptr())
+                Z3_mk_string(ctx.z3_ctx.0, string.as_c_str().as_ptr())
             })
         })
     }
@@ -1203,7 +1199,7 @@ impl<'ctx> String<'ctx> {
     /// `z3::ast::String::from_str(&ctx, s).unwrap().as_string()` returns a
     /// `String` equal to the original value.
     pub fn as_string(&self) -> Option<std::string::String> {
-        let z3_ctx = self.get_ctx().z3_ctx;
+        let z3_ctx = self.get_ctx().z3_ctx.0;
         unsafe {
             let bytes = Z3_get_string(z3_ctx, self.get_z3_ast());
             if bytes.is_null() {
@@ -1233,11 +1229,11 @@ impl<'ctx> String<'ctx> {
     /// );
     /// assert_eq!(solver.check(), z3::SatResult::Sat);
     /// ```
-    pub fn at(&self, index: &Int<'ctx>) -> Self {
+    pub fn at(&self, index: &Int) -> Self {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_mk_seq_at(self.ctx.z3_ctx, self.z3_ast, index.z3_ast),
+                &self.ctx,
+                Z3_mk_seq_at(self.ctx.z3_ctx.0, self.z3_ast, index.z3_ast),
             )
         }
     }
@@ -1278,43 +1274,43 @@ impl<'ctx> String<'ctx> {
     ///     "bc",
     /// );
     /// ```
-    pub fn substr(&self, offset: &Int<'ctx>, length: &Int<'ctx>) -> Self {
+    pub fn substr(&self, offset: &Int, length: &Int) -> Self {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_mk_seq_extract(self.ctx.z3_ctx, self.z3_ast, offset.z3_ast, length.z3_ast),
+                &self.ctx,
+                Z3_mk_seq_extract(self.ctx.z3_ctx.0, self.z3_ast, offset.z3_ast, length.z3_ast),
             )
         }
     }
 
     /// Checks if this string matches a `z3::ast::Regexp`
-    pub fn regex_matches(&self, regex: &Regexp) -> Bool<'ctx> {
+    pub fn regex_matches(&self, regex: &Regexp) -> Bool {
         assert!(self.ctx == regex.ctx);
         unsafe {
             Bool::wrap(
-                self.ctx,
-                Z3_mk_seq_in_re(self.ctx.z3_ctx, self.get_z3_ast(), regex.get_z3_ast()),
+                &self.ctx,
+                Z3_mk_seq_in_re(self.ctx.z3_ctx.0, self.get_z3_ast(), regex.get_z3_ast()),
             )
         }
     }
 
     varop! {
         /// Appends the argument strings to `Self`
-        concat(Z3_mk_seq_concat, String<'ctx>);
+        concat(Z3_mk_seq_concat, String);
     }
 
     unop! {
         /// Gets the length of `Self`.
-        length(Z3_mk_seq_length, Int<'ctx>);
+        length(Z3_mk_seq_length, Int);
     }
 
     binop! {
         /// Checks whether `Self` contains a substring
-        contains(Z3_mk_seq_contains, Bool<'ctx>);
+        contains(Z3_mk_seq_contains, Bool);
         /// Checks whether `Self` is a prefix of the argument
-        prefix(Z3_mk_seq_prefix, Bool<'ctx>);
+        prefix(Z3_mk_seq_prefix, Bool);
         /// Checks whether `Self` is a suffix of the argument
-        suffix(Z3_mk_seq_suffix, Bool<'ctx>);
+        suffix(Z3_mk_seq_suffix, Bool);
     }
 }
 
@@ -1326,10 +1322,10 @@ macro_rules! bv_overflow_check_signed {
     ) => {
         $(
             $( #[ $attr ] )*
-            pub fn $f(&self, other: &BV<'ctx>, b: bool) -> Bool<'ctx> {
+            pub fn $f(&self, other: &BV, b: bool) -> Bool {
                 unsafe {
-                    Ast::wrap(self.ctx, {
-                        $z3fn(self.ctx.z3_ctx, self.z3_ast, other.z3_ast, b)
+                    Ast::wrap(&self.ctx, {
+                        $z3fn(self.ctx.z3_ctx.0, self.z3_ast, other.z3_ast, b)
                     })
                 }
             }
@@ -1337,12 +1333,12 @@ macro_rules! bv_overflow_check_signed {
     };
 }
 
-impl<'ctx> BV<'ctx> {
-    pub fn from_str(ctx: &'ctx Context, sz: u32, value: &str) -> Option<BV<'ctx>> {
+impl BV {
+    pub fn from_str(ctx: &Context, sz: u32, value: &str) -> Option<BV> {
         let sort = Sort::bitvector(ctx, sz);
         let ast = unsafe {
             let bv_cstring = CString::new(value).unwrap();
-            let numeral_ptr = Z3_mk_numeral(ctx.z3_ctx, bv_cstring.as_ptr(), sort.z3_sort);
+            let numeral_ptr = Z3_mk_numeral(ctx.z3_ctx.0, bv_cstring.as_ptr(), sort.z3_sort);
             if numeral_ptr.is_null() {
                 return None;
             }
@@ -1365,8 +1361,8 @@ impl<'ctx> BV<'ctx> {
     /// assert_eq!(bv, BV::from_u64(&ctx, 2, 8));
     /// assert_eq!(bv_none, None);
     /// ```
-    pub fn from_bits(ctx: &'ctx Context, bits: &[bool]) -> Option<BV<'ctx>> {
-        let ast = unsafe { Z3_mk_bv_numeral(ctx.z3_ctx, bits.len() as u32, bits.as_ptr()) };
+    pub fn from_bits(ctx: &Context, bits: &[bool]) -> Option<BV> {
+        let ast = unsafe { Z3_mk_bv_numeral(ctx.z3_ctx.0, bits.len() as u32, bits.as_ptr()) };
         if ast.is_null() {
             None
         } else {
@@ -1374,40 +1370,40 @@ impl<'ctx> BV<'ctx> {
         }
     }
 
-    pub fn new_const<S: Into<Symbol>>(ctx: &'ctx Context, name: S, sz: u32) -> BV<'ctx> {
+    pub fn new_const<S: Into<Symbol>>(ctx: &Context, name: S, sz: u32) -> BV {
         let sort = Sort::bitvector(ctx, sz);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx, name.into().as_z3_symbol(ctx), sort.z3_sort)
+                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(ctx), sort.z3_sort)
             })
         }
     }
 
-    pub fn fresh_const(ctx: &'ctx Context, prefix: &str, sz: u32) -> BV<'ctx> {
+    pub fn fresh_const(ctx: &Context, prefix: &str, sz: u32) -> BV {
         let sort = Sort::bitvector(ctx, sz);
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx, p, sort.z3_sort)
+                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort)
             })
         }
     }
 
-    pub fn from_i64(ctx: &'ctx Context, i: i64, sz: u32) -> BV<'ctx> {
+    pub fn from_i64(ctx: &Context, i: i64, sz: u32) -> BV {
         let sort = Sort::bitvector(ctx, sz);
-        unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx, i, sort.z3_sort)) }
+        unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx.0, i, sort.z3_sort)) }
     }
 
-    pub fn from_u64(ctx: &'ctx Context, u: u64, sz: u32) -> BV<'ctx> {
+    pub fn from_u64(ctx: &Context, u: u64, sz: u32) -> BV {
         let sort = Sort::bitvector(ctx, sz);
-        unsafe { Self::wrap(ctx, Z3_mk_unsigned_int64(ctx.z3_ctx, u, sort.z3_sort)) }
+        unsafe { Self::wrap(ctx, Z3_mk_unsigned_int64(ctx.z3_ctx.0, u, sort.z3_sort)) }
     }
 
     pub fn as_i64(&self) -> Option<i64> {
         unsafe {
             let mut tmp: ::std::os::raw::c_longlong = 0;
-            if Z3_get_numeral_int64(self.ctx.z3_ctx, self.z3_ast, &mut tmp) {
+            if Z3_get_numeral_int64(self.ctx.z3_ctx.0, self.z3_ast, &mut tmp) {
                 Some(tmp)
             } else {
                 None
@@ -1418,7 +1414,7 @@ impl<'ctx> BV<'ctx> {
     pub fn as_u64(&self) -> Option<u64> {
         unsafe {
             let mut tmp: ::std::os::raw::c_ulonglong = 0;
-            if Z3_get_numeral_uint64(self.ctx.z3_ctx, self.z3_ast, &mut tmp) {
+            if Z3_get_numeral_uint64(self.ctx.z3_ctx.0, self.z3_ast, &mut tmp) {
                 Some(tmp)
             } else {
                 None
@@ -1444,25 +1440,25 @@ impl<'ctx> BV<'ctx> {
     /// assert_eq!(64, x.get_size());
     ///
     /// assert_eq!(solver.check(), SatResult::Sat);
-    /// let model = solver.get_model().unwrap();;
+    /// let model = solver.get_model().unwrap();
     ///
     /// assert_eq!(-3, model.eval(&x.to_int(true), true).unwrap().as_i64().expect("as_i64() shouldn't fail"));
     /// ```
-    pub fn from_int(ast: &Int<'ctx>, sz: u32) -> BV<'ctx> {
-        unsafe { Self::wrap(ast.ctx, Z3_mk_int2bv(ast.ctx.z3_ctx, sz, ast.z3_ast)) }
+    pub fn from_int(ast: &Int, sz: u32) -> BV {
+        unsafe { Self::wrap(&ast.ctx, Z3_mk_int2bv(ast.ctx.z3_ctx.0, sz, ast.z3_ast)) }
     }
 
     /// Create an integer from a bitvector.
     /// This is just a convenience wrapper around
     /// [`Int::from_bv()`]; see notes there.
-    pub fn to_int(&self, signed: bool) -> Int<'ctx> {
+    pub fn to_int(&self, signed: bool) -> Int {
         Int::from_bv(self, signed)
     }
 
     /// Get the size of the bitvector (in bits)
     pub fn get_size(&self) -> u32 {
         let sort = self.get_sort();
-        unsafe { Z3_get_bv_sort_size(self.ctx.z3_ctx, sort.z3_sort) }
+        unsafe { Z3_get_bv_sort_size(self.ctx.z3_ctx.0, sort.z3_sort) }
     }
 
     // Bitwise ops
@@ -1514,21 +1510,21 @@ impl<'ctx> BV<'ctx> {
     // Comparison ops
     binop! {
         /// Unsigned less than
-        bvult(Z3_mk_bvult, Bool<'ctx>);
+        bvult(Z3_mk_bvult, Bool);
         /// Signed less than
-        bvslt(Z3_mk_bvslt, Bool<'ctx>);
+        bvslt(Z3_mk_bvslt, Bool);
         /// Unsigned less than or equal
-        bvule(Z3_mk_bvule, Bool<'ctx>);
+        bvule(Z3_mk_bvule, Bool);
         /// Signed less than or equal
-        bvsle(Z3_mk_bvsle, Bool<'ctx>);
+        bvsle(Z3_mk_bvsle, Bool);
         /// Unsigned greater or equal
-        bvuge(Z3_mk_bvuge, Bool<'ctx>);
+        bvuge(Z3_mk_bvuge, Bool);
         /// Signed greater or equal
-        bvsge(Z3_mk_bvsge, Bool<'ctx>);
+        bvsge(Z3_mk_bvsge, Bool);
         /// Unsigned greater than
-        bvugt(Z3_mk_bvugt, Bool<'ctx>);
+        bvugt(Z3_mk_bvugt, Bool);
         /// Signed greater than
-        bvsgt(Z3_mk_bvsgt, Bool<'ctx>);
+        bvsgt(Z3_mk_bvsgt, Bool);
     }
 
     // Shift ops
@@ -1553,7 +1549,7 @@ impl<'ctx> BV<'ctx> {
     // overflow checks
     unop! {
         /// Check if negation overflows
-        bvneg_no_overflow(Z3_mk_bvneg_no_overflow, Bool<'ctx>);
+        bvneg_no_overflow(Z3_mk_bvneg_no_overflow, Bool);
     }
     bv_overflow_check_signed! {
         /// Check if addition overflows
@@ -1565,21 +1561,21 @@ impl<'ctx> BV<'ctx> {
     }
     binop! {
         /// Check if addition underflows
-        bvadd_no_underflow(Z3_mk_bvadd_no_underflow, Bool<'ctx>);
+        bvadd_no_underflow(Z3_mk_bvadd_no_underflow, Bool);
         /// Check if subtraction overflows
-        bvsub_no_overflow(Z3_mk_bvsub_no_overflow, Bool<'ctx>);
+        bvsub_no_overflow(Z3_mk_bvsub_no_overflow, Bool);
         /// Check if signed division overflows
-        bvsdiv_no_overflow(Z3_mk_bvsdiv_no_overflow, Bool<'ctx>);
+        bvsdiv_no_overflow(Z3_mk_bvsdiv_no_overflow, Bool);
         /// Check if multiplication underflows
-        bvmul_no_underflow(Z3_mk_bvmul_no_underflow, Bool<'ctx>);
+        bvmul_no_underflow(Z3_mk_bvmul_no_underflow, Bool);
     }
 
     /// Extract the bits `high` down to `low` from the bitvector.
     /// Returns a bitvector of size `n`, where `n = high - low + 1`.
     pub fn extract(&self, high: u32, low: u32) -> Self {
         unsafe {
-            Self::wrap(self.ctx, {
-                Z3_mk_extract(self.ctx.z3_ctx, high, low, self.z3_ast)
+            Self::wrap(&self.ctx, {
+                Z3_mk_extract(self.ctx.z3_ctx.0, high, low, self.z3_ast)
             })
         }
     }
@@ -1588,8 +1584,8 @@ impl<'ctx> BV<'ctx> {
     /// That is, `i` bits will be added.
     pub fn sign_ext(&self, i: u32) -> Self {
         unsafe {
-            Self::wrap(self.ctx, {
-                Z3_mk_sign_ext(self.ctx.z3_ctx, i, self.z3_ast)
+            Self::wrap(&self.ctx, {
+                Z3_mk_sign_ext(self.ctx.z3_ctx.0, i, self.z3_ast)
             })
         }
     }
@@ -1598,57 +1594,57 @@ impl<'ctx> BV<'ctx> {
     /// That is, `i` bits will be added.
     pub fn zero_ext(&self, i: u32) -> Self {
         unsafe {
-            Self::wrap(self.ctx, {
-                Z3_mk_zero_ext(self.ctx.z3_ctx, i, self.z3_ast)
+            Self::wrap(&self.ctx, {
+                Z3_mk_zero_ext(self.ctx.z3_ctx.0, i, self.z3_ast)
             })
         }
     }
 }
 
-impl<'ctx> Array<'ctx> {
+impl Array {
     /// Create an `Array` which maps from indices of the `domain` `Sort` to
     /// values of the `range` `Sort`.
     ///
     /// All values in the `Array` will be unconstrained.
     pub fn new_const<S: Into<Symbol>>(
-        ctx: &'ctx Context,
+        ctx: &Context,
         name: S,
-        domain: &Sort<'ctx>,
-        range: &Sort<'ctx>,
-    ) -> Array<'ctx> {
+        domain: &Sort,
+        range: &Sort,
+    ) -> Array {
         let sort = Sort::array(ctx, domain, range);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx, name.into().as_z3_symbol(ctx), sort.z3_sort)
+                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(ctx), sort.z3_sort)
             })
         }
     }
 
     pub fn fresh_const(
-        ctx: &'ctx Context,
+        ctx: &Context,
         prefix: &str,
-        domain: &Sort<'ctx>,
-        range: &Sort<'ctx>,
-    ) -> Array<'ctx> {
+        domain: &Sort,
+        range: &Sort,
+    ) -> Array {
         let sort = Sort::array(ctx, domain, range);
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx, p, sort.z3_sort)
+                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort)
             })
         }
     }
 
     /// Create a "constant array", that is, an `Array` initialized so that all of the
     /// indices in the `domain` map to the given value `val`
-    pub fn const_array<A>(ctx: &'ctx Context, domain: &Sort<'ctx>, val: &A) -> Array<'ctx>
+    pub fn const_array<A>(ctx: &Context, domain: &Sort, val: &A) -> Array
     where
-        A: Ast<'ctx>,
+        A: Ast,
     {
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const_array(ctx.z3_ctx, domain.z3_sort, val.get_z3_ast())
+                Z3_mk_const_array(ctx.z3_ctx.0, domain.z3_sort, val.get_z3_ast())
             })
         }
     }
@@ -1659,9 +1655,9 @@ impl<'ctx> Array<'ctx> {
     /// The return type will be of the array's `range` sort.
     //
     // We avoid the binop! macro because the argument has a non-Self type
-    pub fn select<A>(&self, index: &A) -> Dynamic<'ctx>
+    pub fn select<A>(&self, index: &A) -> Dynamic
     where
-        A: Ast<'ctx>,
+        A: Ast,
     {
         // TODO: We could validate here that the index is of the correct type.
         // This would require us either to keep around the original `domain` argument
@@ -1672,21 +1668,21 @@ impl<'ctx> Array<'ctx> {
         // problem.
         // This way we also avoid the redundant check every time this method is called.
         unsafe {
-            Dynamic::wrap(self.ctx, {
-                Z3_mk_select(self.ctx.z3_ctx, self.z3_ast, index.get_z3_ast())
+            Dynamic::wrap(&self.ctx, {
+                Z3_mk_select(self.ctx.z3_ctx.0, self.z3_ast, index.get_z3_ast())
             })
         }
     }
 
     /// n-ary Array read. `idxs` are the indices of the array that gets read.
     /// This is useful for applying lambdas.
-    pub fn select_n(&self, idxs: &[&dyn Ast]) -> Dynamic<'ctx> {
+    pub fn select_n(&self, idxs: &[&dyn Ast]) -> Dynamic {
         let idxs: Vec<_> = idxs.iter().map(|idx| idx.get_z3_ast()).collect();
 
         unsafe {
-            Dynamic::wrap(self.ctx, {
+            Dynamic::wrap(&self.ctx, {
                 Z3_mk_select_n(
-                    self.ctx.z3_ctx,
+                    self.ctx.z3_ctx.0,
                     self.z3_ast,
                     idxs.len().try_into().unwrap(),
                     idxs.as_ptr() as *const Z3_ast,
@@ -1703,13 +1699,13 @@ impl<'ctx> Array<'ctx> {
     // We avoid the trinop! macro because the arguments have non-Self types
     pub fn store<A1, A2>(&self, index: &A1, value: &A2) -> Self
     where
-        A1: Ast<'ctx>,
-        A2: Ast<'ctx>,
+        A1: Ast,
+        A2: Ast,
     {
         unsafe {
-            Self::wrap(self.ctx, {
+            Self::wrap(&self.ctx, {
                 Z3_mk_store(
-                    self.ctx.z3_ctx,
+                    self.ctx.z3_ctx.0,
                     self.z3_ast,
                     index.get_z3_ast(),
                     value.get_z3_ast(),
@@ -1740,34 +1736,34 @@ impl<'ctx> Array<'ctx> {
     }
 }
 
-impl<'ctx> Set<'ctx> {
+impl Set {
     pub fn new_const<S: Into<Symbol>>(
-        ctx: &'ctx Context,
+        ctx: &Context,
         name: S,
-        eltype: &Sort<'ctx>,
-    ) -> Set<'ctx> {
+        eltype: &Sort,
+    ) -> Set {
         let sort = Sort::set(ctx, eltype);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx, name.into().as_z3_symbol(ctx), sort.z3_sort)
+                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(ctx), sort.z3_sort)
             })
         }
     }
 
-    pub fn fresh_const(ctx: &'ctx Context, prefix: &str, eltype: &Sort<'ctx>) -> Set<'ctx> {
+    pub fn fresh_const(ctx: &Context, prefix: &str, eltype: &Sort) -> Set {
         let sort = Sort::set(ctx, eltype);
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx, p, sort.z3_sort)
+                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort)
             })
         }
     }
 
     /// Creates a set that maps the domain to false by default
-    pub fn empty(ctx: &'ctx Context, domain: &Sort<'ctx>) -> Set<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_empty_set(ctx.z3_ctx, domain.z3_sort)) }
+    pub fn empty(ctx: &Context, domain: &Sort) -> Set {
+        unsafe { Self::wrap(ctx, Z3_mk_empty_set(ctx.z3_ctx.0, domain.z3_sort)) }
     }
 
     /// Add an element to the set.
@@ -1775,13 +1771,13 @@ impl<'ctx> Set<'ctx> {
     /// Note that the `element` _must be_ of the `Set`'s `eltype` sort.
     //
     // We avoid the binop! macro because the argument has a non-Self type
-    pub fn add<A>(&self, element: &A) -> Set<'ctx>
+    pub fn add<A>(&self, element: &A) -> Set
     where
-        A: Ast<'ctx>,
+        A: Ast,
     {
         unsafe {
-            Self::wrap(self.ctx, {
-                Z3_mk_set_add(self.ctx.z3_ctx, self.z3_ast, element.get_z3_ast())
+            Self::wrap(&self.ctx, {
+                Z3_mk_set_add(self.ctx.z3_ctx.0, self.z3_ast, element.get_z3_ast())
             })
         }
     }
@@ -1791,13 +1787,13 @@ impl<'ctx> Set<'ctx> {
     /// Note that the `element` _must be_ of the `Set`'s `eltype` sort.
     //
     // We avoid the binop! macro because the argument has a non-Self type
-    pub fn del<A>(&self, element: &A) -> Set<'ctx>
+    pub fn del<A>(&self, element: &A) -> Set
     where
-        A: Ast<'ctx>,
+        A: Ast,
     {
         unsafe {
-            Self::wrap(self.ctx, {
-                Z3_mk_set_del(self.ctx.z3_ctx, self.z3_ast, element.get_z3_ast())
+            Self::wrap(&self.ctx, {
+                Z3_mk_set_del(self.ctx.z3_ctx.0, self.z3_ast, element.get_z3_ast())
             })
         }
     }
@@ -1807,13 +1803,13 @@ impl<'ctx> Set<'ctx> {
     /// Note that the `element` _must be_ of the `Set`'s `eltype` sort.
     //
     // We avoid the binop! macro because the argument has a non-Self type
-    pub fn member<A>(&self, element: &A) -> Bool<'ctx>
+    pub fn member<A>(&self, element: &A) -> Bool
     where
-        A: Ast<'ctx>,
+        A: Ast,
     {
         unsafe {
-            Bool::wrap(self.ctx, {
-                Z3_mk_set_member(self.ctx.z3_ctx, element.get_z3_ast(), self.z3_ast)
+            Bool::wrap(&self.ctx, {
+                Z3_mk_set_member(self.ctx.z3_ctx.0, element.get_z3_ast(), self.z3_ast)
             })
         }
     }
@@ -1830,45 +1826,45 @@ impl<'ctx> Set<'ctx> {
     }
     binop! {
         /// Check if the set is a subset of another set.
-        set_subset(Z3_mk_set_subset, Bool<'ctx>);
+        set_subset(Z3_mk_set_subset, Bool);
         /// Take the set difference between two sets.
         difference(Z3_mk_set_difference, Self);
     }
 }
 
-impl<'ctx> Seq<'ctx> {
-    pub fn new_const<S: Into<Symbol>>(ctx: &'ctx Context, name: S, eltype: &Sort<'ctx>) -> Self {
+impl Seq {
+    pub fn new_const<S: Into<Symbol>>(ctx: &Context, name: S, eltype: &Sort) -> Self {
         let sort = Sort::seq(ctx, eltype);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx, name.into().as_z3_symbol(ctx), sort.z3_sort)
+                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(ctx), sort.z3_sort)
             })
         }
     }
 
-    pub fn fresh_const(ctx: &'ctx Context, prefix: &str, eltype: &Sort<'ctx>) -> Self {
+    pub fn fresh_const(ctx: &Context, prefix: &str, eltype: &Sort) -> Self {
         let sort = Sort::seq(ctx, eltype);
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx, p, sort.z3_sort)
+                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort)
             })
         }
     }
 
     /// Create a unit sequence of `a`.
-    pub fn unit<A: Ast<'ctx>>(ctx: &'ctx Context, a: &A) -> Self {
-        unsafe { Self::wrap(ctx, Z3_mk_seq_unit(ctx.z3_ctx, a.get_z3_ast())) }
+    pub fn unit<A: Ast>(ctx: &Context, a: &A) -> Self {
+        unsafe { Self::wrap(ctx, Z3_mk_seq_unit(ctx.z3_ctx.0, a.get_z3_ast())) }
     }
 
     /// Retrieve the unit sequence positioned at position `index`.
     /// Use [`Seq::nth`] to get just the element.
-    pub fn at(&self, index: &Int<'ctx>) -> Self {
+    pub fn at(&self, index: &Int) -> Self {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_mk_seq_at(self.ctx.z3_ctx, self.z3_ast, index.z3_ast),
+                &self.ctx,
+                Z3_mk_seq_at(self.ctx.z3_ctx.0, self.z3_ast, index.z3_ast),
             )
         }
     }
@@ -1892,17 +1888,17 @@ impl<'ctx> Seq<'ctx> {
     ///         ._eq(&Bool::from_bool(&ctx, true))
     /// );
     /// ```
-    pub fn nth(&self, index: &Int<'ctx>) -> Dynamic<'ctx> {
+    pub fn nth(&self, index: &Int) -> Dynamic {
         unsafe {
             Dynamic::wrap(
-                self.ctx,
-                Z3_mk_seq_nth(self.ctx.z3_ctx, self.z3_ast, index.z3_ast),
+                &self.ctx,
+                Z3_mk_seq_nth(self.ctx.z3_ctx.0, self.z3_ast, index.z3_ast),
             )
         }
     }
 
-    pub fn length(&self) -> Int<'ctx> {
-        unsafe { Int::wrap(self.ctx, Z3_mk_seq_length(self.ctx.z3_ctx, self.z3_ast)) }
+    pub fn length(&self) -> Int {
+        unsafe { Int::wrap(&self.ctx, Z3_mk_seq_length(self.ctx.z3_ctx.0, self.z3_ast)) }
     }
 
     varop! {
@@ -1911,71 +1907,71 @@ impl<'ctx> Seq<'ctx> {
     }
 }
 
-impl<'ctx> Dynamic<'ctx> {
-    pub fn from_ast(ast: &dyn Ast<'ctx>) -> Self {
+impl Dynamic {
+    pub fn from_ast(ast: &dyn Ast) -> Self {
         unsafe { Self::wrap(ast.get_ctx(), ast.get_z3_ast()) }
     }
 
-    pub fn new_const<S: Into<Symbol>>(ctx: &'ctx Context, name: S, sort: &Sort<'ctx>) -> Self {
+    pub fn new_const<S: Into<Symbol>>(ctx: &Context, name: S, sort: &Sort) -> Self {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_const(ctx.z3_ctx, name.into().as_z3_symbol(ctx), sort.z3_sort),
+                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(ctx), sort.z3_sort),
             )
         }
     }
 
-    pub fn fresh_const(ctx: &'ctx Context, prefix: &str, sort: &Sort<'ctx>) -> Self {
+    pub fn fresh_const(ctx: &Context, prefix: &str, sort: &Sort) -> Self {
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx, p, sort.z3_sort)
+                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort)
             })
         }
     }
 
     pub fn sort_kind(&self) -> SortKind {
-        unsafe { Z3_get_sort_kind(self.ctx.z3_ctx, Z3_get_sort(self.ctx.z3_ctx, self.z3_ast)) }
+        unsafe { Z3_get_sort_kind(self.ctx.z3_ctx.0, Z3_get_sort(self.ctx.z3_ctx.0, self.z3_ast)) }
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `Bool`
-    pub fn as_bool(&self) -> Option<Bool<'ctx>> {
+    pub fn as_bool(&self) -> Option<Bool> {
         match self.sort_kind() {
-            SortKind::Bool => Some(unsafe { Bool::wrap(self.ctx, self.z3_ast) }),
+            SortKind::Bool => Some(unsafe { Bool::wrap(&self.ctx, self.z3_ast) }),
             _ => None,
         }
     }
 
     /// Returns `None` if the `Dynamic` is not actually an `Int`
-    pub fn as_int(&self) -> Option<Int<'ctx>> {
+    pub fn as_int(&self) -> Option<Int> {
         match self.sort_kind() {
-            SortKind::Int => Some(unsafe { Int::wrap(self.ctx, self.z3_ast) }),
+            SortKind::Int => Some(unsafe { Int::wrap(&self.ctx, self.z3_ast) }),
             _ => None,
         }
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `Real`
-    pub fn as_real(&self) -> Option<Real<'ctx>> {
+    pub fn as_real(&self) -> Option<Real> {
         match self.sort_kind() {
-            SortKind::Real => Some(unsafe { Real::wrap(self.ctx, self.z3_ast) }),
+            SortKind::Real => Some(unsafe { Real::wrap(&self.ctx, self.z3_ast) }),
             _ => None,
         }
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `Float`
-    pub fn as_float(&self) -> Option<Float<'ctx>> {
+    pub fn as_float(&self) -> Option<Float> {
         match self.sort_kind() {
-            SortKind::FloatingPoint => Some(unsafe { Float::wrap(self.ctx, self.z3_ast) }),
+            SortKind::FloatingPoint => Some(unsafe { Float::wrap(&self.ctx, self.z3_ast) }),
             _ => None,
         }
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `String`
-    pub fn as_string(&self) -> Option<String<'ctx>> {
+    pub fn as_string(&self) -> Option<String> {
         unsafe {
-            if Z3_is_string_sort(self.ctx.z3_ctx, Z3_get_sort(self.ctx.z3_ctx, self.z3_ast)) {
-                Some(String::wrap(self.ctx, self.z3_ast))
+            if Z3_is_string_sort(self.ctx.z3_ctx.0, Z3_get_sort(self.ctx.z3_ctx.0, self.z3_ast)) {
+                Some(String::wrap(&self.ctx, self.z3_ast))
             } else {
                 None
             }
@@ -1983,34 +1979,34 @@ impl<'ctx> Dynamic<'ctx> {
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `BV`
-    pub fn as_bv(&self) -> Option<BV<'ctx>> {
+    pub fn as_bv(&self) -> Option<BV> {
         match self.sort_kind() {
-            SortKind::BV => Some(unsafe { BV::wrap(self.ctx, self.z3_ast) }),
+            SortKind::BV => Some(unsafe { BV::wrap(&self.ctx, self.z3_ast) }),
             _ => None,
         }
     }
 
     /// Returns `None` if the `Dynamic` is not actually an `Array`
-    pub fn as_array(&self) -> Option<Array<'ctx>> {
+    pub fn as_array(&self) -> Option<Array> {
         match self.sort_kind() {
-            SortKind::Array => Some(unsafe { Array::wrap(self.ctx, self.z3_ast) }),
+            SortKind::Array => Some(unsafe { Array::wrap(&self.ctx, self.z3_ast) }),
             _ => None,
         }
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `Set`
-    pub fn as_set(&self) -> Option<Set<'ctx>> {
+    pub fn as_set(&self) -> Option<Set> {
         unsafe {
             match self.sort_kind() {
                 SortKind::Array => {
                     match Z3_get_sort_kind(
-                        self.ctx.z3_ctx,
+                        self.ctx.z3_ctx.0,
                         Z3_get_array_sort_range(
-                            self.ctx.z3_ctx,
-                            Z3_get_sort(self.ctx.z3_ctx, self.z3_ast),
+                            self.ctx.z3_ctx.0,
+                            Z3_get_sort(self.ctx.z3_ctx.0, self.z3_ast),
                         ),
                     ) {
-                        SortKind::Bool => Some(Set::wrap(self.ctx, self.z3_ast)),
+                        SortKind::Bool => Some(Set::wrap(&self.ctx, self.z3_ast)),
                         _ => None,
                     }
                 }
@@ -2020,74 +2016,74 @@ impl<'ctx> Dynamic<'ctx> {
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `Seq`.
-    pub fn as_seq(&self) -> Option<Seq<'ctx>> {
+    pub fn as_seq(&self) -> Option<Seq> {
         match self.sort_kind() {
-            SortKind::Seq => Some(unsafe { Seq::wrap(self.ctx, self.z3_ast) }),
+            SortKind::Seq => Some(unsafe { Seq::wrap(&self.ctx, self.z3_ast) }),
             _ => None,
         }
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `Datatype`
-    pub fn as_datatype(&self) -> Option<Datatype<'ctx>> {
+    pub fn as_datatype(&self) -> Option<Datatype> {
         match self.sort_kind() {
-            SortKind::Datatype => Some(unsafe { Datatype::wrap(self.ctx, self.z3_ast) }),
+            SortKind::Datatype => Some(unsafe { Datatype::wrap(&self.ctx, self.z3_ast) }),
             _ => None,
         }
     }
 }
 
-impl<'ctx> Datatype<'ctx> {
-    pub fn new_const<S: Into<Symbol>>(ctx: &'ctx Context, name: S, sort: &Sort<'ctx>) -> Self {
-        assert_eq!(ctx, sort.ctx);
+impl Datatype {
+    pub fn new_const<S: Into<Symbol>>(ctx: &Context, name: S, sort: &Sort) -> Self {
+        assert_eq!(ctx, &sort.ctx);
         assert_eq!(sort.kind(), SortKind::Datatype);
 
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx, name.into().as_z3_symbol(ctx), sort.z3_sort)
+                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(ctx), sort.z3_sort)
             })
         }
     }
 
-    pub fn fresh_const(ctx: &'ctx Context, prefix: &str, sort: &Sort<'ctx>) -> Self {
-        assert_eq!(ctx, sort.ctx);
+    pub fn fresh_const(ctx: &Context, prefix: &str, sort: &Sort) -> Self {
+        assert_eq!(ctx, &sort.ctx);
         assert_eq!(sort.kind(), SortKind::Datatype);
 
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx, p, sort.z3_sort)
+                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort)
             })
         }
     }
 }
 
-impl<'ctx> Regexp<'ctx> {
+impl Regexp {
     /// Creates a regular expression that recognizes the string given as parameter
-    pub fn literal(ctx: &'ctx Context, s: &str) -> Self {
+    pub fn literal(ctx: &Context, s: &str) -> Self {
         unsafe {
             Self::wrap(ctx, {
                 let c_str = CString::new(s).unwrap();
-                Z3_mk_seq_to_re(ctx.z3_ctx, Z3_mk_string(ctx.z3_ctx, c_str.as_ptr()))
+                Z3_mk_seq_to_re(ctx.z3_ctx.0, Z3_mk_string(ctx.z3_ctx.0, c_str.as_ptr()))
             })
         }
     }
 
     /// Creates a regular expression that recognizes a character in the specified range (e.g.
     /// `[a-z]`)
-    pub fn range(ctx: &'ctx Context, lo: &char, hi: &char) -> Self {
+    pub fn range(ctx: &Context, lo: &char, hi: &char) -> Self {
         unsafe {
             Self::wrap(ctx, {
                 let lo_cs = CString::new(lo.to_string()).unwrap();
                 let hi_cs = CString::new(hi.to_string()).unwrap();
-                let lo_z3s = Z3_mk_string(ctx.z3_ctx, lo_cs.as_ptr());
-                Z3_inc_ref(ctx.z3_ctx, lo_z3s);
-                let hi_z3s = Z3_mk_string(ctx.z3_ctx, hi_cs.as_ptr());
-                Z3_inc_ref(ctx.z3_ctx, hi_z3s);
+                let lo_z3s = Z3_mk_string(ctx.z3_ctx.0, lo_cs.as_ptr());
+                Z3_inc_ref(ctx.z3_ctx.0, lo_z3s);
+                let hi_z3s = Z3_mk_string(ctx.z3_ctx.0, hi_cs.as_ptr());
+                Z3_inc_ref(ctx.z3_ctx.0, hi_z3s);
 
-                let ret = Z3_mk_re_range(ctx.z3_ctx, lo_z3s, hi_z3s);
-                Z3_dec_ref(ctx.z3_ctx, lo_z3s);
-                Z3_dec_ref(ctx.z3_ctx, hi_z3s);
+                let ret = Z3_mk_re_range(ctx.z3_ctx.0, lo_z3s, hi_z3s);
+                Z3_dec_ref(ctx.z3_ctx.0, lo_z3s);
+                Z3_dec_ref(ctx.z3_ctx.0, hi_z3s);
                 ret
             })
         }
@@ -2096,8 +2092,8 @@ impl<'ctx> Regexp<'ctx> {
     /// Creates a regular expression that recognizes this regular expression `lo` to `hi` times (e.g. `a{2,3}`)
     pub fn r#loop(&self, lo: u32, hi: u32) -> Self {
         unsafe {
-            Self::wrap(self.ctx, {
-                Z3_mk_re_loop(self.ctx.z3_ctx, self.z3_ast, lo, hi)
+            Self::wrap(&self.ctx, {
+                Z3_mk_re_loop(self.ctx.z3_ctx.0, self.z3_ast, lo, hi)
             })
         }
     }
@@ -2107,19 +2103,19 @@ impl<'ctx> Regexp<'ctx> {
     /// Requires Z3 4.8.15 or later.
     pub fn power(&self, n: u32) -> Self {
         unsafe {
-            Self::wrap(self.ctx, {
-                Z3_mk_re_power(self.ctx.z3_ctx, self.z3_ast, n)
+            Self::wrap(&self.ctx, {
+                Z3_mk_re_power(self.ctx.z3_ctx.0, self.z3_ast, n)
             })
         }
     }
 
     /// Creates a regular expression that recognizes all sequences
-    pub fn full(ctx: &'ctx Context) -> Self {
+    pub fn full(ctx: &Context) -> Self {
         unsafe {
             Self::wrap(ctx, {
                 Z3_mk_re_full(
-                    ctx.z3_ctx,
-                    Z3_mk_re_sort(ctx.z3_ctx, Z3_mk_string_sort(ctx.z3_ctx)),
+                    ctx.z3_ctx.0,
+                    Z3_mk_re_sort(ctx.z3_ctx.0, Z3_mk_string_sort(ctx.z3_ctx.0)),
                 )
             })
         }
@@ -2127,24 +2123,24 @@ impl<'ctx> Regexp<'ctx> {
 
     /// Creates a regular expression that accepts all singleton sequences of the characters
     /// Requires Z3 4.8.13 or later.
-    pub fn allchar(ctx: &'ctx Context) -> Self {
+    pub fn allchar(ctx: &Context) -> Self {
         unsafe {
             Self::wrap(ctx, {
                 Z3_mk_re_allchar(
-                    ctx.z3_ctx,
-                    Z3_mk_re_sort(ctx.z3_ctx, Z3_mk_string_sort(ctx.z3_ctx)),
+                    ctx.z3_ctx.0,
+                    Z3_mk_re_sort(ctx.z3_ctx.0, Z3_mk_string_sort(ctx.z3_ctx.0)),
                 )
             })
         }
     }
 
     /// Creates a regular expression that doesn't recognize any sequences
-    pub fn empty(ctx: &'ctx Context) -> Self {
+    pub fn empty(ctx: &Context) -> Self {
         unsafe {
             Self::wrap(ctx, {
                 Z3_mk_re_empty(
-                    ctx.z3_ctx,
-                    Z3_mk_re_sort(ctx.z3_ctx, Z3_mk_string_sort(ctx.z3_ctx)),
+                    ctx.z3_ctx.0,
+                    Z3_mk_re_sort(ctx.z3_ctx.0, Z3_mk_string_sort(ctx.z3_ctx.0)),
                 )
             })
         }
@@ -2203,19 +2199,19 @@ impl<'ctx> Regexp<'ctx> {
 /// solver.assert(&forall);
 ///
 /// assert_eq!(solver.check(), SatResult::Sat);
-/// let model = solver.get_model().unwrap();;
+/// let model = solver.get_model().unwrap();
 ///
 /// let f_f_3: ast::Int = f.apply(&[&f.apply(&[&ast::Int::from_u64(&ctx, 3)])]).try_into().unwrap();
 /// assert_eq!(3, model.eval(&f_f_3, true).unwrap().as_u64().unwrap());
 /// ```
-pub fn forall_const<'ctx>(
-    ctx: &'ctx Context,
-    bounds: &[&dyn Ast<'ctx>],
-    patterns: &[&Pattern<'ctx>],
-    body: &Bool<'ctx>,
-) -> Bool<'ctx> {
+pub fn forall_const(
+    ctx: &Context,
+    bounds: &[&dyn Ast],
+    patterns: &[&Pattern],
+    body: &Bool,
+) -> Bool {
     assert!(bounds.iter().all(|a| a.get_ctx() == ctx));
-    assert!(patterns.iter().all(|p| p.ctx == ctx));
+    assert!(patterns.iter().all(|p| &p.ctx == ctx));
     assert_eq!(ctx, body.get_ctx());
 
     if bounds.is_empty() {
@@ -2228,7 +2224,7 @@ pub fn forall_const<'ctx>(
     unsafe {
         Ast::wrap(ctx, {
             Z3_mk_forall_const(
-                ctx.z3_ctx,
+                ctx.z3_ctx.0,
                 0,
                 bounds.len().try_into().unwrap(),
                 bounds.as_ptr() as *const Z3_app,
@@ -2264,19 +2260,19 @@ pub fn forall_const<'ctx>(
 /// solver.assert(&exists.not());
 ///
 /// assert_eq!(solver.check(), SatResult::Sat);
-/// let model = solver.get_model().unwrap();;
+/// let model = solver.get_model().unwrap();
 ///
 /// let f_f_3: ast::Int = f.apply(&[&f.apply(&[&ast::Int::from_u64(&ctx, 3)])]).try_into().unwrap();
 /// assert_eq!(3, model.eval(&f_f_3, true).unwrap().as_u64().unwrap());
 /// ```
-pub fn exists_const<'ctx>(
-    ctx: &'ctx Context,
-    bounds: &[&dyn Ast<'ctx>],
-    patterns: &[&Pattern<'ctx>],
-    body: &Bool<'ctx>,
-) -> Bool<'ctx> {
+pub fn exists_const(
+    ctx: &Context,
+    bounds: &[&dyn Ast],
+    patterns: &[&Pattern],
+    body: &Bool,
+) -> Bool {
     assert!(bounds.iter().all(|a| a.get_ctx() == ctx));
-    assert!(patterns.iter().all(|p| p.ctx == ctx));
+    assert!(patterns.iter().all(|p| &p.ctx == ctx));
     assert_eq!(ctx, body.get_ctx());
 
     if bounds.is_empty() {
@@ -2289,7 +2285,7 @@ pub fn exists_const<'ctx>(
     unsafe {
         Ast::wrap(ctx, {
             Z3_mk_exists_const(
-                ctx.z3_ctx,
+                ctx.z3_ctx.0,
                 0,
                 bounds.len().try_into().unwrap(),
                 bounds.as_ptr() as *const Z3_app,
@@ -2340,25 +2336,25 @@ pub fn exists_const<'ctx>(
 /// solver.assert(&forall);
 ///
 /// assert_eq!(solver.check(), SatResult::Sat);
-/// let model = solver.get_model().unwrap();;
+/// let model = solver.get_model().unwrap();
 ///
 /// let f_f_3: ast::Int = f.apply(&[&f.apply(&[&ast::Int::from_u64(&ctx, 3)])]).try_into().unwrap();
 /// assert_eq!(3, model.eval(&f_f_3, true).unwrap().as_u64().unwrap());
 /// ```
 #[allow(clippy::too_many_arguments)]
-pub fn quantifier_const<'ctx>(
-    ctx: &'ctx Context,
+pub fn quantifier_const(
+    ctx: &Context,
     is_forall: bool,
     weight: u32,
     quantifier_id: impl Into<Symbol>,
     skolem_id: impl Into<Symbol>,
-    bounds: &[&dyn Ast<'ctx>],
-    patterns: &[&Pattern<'ctx>],
-    no_patterns: &[&dyn Ast<'ctx>],
-    body: &Bool<'ctx>,
-) -> Bool<'ctx> {
+    bounds: &[&dyn Ast],
+    patterns: &[&Pattern],
+    no_patterns: &[&dyn Ast],
+    body: &Bool,
+) -> Bool {
     assert!(bounds.iter().all(|a| a.get_ctx() == ctx));
-    assert!(patterns.iter().all(|p| p.ctx == ctx));
+    assert!(patterns.iter().all(|p| &p.ctx == ctx));
     assert!(no_patterns.iter().all(|p| p.get_ctx() == ctx));
     assert_eq!(ctx, body.get_ctx());
 
@@ -2373,7 +2369,7 @@ pub fn quantifier_const<'ctx>(
     unsafe {
         Ast::wrap(ctx, {
             Z3_mk_quantifier_const_ex(
-                ctx.z3_ctx,
+                ctx.z3_ctx.0,
                 is_forall,
                 weight,
                 quantifier_id.into().as_z3_symbol(ctx),
@@ -2429,18 +2425,18 @@ pub fn quantifier_const<'ctx>(
 ///
 /// assert_eq!(solver.check(), SatResult::Unsat);
 /// ```
-pub fn lambda_const<'ctx>(
-    ctx: &'ctx Context,
-    bounds: &[&dyn Ast<'ctx>],
-    body: &Dynamic<'ctx>,
-) -> Array<'ctx> {
+pub fn lambda_const(
+    ctx: &Context,
+    bounds: &[&dyn Ast],
+    body: &Dynamic,
+) -> Array {
     let bounds: Vec<_> = bounds.iter().map(|a| a.get_z3_ast()).collect();
 
     unsafe {
         Ast::wrap(
             ctx,
             Z3_mk_lambda_const(
-                ctx.z3_ctx,
+                ctx.z3_ctx.0,
                 bounds.len().try_into().unwrap(),
                 bounds.as_ptr() as *const Z3_app,
                 body.get_z3_ast(),

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -6,7 +6,7 @@ use z3_sys::*;
 use crate::{Config, ContextHandle};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct ContextInternal(pub(crate) Z3_context);
+pub(crate) struct ContextInternal(pub(crate) Z3_context);
 
 impl Drop for ContextInternal {
     fn drop(&mut self) {
@@ -36,7 +36,7 @@ impl Drop for ContextInternal {
 /// - [`Context::new()`]
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Context {
-    pub z3_ctx: Rc<ContextInternal>,
+    pub(crate) z3_ctx: Rc<ContextInternal>,
 }
 impl Context {
     pub fn new(cfg: &Config) -> Context {

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -6,7 +6,7 @@ use z3_sys::*;
 use crate::{Config, ContextHandle};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct ContextInternal(Z3_context);
+struct ContextInternal(pub(crate) Z3_context);
 
 impl Drop for ContextInternal {
     fn drop(&mut self) {
@@ -34,7 +34,7 @@ impl Drop for ContextInternal {
 ///
 /// - [`Config`]
 /// - [`Context::new()`]
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Context {
     pub z3_ctx: Rc<ContextInternal>,
 }

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -52,6 +52,37 @@ impl Context {
         }
     }
 
+    /// Construct a `Context` from a raw `Z3_context` pointer. This is mostly useful for
+    /// consumers who want to interoperate with Z3 contexts created through other means,
+    /// such as the C API or other bindings such as Python.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the pointer is valid and not already managed elsewhere.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use z3::ast::Bool;
+    /// use z3_sys::{Z3_mk_config, Z3_del_config, Z3_mk_context_rc};
+    /// use z3::Context;
+    ///
+    /// // Create a raw Z3_config using the low-level API
+    /// let cfg = unsafe { Z3_mk_config() };
+    /// let raw_ctx = unsafe { Z3_mk_context_rc(cfg) };
+    /// let ctx = unsafe { Context::from_raw(raw_ctx) };
+    /// // Use `ctx` as usual...
+    /// unsafe { Z3_del_config(cfg) };
+    /// let b = Bool::from_bool(&ctx, true);
+    /// assert_eq!(b.as_bool(), Some(true));
+    /// ```
+    pub unsafe fn from_raw(z3_ctx: Z3_context) -> Context {
+        debug!("from_raw context {z3_ctx:p}");
+        Context {
+            z3_ctx: Rc::new(ContextInternal(z3_ctx)),
+        }
+    }
+
     pub fn get_z3_context(&self) -> Z3_context {
         self.z3_ctx.0
     }

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -104,8 +104,3 @@ impl ContextHandle<'_> {
 unsafe impl Sync for ContextHandle<'_> {}
 unsafe impl Send for ContextHandle<'_> {}
 
-impl Drop for Context {
-    fn drop(&mut self) {
-        unsafe { Z3_del_context(self.z3_ctx.0) };
-    }
-}

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -105,4 +105,3 @@ impl ContextHandle<'_> {
 
 unsafe impl Sync for ContextHandle<'_> {}
 unsafe impl Send for ContextHandle<'_> {}
-

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -5,6 +5,8 @@ use z3_sys::*;
 
 use crate::{Config, ContextHandle};
 
+/// A wrapper around [Z3_context] that enforces proper dropping behavior.
+/// All high-level code should instead use [Context](crate::Context)
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ContextInternal(pub(crate) Z3_context);
 

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -52,7 +52,7 @@ impl Context {
         }
     }
 
-    /// Construct a `Context` from a raw `Z3_context` pointer. This is mostly useful for
+    /// Construct a [`Context`] from a raw [`Z3_context`] pointer. This is mostly useful for
     /// consumers who want to interoperate with Z3 contexts created through other means,
     /// such as the C API or other bindings such as Python.
     ///

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -5,8 +5,8 @@ use z3_sys::*;
 
 use crate::{Config, ContextHandle};
 
-/// A wrapper around [Z3_context] that enforces proper dropping behavior.
-/// All high-level code should instead use [Context](crate::Context)
+/// A wrapper around [`Z3_context`] that enforces proper dropping behavior.
+/// All high-level code should instead use [`Context`]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ContextInternal(pub(crate) Z3_context);
 

--- a/z3/src/datatype_builder.rs
+++ b/z3/src/datatype_builder.rs
@@ -9,17 +9,17 @@ use crate::{
     Symbol,
 };
 
-impl<'ctx> DatatypeBuilder<'ctx> {
-    pub fn new<S: Into<Symbol>>(ctx: &'ctx Context, name: S) -> Self {
+impl DatatypeBuilder {
+    pub fn new<S: Into<Symbol>>(ctx: &Context, name: S) -> Self {
         Self {
-            ctx,
+            ctx: ctx.clone(),
             name: name.into(),
             constructors: Vec::new(),
         }
     }
 
-    pub fn variant(mut self, name: &str, fields: Vec<(&str, DatatypeAccessor<'ctx>)>) -> Self {
-        let mut accessor_vec: Vec<(String, DatatypeAccessor<'ctx>)> = Vec::new();
+    pub fn variant(mut self, name: &str, fields: Vec<(&str, DatatypeAccessor)>) -> Self {
+        let mut accessor_vec: Vec<(String, DatatypeAccessor)> = Vec::new();
         for (accessor_name, accessor) in fields {
             accessor_vec.push((accessor_name.to_string(), accessor));
         }
@@ -29,19 +29,19 @@ impl<'ctx> DatatypeBuilder<'ctx> {
         self
     }
 
-    pub fn finish(self) -> DatatypeSort<'ctx> {
+    pub fn finish(self) -> DatatypeSort {
         let mut dtypes = create_datatypes(vec![self]);
         dtypes.remove(0)
     }
 }
 
-pub fn create_datatypes<'ctx>(
-    datatype_builders: Vec<DatatypeBuilder<'ctx>>,
-) -> Vec<DatatypeSort<'ctx>> {
+pub fn create_datatypes(
+    datatype_builders: Vec<DatatypeBuilder>,
+) -> Vec<DatatypeSort> {
     let num = datatype_builders.len();
     assert!(num > 0, "At least one DatatypeBuilder must be specified");
 
-    let ctx: &'ctx Context = datatype_builders[0].ctx;
+    let ctx: Context = datatype_builders[0].ctx.clone();
     let mut names: Vec<Z3_symbol> = Vec::with_capacity(num);
 
     let mut raw_sorts: Vec<Z3_sort> = Vec::with_capacity(num);
@@ -53,7 +53,7 @@ pub fn create_datatypes<'ctx>(
     let mut ctors: Vec<Z3_constructor> = Vec::with_capacity(num * 2);
 
     for d in datatype_builders.iter() {
-        names.push(d.name.as_z3_symbol(ctx));
+        names.push(d.name.as_z3_symbol(&ctx));
         let num_cs = d.constructors.len();
         let mut cs: Vec<Z3_constructor> = Vec::with_capacity(num_cs);
 
@@ -61,8 +61,8 @@ pub fn create_datatypes<'ctx>(
             let mut rname: String = "is-".to_string();
             rname.push_str(cname);
 
-            let cname_symbol: Z3_symbol = Symbol::String(cname.clone()).as_z3_symbol(ctx);
-            let rname_symbol: Z3_symbol = Symbol::String(rname).as_z3_symbol(ctx);
+            let cname_symbol: Z3_symbol = Symbol::String(cname.clone()).as_z3_symbol(&ctx);
+            let rname_symbol: Z3_symbol = Symbol::String(rname).as_z3_symbol(&ctx);
 
             let num_fs = fs.len();
             let mut field_names: Vec<Z3_symbol> = Vec::with_capacity(num_fs);
@@ -70,7 +70,7 @@ pub fn create_datatypes<'ctx>(
             let mut sort_refs: Vec<::std::os::raw::c_uint> = Vec::with_capacity(num_fs);
 
             for (fname, accessor) in fs {
-                field_names.push(Symbol::String(fname.clone()).as_z3_symbol(ctx));
+                field_names.push(Symbol::String(fname.clone()).as_z3_symbol(&ctx));
                 match accessor {
                     DatatypeAccessor::Datatype(dtype_name) => {
                         field_sorts.push(null_mut());
@@ -99,7 +99,7 @@ pub fn create_datatypes<'ctx>(
 
             let constructor = unsafe {
                 Z3_mk_constructor(
-                    ctx.z3_ctx,
+                    ctx.z3_ctx.0,
                     cname_symbol,
                     rname_symbol,
                     num_fs.try_into().unwrap(),
@@ -113,7 +113,7 @@ pub fn create_datatypes<'ctx>(
         assert!(!cs.is_empty());
 
         let clist = unsafe {
-            Z3_mk_constructor_list(ctx.z3_ctx, num_cs.try_into().unwrap(), cs.as_mut_ptr())
+            Z3_mk_constructor_list(ctx.z3_ctx.0, num_cs.try_into().unwrap(), cs.as_mut_ptr())
         };
         clists.push(clist);
         ctors.extend(cs);
@@ -124,7 +124,7 @@ pub fn create_datatypes<'ctx>(
 
     unsafe {
         Z3_mk_datatypes(
-            ctx.z3_ctx,
+            ctx.z3_ctx.0,
             num.try_into().unwrap(),
             names.as_ptr(),
             raw_sorts.as_mut_ptr(),
@@ -133,40 +133,40 @@ pub fn create_datatypes<'ctx>(
         raw_sorts.set_len(num);
     };
 
-    let mut datatype_sorts: Vec<DatatypeSort<'ctx>> = Vec::with_capacity(raw_sorts.len());
+    let mut datatype_sorts: Vec<DatatypeSort> = Vec::with_capacity(raw_sorts.len());
     for (z3_sort, datatype_builder) in raw_sorts.into_iter().zip(&datatype_builders) {
         let num_cs = datatype_builder.constructors.len();
 
-        unsafe { Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, z3_sort)) };
-        let sort = Sort { ctx, z3_sort };
+        unsafe { Z3_inc_ref(ctx.z3_ctx.0, Z3_sort_to_ast(ctx.z3_ctx.0, z3_sort)) };
+        let sort = Sort { ctx: ctx.clone(), z3_sort };
 
-        let mut variants: Vec<DatatypeVariant<'ctx>> = Vec::with_capacity(num_cs);
+        let mut variants: Vec<DatatypeVariant> = Vec::with_capacity(num_cs);
 
         for (j, (_cname, fs)) in datatype_builder.constructors.iter().enumerate() {
             let num_fs = fs.len();
 
             let raw_constructor: Z3_func_decl = unsafe {
-                Z3_get_datatype_sort_constructor(ctx.z3_ctx, z3_sort, j.try_into().unwrap())
+                Z3_get_datatype_sort_constructor(ctx.z3_ctx.0, z3_sort, j.try_into().unwrap())
             };
-            let constructor: FuncDecl<'ctx> = unsafe { FuncDecl::wrap(ctx, raw_constructor) };
+            let constructor: FuncDecl = unsafe { FuncDecl::wrap(&ctx, raw_constructor) };
 
             let tester_func: Z3_func_decl = unsafe {
-                Z3_get_datatype_sort_recognizer(ctx.z3_ctx, z3_sort, j.try_into().unwrap())
+                Z3_get_datatype_sort_recognizer(ctx.z3_ctx.0, z3_sort, j.try_into().unwrap())
             };
-            let tester = unsafe { FuncDecl::wrap(ctx, tester_func) };
+            let tester = unsafe { FuncDecl::wrap(&ctx, tester_func) };
 
-            let mut accessors: Vec<FuncDecl<'ctx>> = Vec::new();
+            let mut accessors: Vec<FuncDecl> = Vec::new();
             for k in 0..num_fs {
                 let accessor_func: Z3_func_decl = unsafe {
                     Z3_get_datatype_sort_constructor_accessor(
-                        ctx.z3_ctx,
+                        ctx.z3_ctx.0,
                         z3_sort,
                         j.try_into().unwrap(),
                         k.try_into().unwrap(),
                     )
                 };
 
-                accessors.push(unsafe { FuncDecl::wrap(ctx, accessor_func) });
+                accessors.push(unsafe { FuncDecl::wrap(&ctx, accessor_func) });
             }
 
             variants.push(DatatypeVariant {
@@ -181,13 +181,13 @@ pub fn create_datatypes<'ctx>(
 
     for ctor in ctors {
         unsafe {
-            Z3_del_constructor(ctx.z3_ctx, ctor);
+            Z3_del_constructor(ctx.z3_ctx.0, ctor);
         }
     }
 
     for clist in clists {
         unsafe {
-            Z3_del_constructor_list(ctx.z3_ctx, clist);
+            Z3_del_constructor_list(ctx.z3_ctx.0, clist);
         }
     }
 

--- a/z3/src/datatype_builder.rs
+++ b/z3/src/datatype_builder.rs
@@ -35,9 +35,7 @@ impl DatatypeBuilder {
     }
 }
 
-pub fn create_datatypes(
-    datatype_builders: Vec<DatatypeBuilder>,
-) -> Vec<DatatypeSort> {
+pub fn create_datatypes(datatype_builders: Vec<DatatypeBuilder>) -> Vec<DatatypeSort> {
     let num = datatype_builders.len();
     assert!(num > 0, "At least one DatatypeBuilder must be specified");
 
@@ -138,7 +136,10 @@ pub fn create_datatypes(
         let num_cs = datatype_builder.constructors.len();
 
         unsafe { Z3_inc_ref(ctx.z3_ctx.0, Z3_sort_to_ast(ctx.z3_ctx.0, z3_sort)) };
-        let sort = Sort { ctx: ctx.clone(), z3_sort };
+        let sort = Sort {
+            ctx: ctx.clone(),
+            z3_sort,
+        };
 
         let mut variants: Vec<DatatypeVariant> = Vec::with_capacity(num_cs);
 

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -6,30 +6,29 @@ use z3_sys::*;
 
 use crate::{Context, FuncDecl, Sort, Symbol, ast, ast::Ast};
 
-impl<'ctx> FuncDecl<'ctx> {
-    pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_func_decl: Z3_func_decl) -> Self {
+impl FuncDecl {
+    pub(crate) unsafe fn wrap(ctx: &Context, z3_func_decl: Z3_func_decl) -> Self {
         unsafe {
-            Z3_inc_ref(ctx.z3_ctx, Z3_func_decl_to_ast(ctx.z3_ctx, z3_func_decl));
+            Z3_inc_ref(ctx.z3_ctx.0, Z3_func_decl_to_ast(ctx.z3_ctx.0, z3_func_decl));
         }
-        Self { ctx, z3_func_decl }
+        Self { ctx: ctx.clone(), z3_func_decl }
     }
 
     pub fn new<S: Into<Symbol>>(
-        ctx: &'ctx Context,
+        ctx: &Context,
         name: S,
-        domain: &[&Sort<'ctx>],
-        range: &Sort<'ctx>,
+        domain: &[&Sort],
+        range: &Sort,
     ) -> Self {
         assert!(domain.iter().all(|s| s.ctx.z3_ctx == ctx.z3_ctx));
         assert_eq!(ctx.z3_ctx, range.ctx.z3_ctx);
 
         let domain: Vec<_> = domain.iter().map(|s| s.z3_sort).collect();
-
         unsafe {
             Self::wrap(
                 ctx,
                 Z3_mk_func_decl(
-                    ctx.z3_ctx,
+                    ctx.z3_ctx.0,
                     name.into().as_z3_symbol(ctx),
                     domain.len().try_into().unwrap(),
                     domain.as_ptr(),
@@ -55,21 +54,21 @@ impl<'ctx> FuncDecl<'ctx> {
     /// assert_eq!(f.arity(), 2);
     /// ```
     pub fn arity(&self) -> usize {
-        unsafe { Z3_get_arity(self.ctx.z3_ctx, self.z3_func_decl) as usize }
+        unsafe { Z3_get_arity(self.ctx.z3_ctx.0, self.z3_func_decl) as usize }
     }
 
     /// Create a constant (if `args` has length 0) or function application (otherwise).
     ///
     /// Note that `args` should have the types corresponding to the `domain` of the `FuncDecl`.
-    pub fn apply(&self, args: &[&dyn ast::Ast<'ctx>]) -> ast::Dynamic<'ctx> {
+    pub fn apply(&self, args: &[&dyn ast::Ast]) -> ast::Dynamic {
         assert!(args.iter().all(|s| s.get_ctx().z3_ctx == self.ctx.z3_ctx));
 
         let args: Vec<_> = args.iter().map(|a| a.get_z3_ast()).collect();
 
         unsafe {
-            ast::Dynamic::wrap(self.ctx, {
+            ast::Dynamic::wrap(&self.ctx, {
                 Z3_mk_app(
-                    self.ctx.z3_ctx,
+                    self.ctx.z3_ctx.0,
                     self.z3_func_decl,
                     args.len().try_into().unwrap(),
                     args.as_ptr(),
@@ -80,7 +79,7 @@ impl<'ctx> FuncDecl<'ctx> {
 
     /// Return the `DeclKind` of this `FuncDecl`.
     pub fn kind(&self) -> DeclKind {
-        unsafe { Z3_get_decl_kind(self.ctx.z3_ctx, self.z3_func_decl) }
+        unsafe { Z3_get_decl_kind(self.ctx.z3_ctx.0, self.z3_func_decl) }
     }
 
     /// Return the name of this `FuncDecl`.
@@ -89,7 +88,7 @@ impl<'ctx> FuncDecl<'ctx> {
     /// the `Symbol`.
     pub fn name(&self) -> String {
         unsafe {
-            let z3_ctx = self.ctx.z3_ctx;
+            let z3_ctx = self.ctx.z3_ctx.0;
             let symbol = Z3_get_decl_name(z3_ctx, self.z3_func_decl);
             match Z3_get_symbol_kind(z3_ctx, symbol) {
                 SymbolKind::String => CStr::from_ptr(Z3_get_symbol_string(z3_ctx, symbol))
@@ -101,9 +100,9 @@ impl<'ctx> FuncDecl<'ctx> {
     }
 }
 
-impl fmt::Display for FuncDecl<'_> {
+impl fmt::Display for FuncDecl {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_func_decl_to_string(self.ctx.z3_ctx, self.z3_func_decl) };
+        let p = unsafe { Z3_func_decl_to_string(self.ctx.z3_ctx.0, self.z3_func_decl) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -114,18 +113,18 @@ impl fmt::Display for FuncDecl<'_> {
     }
 }
 
-impl fmt::Debug for FuncDecl<'_> {
+impl fmt::Debug for FuncDecl {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         <Self as fmt::Display>::fmt(self, f)
     }
 }
 
-impl Drop for FuncDecl<'_> {
+impl Drop for FuncDecl {
     fn drop(&mut self) {
         unsafe {
             Z3_dec_ref(
-                self.ctx.z3_ctx,
-                Z3_func_decl_to_ast(self.ctx.z3_ctx, self.z3_func_decl),
+                self.ctx.z3_ctx.0,
+                Z3_func_decl_to_ast(self.ctx.z3_ctx.0, self.z3_func_decl),
             );
         }
     }

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -9,17 +9,18 @@ use crate::{Context, FuncDecl, Sort, Symbol, ast, ast::Ast};
 impl FuncDecl {
     pub(crate) unsafe fn wrap(ctx: &Context, z3_func_decl: Z3_func_decl) -> Self {
         unsafe {
-            Z3_inc_ref(ctx.z3_ctx.0, Z3_func_decl_to_ast(ctx.z3_ctx.0, z3_func_decl));
+            Z3_inc_ref(
+                ctx.z3_ctx.0,
+                Z3_func_decl_to_ast(ctx.z3_ctx.0, z3_func_decl),
+            );
         }
-        Self { ctx: ctx.clone(), z3_func_decl }
+        Self {
+            ctx: ctx.clone(),
+            z3_func_decl,
+        }
     }
 
-    pub fn new<S: Into<Symbol>>(
-        ctx: &Context,
-        name: S,
-        domain: &[&Sort],
-        range: &Sort,
-    ) -> Self {
+    pub fn new<S: Into<Symbol>>(ctx: &Context, name: S, domain: &[&Sort], range: &Sort) -> Self {
         assert!(domain.iter().all(|s| s.ctx.z3_ctx == ctx.z3_ctx));
         assert_eq!(ctx.z3_ctx, range.ctx.z3_ctx);
 

--- a/z3/src/func_entry.rs
+++ b/z3/src/func_entry.rs
@@ -12,7 +12,10 @@ impl FuncEntry {
         unsafe {
             Z3_func_entry_inc_ref(ctx.z3_ctx.0, z3_func_entry);
         }
-        Self { ctx: ctx.clone(), z3_func_entry }
+        Self {
+            ctx: ctx.clone(),
+            z3_func_entry,
+        }
     }
 
     /// Returns the value of the function.

--- a/z3/src/func_entry.rs
+++ b/z3/src/func_entry.rs
@@ -7,43 +7,43 @@ use crate::{
     ast::{Ast, Dynamic},
 };
 
-impl<'ctx> FuncEntry<'ctx> {
-    pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_func_entry: Z3_func_entry) -> Self {
+impl FuncEntry {
+    pub(crate) unsafe fn wrap(ctx: &Context, z3_func_entry: Z3_func_entry) -> Self {
         unsafe {
-            Z3_func_entry_inc_ref(ctx.z3_ctx, z3_func_entry);
+            Z3_func_entry_inc_ref(ctx.z3_ctx.0, z3_func_entry);
         }
-        Self { ctx, z3_func_entry }
+        Self { ctx: ctx.clone(), z3_func_entry }
     }
 
     /// Returns the value of the function.
-    pub fn get_value(&self) -> Dynamic<'_> {
+    pub fn get_value(&self) -> Dynamic {
         unsafe {
             Dynamic::wrap(
-                self.ctx,
-                Z3_func_entry_get_value(self.ctx.z3_ctx, self.z3_func_entry),
+                &self.ctx,
+                Z3_func_entry_get_value(self.ctx.z3_ctx.0, self.z3_func_entry),
             )
         }
     }
 
     /// Returns the number of arguments in the function entry.
     pub fn get_num_args(&self) -> u32 {
-        unsafe { Z3_func_entry_get_num_args(self.ctx.z3_ctx, self.z3_func_entry) }
+        unsafe { Z3_func_entry_get_num_args(self.ctx.z3_ctx.0, self.z3_func_entry) }
     }
 
     /// Returns the arguments of the function entry.
-    pub fn get_args(&self) -> Vec<Dynamic<'_>> {
+    pub fn get_args(&self) -> Vec<Dynamic> {
         (0..self.get_num_args())
             .map(|i| unsafe {
                 Dynamic::wrap(
-                    self.ctx,
-                    Z3_func_entry_get_arg(self.ctx.z3_ctx, self.z3_func_entry, i),
+                    &self.ctx,
+                    Z3_func_entry_get_arg(self.ctx.z3_ctx.0, self.z3_func_entry, i),
                 )
             })
             .collect()
     }
 }
 
-impl fmt::Display for FuncEntry<'_> {
+impl fmt::Display for FuncEntry {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "[")?;
         self.get_args()
@@ -54,16 +54,16 @@ impl fmt::Display for FuncEntry<'_> {
     }
 }
 
-impl fmt::Debug for FuncEntry<'_> {
+impl fmt::Debug for FuncEntry {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         <Self as fmt::Display>::fmt(self, f)
     }
 }
 
-impl Drop for FuncEntry<'_> {
+impl Drop for FuncEntry {
     fn drop(&mut self) {
         unsafe {
-            Z3_func_entry_dec_ref(self.ctx.z3_ctx, self.z3_func_entry);
+            Z3_func_entry_dec_ref(self.ctx.z3_ctx.0, self.z3_func_entry);
         }
     }
 }

--- a/z3/src/func_interp.rs
+++ b/z3/src/func_interp.rs
@@ -7,47 +7,47 @@ use crate::{
     ast::{Ast, Dynamic},
 };
 
-impl<'ctx> FuncInterp<'ctx> {
-    pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_func_interp: Z3_func_interp) -> Self {
+impl FuncInterp {
+    pub(crate) unsafe fn wrap(ctx: &Context, z3_func_interp: Z3_func_interp) -> Self {
         unsafe {
-            Z3_func_interp_inc_ref(ctx.z3_ctx, z3_func_interp);
+            Z3_func_interp_inc_ref(ctx.z3_ctx.0, z3_func_interp);
         }
 
         Self {
-            ctx,
+            ctx: ctx.clone(),
             z3_func_interp,
         }
     }
 
     /// Returns the number of arguments in the function interpretation.
     pub fn get_arity(&self) -> usize {
-        unsafe { Z3_func_interp_get_arity(self.ctx.z3_ctx, self.z3_func_interp) as usize }
+        unsafe { Z3_func_interp_get_arity(self.ctx.z3_ctx.0, self.z3_func_interp) as usize }
     }
 
     /// Returns the number of entries in the function interpretation.
     pub fn get_num_entries(&self) -> u32 {
-        unsafe { Z3_func_interp_get_num_entries(self.ctx.z3_ctx, self.z3_func_interp) }
+        unsafe { Z3_func_interp_get_num_entries(self.ctx.z3_ctx.0, self.z3_func_interp) }
     }
 
     /// Adds an entry to the function interpretation.
-    pub fn add_entry(&self, args: &[Dynamic<'ctx>], value: &Dynamic<'ctx>) {
+    pub fn add_entry(&self, args: &[Dynamic], value: &Dynamic) {
         unsafe {
-            let v = Z3_mk_ast_vector(self.ctx.z3_ctx);
-            Z3_ast_vector_inc_ref(self.ctx.z3_ctx, v);
+            let v = Z3_mk_ast_vector(self.ctx.z3_ctx.0);
+            Z3_ast_vector_inc_ref(self.ctx.z3_ctx.0, v);
             args.iter()
-                .for_each(|a| Z3_ast_vector_push(self.ctx.z3_ctx, v, a.z3_ast));
+                .for_each(|a| Z3_ast_vector_push(self.ctx.z3_ctx.0, v, a.z3_ast));
 
-            Z3_func_interp_add_entry(self.ctx.z3_ctx, self.z3_func_interp, v, value.z3_ast);
+            Z3_func_interp_add_entry(self.ctx.z3_ctx.0, self.z3_func_interp, v, value.z3_ast);
         }
     }
 
     /// Returns the entries of the function interpretation.
-    pub fn get_entries(&self) -> Vec<FuncEntry<'_>> {
+    pub fn get_entries(&self) -> Vec<FuncEntry> {
         (0..self.get_num_entries())
             .map(|i| unsafe {
                 FuncEntry::wrap(
-                    self.ctx,
-                    Z3_func_interp_get_entry(self.ctx.z3_ctx, self.z3_func_interp, i),
+                    &self.ctx,
+                    Z3_func_interp_get_entry(self.ctx.z3_ctx.0, self.z3_func_interp, i),
                 )
             })
             .collect()
@@ -55,22 +55,22 @@ impl<'ctx> FuncInterp<'ctx> {
 
     /// Returns the else value of the function interpretation.
     /// Returns None if the else value is not set by Z3.
-    pub fn get_else(&self) -> Dynamic<'ctx> {
+    pub fn get_else(&self) -> Dynamic {
         unsafe {
             Dynamic::wrap(
-                self.ctx,
-                Z3_func_interp_get_else(self.ctx.z3_ctx, self.z3_func_interp),
+                &self.ctx,
+                Z3_func_interp_get_else(self.ctx.z3_ctx.0, self.z3_func_interp),
             )
         }
     }
 
     /// Sets the else value of the function interpretation.
     pub fn set_else(&self, ast: &Dynamic) {
-        unsafe { Z3_func_interp_set_else(self.ctx.z3_ctx, self.z3_func_interp, ast.z3_ast) }
+        unsafe { Z3_func_interp_set_else(self.ctx.z3_ctx.0, self.z3_func_interp, ast.z3_ast) }
     }
 }
 
-impl fmt::Display for FuncInterp<'_> {
+impl fmt::Display for FuncInterp {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "[")?;
         self.get_entries().into_iter().try_for_each(|e| {
@@ -97,16 +97,16 @@ impl fmt::Display for FuncInterp<'_> {
     }
 }
 
-impl fmt::Debug for FuncInterp<'_> {
+impl fmt::Debug for FuncInterp {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         <Self as fmt::Display>::fmt(self, f)
     }
 }
 
-impl Drop for FuncInterp<'_> {
+impl Drop for FuncInterp {
     fn drop(&mut self) {
         unsafe {
-            Z3_func_interp_dec_ref(self.ctx.z3_ctx, self.z3_func_interp);
+            Z3_func_interp_dec_ref(self.ctx.z3_ctx.0, self.z3_func_interp);
         }
     }
 }

--- a/z3/src/goal.rs
+++ b/z3/src/goal.rs
@@ -5,7 +5,6 @@ use z3_sys::*;
 
 use crate::{Context, Goal, ast, ast::Ast};
 
-
 // todo: is this sound? This should be through `wrap`, no?
 impl Clone for Goal {
     fn clone(&self) -> Self {
@@ -21,7 +20,10 @@ impl Goal {
         unsafe {
             Z3_goal_inc_ref(ctx.z3_ctx.0, z3_goal);
         }
-        Goal { ctx: ctx.clone(), z3_goal }
+        Goal {
+            ctx: ctx.clone(),
+            z3_goal,
+        }
     }
 
     pub fn new(ctx: &Context, models: bool, unsat_cores: bool, proofs: bool) -> Goal {

--- a/z3/src/goal.rs
+++ b/z3/src/goal.rs
@@ -5,115 +5,117 @@ use z3_sys::*;
 
 use crate::{Context, Goal, ast, ast::Ast};
 
-impl Clone for Goal<'_> {
+
+// todo: is this sound? This should be through `wrap`, no?
+impl Clone for Goal {
     fn clone(&self) -> Self {
         Self {
-            ctx: self.ctx,
+            ctx: self.ctx.clone(),
             z3_goal: self.z3_goal,
         }
     }
 }
 
-impl<'ctx> Goal<'ctx> {
-    pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_goal: Z3_goal) -> Goal<'ctx> {
+impl Goal {
+    pub(crate) unsafe fn wrap(ctx: &Context, z3_goal: Z3_goal) -> Goal {
         unsafe {
-            Z3_goal_inc_ref(ctx.z3_ctx, z3_goal);
+            Z3_goal_inc_ref(ctx.z3_ctx.0, z3_goal);
         }
-        Goal { ctx, z3_goal }
+        Goal { ctx: ctx.clone(), z3_goal }
     }
 
-    pub fn new(ctx: &'ctx Context, models: bool, unsat_cores: bool, proofs: bool) -> Goal<'ctx> {
+    pub fn new(ctx: &Context, models: bool, unsat_cores: bool, proofs: bool) -> Goal {
         // NOTE: The Z3 context ctx must have been created with proof generation support.
-        unsafe { Self::wrap(ctx, Z3_mk_goal(ctx.z3_ctx, models, unsat_cores, proofs)) }
+        unsafe { Self::wrap(ctx, Z3_mk_goal(ctx.z3_ctx.0, models, unsat_cores, proofs)) }
     }
 
     /// Add a new formula `a` to the given goal.
-    pub fn assert(&self, ast: &impl ast::Ast<'ctx>) {
-        unsafe { Z3_goal_assert(self.ctx.z3_ctx, self.z3_goal, ast.get_z3_ast()) }
+    pub fn assert(&self, ast: &impl ast::Ast) {
+        unsafe { Z3_goal_assert(self.ctx.z3_ctx.0, self.z3_goal, ast.get_z3_ast()) }
     }
 
     /// Return true if the given goal contains the formula `false`.
     pub fn is_inconsistent(&self) -> bool {
-        unsafe { Z3_goal_inconsistent(self.ctx.z3_ctx, self.z3_goal) }
+        unsafe { Z3_goal_inconsistent(self.ctx.z3_ctx.0, self.z3_goal) }
     }
 
     /// Return the depth of the given goal. It tracks how many transformations were applied to it.
     pub fn get_depth(&self) -> u32 {
-        unsafe { Z3_goal_depth(self.ctx.z3_ctx, self.z3_goal) }
+        unsafe { Z3_goal_depth(self.ctx.z3_ctx.0, self.z3_goal) }
     }
 
     /// Return the number of formulas in the given goal.
     pub fn get_size(&self) -> u32 {
-        unsafe { Z3_goal_size(self.ctx.z3_ctx, self.z3_goal) }
+        unsafe { Z3_goal_size(self.ctx.z3_ctx.0, self.z3_goal) }
     }
 
     /// Return the number of formulas, subformulas and terms in the given goal.
     pub fn get_num_expr(&self) -> u32 {
-        unsafe { Z3_goal_num_exprs(self.ctx.z3_ctx, self.z3_goal) }
+        unsafe { Z3_goal_num_exprs(self.ctx.z3_ctx.0, self.z3_goal) }
     }
 
     /// Return true if the goal is empty, and it is precise or the product of a under approximation.
     pub fn is_decided_sat(&self) -> bool {
-        unsafe { Z3_goal_is_decided_sat(self.ctx.z3_ctx, self.z3_goal) }
+        unsafe { Z3_goal_is_decided_sat(self.ctx.z3_ctx.0, self.z3_goal) }
     }
     /// Return true if the goal contains false, and it is precise or the product of an over approximation.
     pub fn is_decided_unsat(&self) -> bool {
-        unsafe { Z3_goal_is_decided_unsat(self.ctx.z3_ctx, self.z3_goal) }
+        unsafe { Z3_goal_is_decided_unsat(self.ctx.z3_ctx.0, self.z3_goal) }
     }
 
     /// Erase all formulas from the given goal.
     pub fn reset(&self) {
-        unsafe { Z3_goal_reset(self.ctx.z3_ctx, self.z3_goal) };
+        unsafe { Z3_goal_reset(self.ctx.z3_ctx.0, self.z3_goal) };
     }
 
     /// Copy a goal `g` from the context `source` to the context `target`.
     #[allow(clippy::needless_lifetimes)]
-    pub fn translate<'dest_ctx>(self, ctx: &'dest_ctx Context) -> Goal<'dest_ctx> {
+    pub fn translate(self, ctx: &Context) -> Goal {
         unsafe {
             Goal::wrap(
                 ctx,
-                Z3_goal_translate(self.ctx.z3_ctx, self.z3_goal, ctx.z3_ctx),
+                Z3_goal_translate(self.ctx.z3_ctx.0, self.z3_goal, ctx.z3_ctx.0),
             )
         }
     }
 
     /// Return the "precision" of the given goal. Goals can be transformed using over and under approximations.
     pub fn get_precision(&self) -> GoalPrec {
-        unsafe { Z3_goal_precision(self.ctx.z3_ctx, self.z3_goal) }
+        unsafe { Z3_goal_precision(self.ctx.z3_ctx.0, self.z3_goal) }
     }
 
     pub fn iter_formulas<'a, T>(&'a self) -> impl Iterator<Item = T> + 'a
     where
-        T: Ast<'a>,
+        T: Ast,
     {
         let goal_size = self.get_size() as usize;
-        let z3_ctx = self.ctx.z3_ctx;
+        let z3_ctx = self.ctx.z3_ctx.0;
         let z3_goal = self.z3_goal;
         (0..goal_size).map(move |i| {
             let formula = unsafe { Z3_goal_formula(z3_ctx, z3_goal, i as u32) };
-            unsafe { T::wrap(self.ctx, formula) }
+            unsafe { T::wrap(&self.ctx, formula) }
         })
     }
 
     /// Return a vector of the formulas from the given goal.
     pub fn get_formulas<T>(&self) -> Vec<T>
     where
-        T: Ast<'ctx>,
+        T: Ast,
     {
         let goal_size = self.get_size() as usize;
         let mut formulas: Vec<T> = Vec::with_capacity(goal_size);
 
         for i in 0..goal_size {
-            let formula = unsafe { Z3_goal_formula(self.ctx.z3_ctx, self.z3_goal, i as u32) };
-            formulas.push(unsafe { T::wrap(self.ctx, formula) });
+            let formula = unsafe { Z3_goal_formula(self.ctx.z3_ctx.0, self.z3_goal, i as u32) };
+            formulas.push(unsafe { T::wrap(&self.ctx, formula) });
         }
         formulas
     }
 }
 
-impl fmt::Display for Goal<'_> {
+impl fmt::Display for Goal {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_goal_to_string(self.ctx.z3_ctx, self.z3_goal) };
+        let p = unsafe { Z3_goal_to_string(self.ctx.z3_ctx.0, self.z3_goal) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -124,16 +126,16 @@ impl fmt::Display for Goal<'_> {
     }
 }
 
-impl fmt::Debug for Goal<'_> {
+impl fmt::Debug for Goal {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         <Self as fmt::Display>::fmt(self, f)
     }
 }
 
-impl Drop for Goal<'_> {
+impl Drop for Goal {
     fn drop(&mut self) {
         unsafe {
-            Z3_goal_dec_ref(self.ctx.z3_ctx, self.z3_goal);
+            Z3_goal_dec_ref(self.ctx.z3_ctx.0, self.z3_goal);
         };
     }
 }

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -57,8 +57,8 @@ pub struct Config {
 /// - [`Context::handle()`]
 /// - [`ContextHandle::interrupt()`]
 #[derive(PartialEq, Eq, Debug)]
-pub struct ContextHandle<'ctx> {
-    ctx: &'ctx Context,
+pub struct ContextHandle {
+    ctx: Context,
 }
 
 /// Symbols are used to name several term and type constructors.
@@ -72,16 +72,16 @@ pub enum Symbol {
 //
 // Note for in-crate users: Never construct a `Sort` directly; only use
 // `Sort::new()` which handles Z3 refcounting properly.
-pub struct Sort<'ctx> {
-    ctx: &'ctx Context,
+pub struct Sort {
+    ctx: Context,
     z3_sort: Z3_sort,
 }
 
 /// A struct to represent when two sorts are of different types.
 #[derive(Debug)]
-pub struct SortDiffers<'ctx> {
-    left: Sort<'ctx>,
-    right: Sort<'ctx>,
+pub struct SortDiffers {
+    left: Sort,
+    right: Sort,
 }
 
 /// A struct to represent when an ast is not a function application.
@@ -94,8 +94,8 @@ pub struct IsNotApp {
 //
 // Note for in-crate users: Never construct a `Solver` directly; only use
 // `Solver::new()` which handles Z3 refcounting properly.
-pub struct Solver<'ctx> {
-    ctx: &'ctx Context,
+pub struct Solver {
+    ctx: Context,
     z3_slv: Z3_solver,
 }
 
@@ -103,8 +103,8 @@ pub struct Solver<'ctx> {
 //
 // Note for in-crate users: Never construct a `Model` directly; only use
 // `Model::new()` which handles Z3 refcounting properly.
-pub struct Model<'ctx> {
-    ctx: &'ctx Context,
+pub struct Model {
+    ctx: Context,
     z3_mdl: Z3_model,
 }
 
@@ -112,8 +112,8 @@ pub struct Model<'ctx> {
 //
 // Note for in-crate users: Never construct an `Optimize` directly; only use
 // `Optimize::new()` which handles Z3 refcounting properly.
-pub struct Optimize<'ctx> {
-    ctx: &'ctx Context,
+pub struct Optimize {
+    ctx: Context,
     z3_opt: Z3_optimize,
 }
 
@@ -129,22 +129,22 @@ pub struct Optimize<'ctx> {
 //
 // Note for in-crate users: Never construct a `FuncDecl` directly; only use
 // `FuncDecl::new()` which handles Z3 refcounting properly.
-pub struct FuncDecl<'ctx> {
-    ctx: &'ctx Context,
+pub struct FuncDecl {
+    ctx: Context,
     z3_func_decl: Z3_func_decl,
 }
 
 /// Stores the interpretation of a function in a Z3 model.
 /// <https://z3prover.github.io/api/html/classz3py_1_1_func_interp.html>
-pub struct FuncInterp<'ctx> {
-    ctx: &'ctx Context,
+pub struct FuncInterp {
+    ctx: Context,
     z3_func_interp: Z3_func_interp,
 }
 
 /// Store the value of the interpretation of a function in a particular point.
 /// <https://z3prover.github.io/api/html/classz3py_1_1_func_entry.html>
-pub struct FuncEntry<'ctx> {
-    ctx: &'ctx Context,
+pub struct FuncEntry {
+    ctx: Context,
     z3_func_entry: Z3_func_entry,
 }
 
@@ -161,8 +161,8 @@ pub struct FuncEntry<'ctx> {
 /// - [`RecFuncDecl::add_def`]
 // Note for in-crate users: Never construct a `RecFuncDecl` directly; only use
 // `RecFuncDecl::new()` which handles Z3 refcounting properly.
-pub struct RecFuncDecl<'ctx> {
-    ctx: &'ctx Context,
+pub struct RecFuncDecl {
+    ctx: Context,
     z3_func_decl: Z3_func_decl,
 }
 
@@ -202,37 +202,37 @@ pub use z3_sys::DeclKind;
 /// assert_eq!(3, model.eval(&ast.as_int().unwrap(), true).unwrap().as_i64().unwrap());
 /// ```
 #[derive(Debug)]
-pub struct DatatypeBuilder<'ctx> {
-    ctx: &'ctx Context,
+pub struct DatatypeBuilder {
+    ctx: Context,
     name: Symbol,
-    constructors: Vec<(String, Vec<(String, DatatypeAccessor<'ctx>)>)>,
+    constructors: Vec<(String, Vec<(String, DatatypeAccessor)>)>,
 }
 
 /// Wrapper which can point to a sort (by value) or to a custom datatype (by name).
 #[derive(Debug)]
-pub enum DatatypeAccessor<'ctx> {
-    Sort(Sort<'ctx>),
+pub enum DatatypeAccessor {
+    Sort(Sort),
     Datatype(Symbol),
 }
 
 /// Inner variant for a custom [datatype sort](DatatypeSort).
 #[derive(Debug)]
-pub struct DatatypeVariant<'ctx> {
-    pub constructor: FuncDecl<'ctx>,
-    pub tester: FuncDecl<'ctx>,
-    pub accessors: Vec<FuncDecl<'ctx>>,
+pub struct DatatypeVariant {
+    pub constructor: FuncDecl,
+    pub tester: FuncDecl,
+    pub accessors: Vec<FuncDecl>,
 }
 
 /// A custom datatype sort.
 #[derive(Debug)]
-pub struct DatatypeSort<'ctx> {
-    pub sort: Sort<'ctx>,
-    pub variants: Vec<DatatypeVariant<'ctx>>,
+pub struct DatatypeSort {
+    pub sort: Sort,
+    pub variants: Vec<DatatypeVariant>,
 }
 
 /// Parameter set used to configure many components (simplifiers, tactics, solvers, etc).
-pub struct Params<'ctx> {
-    ctx: &'ctx Context,
+pub struct Params {
+    ctx: Context,
     z3_params: Z3_params,
 }
 
@@ -248,15 +248,15 @@ pub enum SatResult {
 }
 
 /// A pattern for quantifier instantiation, used to guide quantifier instantiation.
-pub struct Pattern<'ctx> {
-    ctx: &'ctx Context,
+pub struct Pattern {
+    ctx: Context,
     z3_pattern: Z3_pattern,
 }
 
 /// Collection of subgoals resulting from applying of a tactic to a goal.
 #[derive(Clone, Debug)]
-pub struct ApplyResult<'ctx> {
-    ctx: &'ctx Context,
+pub struct ApplyResult {
+    ctx: Context,
     z3_apply_result: Z3_apply_result,
 }
 
@@ -278,14 +278,14 @@ pub struct ApplyResult<'ctx> {
 ///
 /// Finally, a solver utilizing a tactic can be created via
 /// [`Tactic::solver()`].
-pub struct Tactic<'ctx> {
-    ctx: &'ctx Context,
+pub struct Tactic {
+    ctx: Context,
     z3_tactic: Z3_tactic,
 }
 
 /// Set of formulas that can be solved and/or transformed using tactics and solvers.
-pub struct Goal<'ctx> {
-    ctx: &'ctx Context,
+pub struct Goal {
+    ctx: Context,
     z3_goal: Z3_goal,
 }
 
@@ -295,8 +295,8 @@ pub struct Goal<'ctx> {
 ///
 /// Z3 provides a variety of probes, which can be queried via
 /// [`Probe::list_all()`].
-pub struct Probe<'ctx> {
-    ctx: &'ctx Context,
+pub struct Probe {
+    ctx: Context,
     z3_probe: Z3_probe,
 }
 
@@ -306,7 +306,7 @@ pub struct Probe<'ctx> {
 ///
 /// - [`Optimize::get_statistics()`]
 /// - [`Solver::get_statistics()`]
-pub struct Statistics<'ctx> {
-    ctx: &'ctx Context,
+pub struct Statistics {
+    ctx: Context,
     z3_stats: Z3_stats,
 }

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(missing_debug_implementations)]
 
 use std::ffi::CString;
+use std::rc::Rc;
 use z3_sys::*;
 pub use z3_sys::{AstKind, GoalPrec, SortKind};
 
@@ -35,6 +36,7 @@ mod version;
 pub use crate::params::{get_global_param, reset_all_global_params, set_global_param};
 pub use crate::statistics::{StatisticsEntry, StatisticsValue};
 pub use crate::version::{Version, full_version, version};
+pub use context::Context;
 
 /// Configuration used to initialize [logical contexts](Context).
 ///
@@ -45,31 +47,6 @@ pub use crate::version::{Version, full_version, version};
 pub struct Config {
     kvs: Vec<(CString, CString)>,
     z3_cfg: Z3_config,
-}
-
-/// Manager of all other Z3 objects, global configuration options, etc.
-///
-/// An application may use multiple Z3 contexts. Objects created in one context
-/// cannot be used in another one. However, several objects may be "translated" from
-/// one context to another. It is not safe to access Z3 objects from multiple threads.
-///
-/// # Examples:
-///
-/// Creating a context with the default configuration:
-///
-/// ```
-/// use z3::{Config, Context};
-/// let cfg = Config::new();
-/// let ctx = Context::new(&cfg);
-/// ```
-///
-/// # See also:
-///
-/// - [`Config`]
-/// - [`Context::new()`]
-#[derive(PartialEq, Eq, Debug)]
-pub struct Context {
-    pub z3_ctx: Z3_context,
 }
 
 /// Handle that can be used to interrupt a computation from another thread.

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -57,8 +57,8 @@ pub struct Config {
 /// - [`Context::handle()`]
 /// - [`ContextHandle::interrupt()`]
 #[derive(PartialEq, Eq, Debug)]
-pub struct ContextHandle {
-    ctx: Context,
+pub struct ContextHandle<'ctx> {
+    ctx: &'ctx Context,
 }
 
 /// Symbols are used to name several term and type constructors.

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -7,7 +7,6 @@
 #![deny(missing_debug_implementations)]
 
 use std::ffi::CString;
-use std::rc::Rc;
 use z3_sys::*;
 pub use z3_sys::{AstKind, GoalPrec, SortKind};
 

--- a/z3/src/model.rs
+++ b/z3/src/model.rs
@@ -10,7 +10,10 @@ impl Model {
         unsafe {
             Z3_model_inc_ref(ctx.z3_ctx.0, z3_mdl);
         }
-        Model { ctx: ctx.clone(), z3_mdl }
+        Model {
+            ctx: ctx.clone(),
+            z3_mdl,
+        }
     }
 
     pub fn of_solver(slv: &Solver) -> Option<Model> {
@@ -63,8 +66,9 @@ impl Model {
     /// Returns `None` if there is no interpretation in the `Model`
     pub fn get_func_interp(&self, f: &FuncDecl) -> Option<FuncInterp> {
         if f.arity() == 0 {
-            let ret =
-                unsafe { Z3_model_get_const_interp(self.ctx.z3_ctx.0, self.z3_mdl, f.z3_func_decl) };
+            let ret = unsafe {
+                Z3_model_get_const_interp(self.ctx.z3_ctx.0, self.z3_mdl, f.z3_func_decl)
+            };
             if ret.is_null() {
                 None
             } else {

--- a/z3/src/ops.rs
+++ b/z3/src/ops.rs
@@ -25,7 +25,7 @@ macro_rules! mk_const_bool {
 
 macro_rules! impl_binary_op_raw {
     ($ty:ty, $rhs:ty, $output:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $function:ident) => {
-        impl<'ctx> $base_trait<$rhs> for $ty {
+        impl $base_trait<$rhs> for $ty {
             type Output = $output;
 
             fn $base_fn(self, rhs: $rhs) -> Self::Output {
@@ -47,7 +47,7 @@ macro_rules! impl_binary_assign_op_raw {
             $assign_fn,
             $function
         );
-        impl<'ctx> $assign_trait<$rhs> for $ty {
+        impl $assign_trait<$rhs> for $ty {
             fn $assign_fn(&mut self, rhs: $rhs) {
                 *self = (self as &$ty).$function(&rhs as &$ty);
             }
@@ -57,7 +57,7 @@ macro_rules! impl_binary_assign_op_raw {
 
 macro_rules! impl_binary_op_number_raw {
     ($ty:ty, $other:ty, $other_fn:ident, $output:ty, $base_trait:ident, $base_fn:ident, $function:ident, $construct_constant:ident) => {
-        impl<'ctx> $base_trait<$other> for $ty {
+        impl $base_trait<$other> for $ty {
             type Output = $output;
 
             fn $base_fn(self, rhs: $other) -> Self::Output {
@@ -67,7 +67,7 @@ macro_rules! impl_binary_op_number_raw {
             }
         }
 
-        impl<'ctx> $base_trait<$ty> for $other {
+        impl $base_trait<$ty> for $other {
             type Output = $output;
 
             fn $base_fn(self, rhs: $ty) -> Self::Output {
@@ -92,7 +92,7 @@ macro_rules! impl_binary_op_assign_number_raw {
             $construct_constant
         );
 
-        impl<'ctx> $assign_trait<$other> for $ty {
+        impl $assign_trait<$other> for $ty {
             fn $assign_fn(&mut self, rhs: $other) {
                 let c;
                 $construct_constant!(c, $other_fn, rhs, self);
@@ -239,7 +239,7 @@ macro_rules! impl_binary_op {
 
 macro_rules! impl_unary_op_raw {
     ($ty:ty, $output:ty, $base_trait:ident, $base_fn:ident, $function:ident) => {
-        impl<'ctx> $base_trait for $ty {
+        impl $base_trait for $ty {
             type Output = $output;
 
             fn $base_fn(self) -> Self::Output {
@@ -258,7 +258,7 @@ macro_rules! impl_unary_op {
 
 macro_rules! impl_binary_mult_op_raw {
     ($base_ty:ident, $ty:ty, $rhs:ty, $output:ty, $base_trait:ident, $base_fn:ident, $function:ident) => {
-        impl<'ctx> $base_trait<$rhs> for $ty {
+        impl $base_trait<$rhs> for $ty {
             type Output = $output;
 
             fn $base_fn(self, other: $rhs) -> Self::Output {
@@ -272,7 +272,7 @@ macro_rules! impl_binary_mult_op_assign_raw {
     ($base_ty:ident, $ty:ty, $rhs:ty, $base_trait:ident, $assign_trait:ident, $base_fn:ident, $assign_fn:ident, $function:ident) => {
         impl_binary_mult_op_raw!($base_ty, $ty, $rhs, $ty, $base_trait, $base_fn, $function);
 
-        impl<'ctx> $assign_trait<$rhs> for $ty {
+        impl $assign_trait<$rhs> for $ty {
             fn $assign_fn(&mut self, other: $rhs) {
                 *self = $base_ty::$function(self.get_ctx(), &[&self as &$ty, &other as &$ty])
             }
@@ -282,7 +282,7 @@ macro_rules! impl_binary_mult_op_assign_raw {
 
 macro_rules! impl_binary_mult_op_number_raw {
     ($ty:ty, $other:ty, $other_fn:ident, $output:ty, $base_trait:ident, $base_fn:ident, $construct_constant:ident) => {
-        impl<'ctx> $base_trait<$other> for $ty {
+        impl $base_trait<$other> for $ty {
             type Output = $output;
 
             fn $base_fn(self, rhs: $other) -> Self::Output {
@@ -292,7 +292,7 @@ macro_rules! impl_binary_mult_op_number_raw {
             }
         }
 
-        impl<'ctx> $base_trait<$ty> for $other {
+        impl $base_trait<$ty> for $other {
             type Output = $output;
 
             fn $base_fn(self, rhs: $ty) -> Self::Output {
@@ -316,7 +316,7 @@ macro_rules! impl_binary_mult_op_assign_number_raw {
             $construct_constant
         );
 
-        impl<'ctx> $assign_trait<$other> for $ty {
+        impl $assign_trait<$other> for $ty {
             fn $assign_fn(&mut self, rhs: $other) {
                 let c;
                 $construct_constant!(c, $other_fn, rhs, self);
@@ -453,7 +453,7 @@ macro_rules! impl_binary_mult_op {
 
 // implementations for BV
 impl_binary_op!(
-    BV<'ctx>,
+    BV,
     Add,
     AddAssign,
     add,
@@ -462,7 +462,7 @@ impl_binary_op!(
     mk_const_bv
 );
 impl_binary_op!(
-    BV<'ctx>,
+    BV,
     Sub,
     SubAssign,
     sub,
@@ -471,7 +471,7 @@ impl_binary_op!(
     mk_const_bv
 );
 impl_binary_op!(
-    BV<'ctx>,
+    BV,
     Mul,
     MulAssign,
     mul,
@@ -480,7 +480,7 @@ impl_binary_op!(
     mk_const_bv
 );
 impl_binary_op!(
-    BV<'ctx>,
+    BV,
     BitAnd,
     BitAndAssign,
     bitand,
@@ -489,7 +489,7 @@ impl_binary_op!(
     mk_const_bv
 );
 impl_binary_op!(
-    BV<'ctx>,
+    BV,
     BitOr,
     BitOrAssign,
     bitor,
@@ -498,7 +498,7 @@ impl_binary_op!(
     mk_const_bv
 );
 impl_binary_op!(
-    BV<'ctx>,
+    BV,
     BitXor,
     BitXorAssign,
     bitxor,
@@ -507,7 +507,7 @@ impl_binary_op!(
     mk_const_bv
 );
 impl_binary_op!(
-    BV<'ctx>,
+    BV,
     Shl,
     ShlAssign,
     shl,
@@ -515,13 +515,13 @@ impl_binary_op!(
     bvshl,
     mk_const_bv
 );
-impl_unary_op!(BV<'ctx>, Not, not, bvnot);
-impl_unary_op!(BV<'ctx>, Neg, neg, bvneg);
+impl_unary_op!(BV, Not, not, bvnot);
+impl_unary_op!(BV, Neg, neg, bvneg);
 
 // implementations for Int
 impl_binary_mult_op!(
     Int,
-    Int<'ctx>,
+    Int,
     Add,
     AddAssign,
     add,
@@ -530,7 +530,7 @@ impl_binary_mult_op!(
 );
 impl_binary_mult_op!(
     Int,
-    Int<'ctx>,
+    Int,
     Sub,
     SubAssign,
     sub,
@@ -539,7 +539,7 @@ impl_binary_mult_op!(
 );
 impl_binary_mult_op!(
     Int,
-    Int<'ctx>,
+    Int,
     Mul,
     MulAssign,
     mul,
@@ -547,7 +547,7 @@ impl_binary_mult_op!(
     mk_const_int
 );
 impl_binary_op!(
-    Int<'ctx>,
+    Int,
     Div,
     DivAssign,
     div,
@@ -556,7 +556,7 @@ impl_binary_op!(
     mk_const_int
 );
 impl_binary_op!(
-    Int<'ctx>,
+    Int,
     Rem,
     RemAssign,
     rem,
@@ -564,22 +564,22 @@ impl_binary_op!(
     rem,
     mk_const_int
 );
-impl_unary_op!(Int<'ctx>, Neg, neg, unary_minus);
+impl_unary_op!(Int, Neg, neg, unary_minus);
 
 // implementations for Real
-impl_binary_mult_op_without_numbers!(Real, Real<'ctx>, Add, AddAssign, add, add_assign);
-impl_binary_mult_op_without_numbers!(Real, Real<'ctx>, Sub, SubAssign, sub, sub_assign);
-impl_binary_mult_op_without_numbers!(Real, Real<'ctx>, Mul, MulAssign, mul, mul_assign);
-impl_binary_op_without_numbers!(Real<'ctx>, Div, DivAssign, div, div_assign, div);
-impl_unary_op!(Real<'ctx>, Neg, neg, unary_minus);
+impl_binary_mult_op_without_numbers!(Real, Real, Add, AddAssign, add, add_assign);
+impl_binary_mult_op_without_numbers!(Real, Real, Sub, SubAssign, sub, sub_assign);
+impl_binary_mult_op_without_numbers!(Real, Real, Mul, MulAssign, mul, mul_assign);
+impl_binary_op_without_numbers!(Real, Div, DivAssign, div, div_assign, div);
+impl_unary_op!(Real, Neg, neg, unary_minus);
 
 // // implementations for Float
-impl_unary_op!(Float<'ctx>, Neg, neg, unary_neg);
+impl_unary_op!(Float, Neg, neg, unary_neg);
 
 // implementations for Bool
 impl_binary_mult_op_bool!(
     Bool,
-    Bool<'ctx>,
+    Bool,
     BitAnd,
     BitAndAssign,
     bitand,
@@ -588,12 +588,12 @@ impl_binary_mult_op_bool!(
 );
 impl_binary_mult_op_bool!(
     Bool,
-    Bool<'ctx>,
+    Bool,
     BitOr,
     BitOrAssign,
     bitor,
     bitor_assign,
     or
 );
-impl_binary_op_bool!(Bool<'ctx>, BitXor, BitXorAssign, bitxor, bitxor_assign, xor);
-impl_unary_op!(Bool<'ctx>, Not, not, not);
+impl_binary_op_bool!(Bool, BitXor, BitXorAssign, bitxor, bitxor_assign, xor);
+impl_unary_op!(Bool, Not, not, not);

--- a/z3/src/ops.rs
+++ b/z3/src/ops.rs
@@ -452,33 +452,9 @@ macro_rules! impl_binary_mult_op {
 }
 
 // implementations for BV
-impl_binary_op!(
-    BV,
-    Add,
-    AddAssign,
-    add,
-    add_assign,
-    bvadd,
-    mk_const_bv
-);
-impl_binary_op!(
-    BV,
-    Sub,
-    SubAssign,
-    sub,
-    sub_assign,
-    bvsub,
-    mk_const_bv
-);
-impl_binary_op!(
-    BV,
-    Mul,
-    MulAssign,
-    mul,
-    mul_assign,
-    bvmul,
-    mk_const_bv
-);
+impl_binary_op!(BV, Add, AddAssign, add, add_assign, bvadd, mk_const_bv);
+impl_binary_op!(BV, Sub, SubAssign, sub, sub_assign, bvsub, mk_const_bv);
+impl_binary_op!(BV, Mul, MulAssign, mul, mul_assign, bvmul, mk_const_bv);
 impl_binary_op!(
     BV,
     BitAnd,
@@ -506,64 +482,16 @@ impl_binary_op!(
     bvxor,
     mk_const_bv
 );
-impl_binary_op!(
-    BV,
-    Shl,
-    ShlAssign,
-    shl,
-    shl_assign,
-    bvshl,
-    mk_const_bv
-);
+impl_binary_op!(BV, Shl, ShlAssign, shl, shl_assign, bvshl, mk_const_bv);
 impl_unary_op!(BV, Not, not, bvnot);
 impl_unary_op!(BV, Neg, neg, bvneg);
 
 // implementations for Int
-impl_binary_mult_op!(
-    Int,
-    Int,
-    Add,
-    AddAssign,
-    add,
-    add_assign,
-    mk_const_int
-);
-impl_binary_mult_op!(
-    Int,
-    Int,
-    Sub,
-    SubAssign,
-    sub,
-    sub_assign,
-    mk_const_int
-);
-impl_binary_mult_op!(
-    Int,
-    Int,
-    Mul,
-    MulAssign,
-    mul,
-    mul_assign,
-    mk_const_int
-);
-impl_binary_op!(
-    Int,
-    Div,
-    DivAssign,
-    div,
-    div_assign,
-    div,
-    mk_const_int
-);
-impl_binary_op!(
-    Int,
-    Rem,
-    RemAssign,
-    rem,
-    rem_assign,
-    rem,
-    mk_const_int
-);
+impl_binary_mult_op!(Int, Int, Add, AddAssign, add, add_assign, mk_const_int);
+impl_binary_mult_op!(Int, Int, Sub, SubAssign, sub, sub_assign, mk_const_int);
+impl_binary_mult_op!(Int, Int, Mul, MulAssign, mul, mul_assign, mk_const_int);
+impl_binary_op!(Int, Div, DivAssign, div, div_assign, div, mk_const_int);
+impl_binary_op!(Int, Rem, RemAssign, rem, rem_assign, rem, mk_const_int);
 impl_unary_op!(Int, Neg, neg, unary_minus);
 
 // implementations for Real
@@ -577,23 +505,7 @@ impl_unary_op!(Real, Neg, neg, unary_minus);
 impl_unary_op!(Float, Neg, neg, unary_neg);
 
 // implementations for Bool
-impl_binary_mult_op_bool!(
-    Bool,
-    Bool,
-    BitAnd,
-    BitAndAssign,
-    bitand,
-    bitand_assign,
-    and
-);
-impl_binary_mult_op_bool!(
-    Bool,
-    Bool,
-    BitOr,
-    BitOrAssign,
-    bitor,
-    bitor_assign,
-    or
-);
+impl_binary_mult_op_bool!(Bool, Bool, BitAnd, BitAndAssign, bitand, bitand_assign, and);
+impl_binary_mult_op_bool!(Bool, Bool, BitOr, BitOrAssign, bitor, bitor_assign, or);
 impl_binary_op_bool!(Bool, BitXor, BitXorAssign, bitxor, bitxor_assign, xor);
 impl_unary_op!(Bool, Not, not, not);

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -15,17 +15,20 @@ use num::{
     rational::BigRational,
 };
 
-impl<'ctx> Optimize<'ctx> {
-    unsafe fn wrap(ctx: &'ctx Context, z3_opt: Z3_optimize) -> Optimize<'ctx> {
+impl Optimize {
+    unsafe fn wrap(ctx: &Context, z3_opt: Z3_optimize) -> Optimize {
         unsafe {
-            Z3_optimize_inc_ref(ctx.z3_ctx, z3_opt);
+            Z3_optimize_inc_ref(ctx.z3_ctx.0, z3_opt);
         }
-        Optimize { ctx, z3_opt }
+        Optimize {
+            ctx: ctx.clone(),
+            z3_opt,
+        }
     }
 
     /// Create a new optimize context.
-    pub fn new(ctx: &'ctx Context) -> Optimize<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_optimize(ctx.z3_ctx)) }
+    pub fn new(ctx: &Context) -> Optimize {
+        unsafe { Self::wrap(ctx, Z3_mk_optimize(ctx.z3_ctx.0)) }
     }
 
     /// Parse an SMT-LIB2 string with assertions, soft constraints and optimization objectives.
@@ -33,13 +36,13 @@ impl<'ctx> Optimize<'ctx> {
     pub fn from_string<T: Into<Vec<u8>>>(&self, source_string: T) {
         let source_cstring = CString::new(source_string).unwrap();
         unsafe {
-            Z3_optimize_from_string(self.ctx.z3_ctx, self.z3_opt, source_cstring.as_ptr());
+            Z3_optimize_from_string(self.ctx.z3_ctx.0, self.z3_opt, source_cstring.as_ptr());
         }
     }
 
     /// Get this optimizers 's context.
-    pub fn get_context(&self) -> &'ctx Context {
-        self.ctx
+    pub fn get_context(&self) -> &Context {
+        &self.ctx
     }
 
     /// Assert hard constraint to the optimization context.
@@ -49,8 +52,8 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::assert_soft()`]
     /// - [`Optimize::maximize()`]
     /// - [`Optimize::minimize()`]
-    pub fn assert(&self, ast: &impl Ast<'ctx>) {
-        unsafe { Z3_optimize_assert(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
+    pub fn assert(&self, ast: &impl Ast) {
+        unsafe { Z3_optimize_assert(self.ctx.z3_ctx.0, self.z3_opt, ast.get_z3_ast()) };
     }
 
     /// Assert a constraint `a` into the solver, and track it (in the
@@ -68,9 +71,11 @@ impl<'ctx> Optimize<'ctx> {
     ///
     /// - [`Optimize::assert()`]
     /// - [`Optimize::assert_soft()`]
-    pub fn assert_and_track(&self, ast: &Bool<'ctx>, p: &Bool<'ctx>) {
+    pub fn assert_and_track(&self, ast: &Bool, p: &Bool) {
         debug!("assert_and_track: {ast:?}");
-        unsafe { Z3_optimize_assert_and_track(self.ctx.z3_ctx, self.z3_opt, ast.z3_ast, p.z3_ast) };
+        unsafe {
+            Z3_optimize_assert_and_track(self.ctx.z3_ctx.0, self.z3_opt, ast.z3_ast, p.z3_ast)
+        };
     }
 
     /// Assert soft constraint to the optimization context.
@@ -82,15 +87,15 @@ impl<'ctx> Optimize<'ctx> {
     /// - [`Optimize::assert()`]
     /// - [`Optimize::maximize()`]
     /// - [`Optimize::minimize()`]
-    pub fn assert_soft(&self, ast: &impl Ast<'ctx>, weight: impl Weight, group: Option<Symbol>) {
+    pub fn assert_soft(&self, ast: &impl Ast, weight: impl Weight, group: Option<Symbol>) {
         let weight_string = weight.to_string();
         let weight_cstring = CString::new(weight_string).unwrap();
         let group = group
-            .map(|g| g.as_z3_symbol(self.ctx))
+            .map(|g| g.as_z3_symbol(&self.ctx))
             .unwrap_or_else(std::ptr::null_mut);
         unsafe {
             Z3_optimize_assert_soft(
-                self.ctx.z3_ctx,
+                self.ctx.z3_ctx.0,
                 self.z3_opt,
                 ast.get_z3_ast(),
                 weight_cstring.as_ptr(),
@@ -105,13 +110,13 @@ impl<'ctx> Optimize<'ctx> {
     ///
     /// - [`Optimize::assert()`]
     /// - [`Optimize::minimize()`]
-    pub fn maximize(&self, ast: &impl Ast<'ctx>) {
+    pub fn maximize(&self, ast: &impl Ast) {
         // https://github.com/Z3Prover/z3/blob/09f911d8a84cd91988e5b96b69485b2a9a2edba3/src/opt/opt_context.cpp#L118-L120
         assert!(matches!(
             ast.get_sort().kind(),
             SortKind::Int | SortKind::Real | SortKind::BV
         ));
-        unsafe { Z3_optimize_maximize(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
+        unsafe { Z3_optimize_maximize(self.ctx.z3_ctx.0, self.z3_opt, ast.get_z3_ast()) };
     }
 
     /// Add a minimization constraint.
@@ -120,12 +125,12 @@ impl<'ctx> Optimize<'ctx> {
     ///
     /// - [`Optimize::assert()`]
     /// - [`Optimize::maximize()`]
-    pub fn minimize(&self, ast: &impl Ast<'ctx>) {
+    pub fn minimize(&self, ast: &impl Ast) {
         assert!(matches!(
             ast.get_sort().kind(),
             SortKind::Int | SortKind::Real | SortKind::BV
         ));
-        unsafe { Z3_optimize_minimize(self.ctx.z3_ctx, self.z3_opt, ast.get_z3_ast()) };
+        unsafe { Z3_optimize_minimize(self.ctx.z3_ctx.0, self.z3_opt, ast.get_z3_ast()) };
     }
 
     /// Return a subset of the assumptions provided to either the last
@@ -148,19 +153,19 @@ impl<'ctx> Optimize<'ctx> {
     /// # See also:
     ///
     /// - [`Optimize::check`]
-    pub fn get_unsat_core(&self) -> Vec<Bool<'ctx>> {
-        let z3_unsat_core = unsafe { Z3_optimize_get_unsat_core(self.ctx.z3_ctx, self.z3_opt) };
+    pub fn get_unsat_core(&self) -> Vec<Bool> {
+        let z3_unsat_core = unsafe { Z3_optimize_get_unsat_core(self.ctx.z3_ctx.0, self.z3_opt) };
         if z3_unsat_core.is_null() {
             return vec![];
         }
 
-        let len = unsafe { Z3_ast_vector_size(self.ctx.z3_ctx, z3_unsat_core) };
+        let len = unsafe { Z3_ast_vector_size(self.ctx.z3_ctx.0, z3_unsat_core) };
 
         let mut unsat_core = Vec::with_capacity(len as usize);
 
         for i in 0..len {
-            let elem = unsafe { Z3_ast_vector_get(self.ctx.z3_ctx, z3_unsat_core, i) };
-            let elem = unsafe { Bool::wrap(self.ctx, elem) };
+            let elem = unsafe { Z3_ast_vector_get(self.ctx.z3_ctx.0, z3_unsat_core, i) };
+            let elem = unsafe { Bool::wrap(&self.ctx, elem) };
             unsat_core.push(elem);
         }
 
@@ -177,7 +182,7 @@ impl<'ctx> Optimize<'ctx> {
     ///
     /// - [`Optimize::pop()`]
     pub fn push(&self) {
-        unsafe { Z3_optimize_push(self.ctx.z3_ctx, self.z3_opt) };
+        unsafe { Z3_optimize_push(self.ctx.z3_ctx.0, self.z3_opt) };
     }
 
     /// Backtrack one level.
@@ -191,7 +196,7 @@ impl<'ctx> Optimize<'ctx> {
     ///
     /// - [`Optimize::push()`]
     pub fn pop(&self) {
-        unsafe { Z3_optimize_pop(self.ctx.z3_ctx, self.z3_opt) };
+        unsafe { Z3_optimize_pop(self.ctx.z3_ctx.0, self.z3_opt) };
     }
 
     /// Check consistency and produce optimal values.
@@ -199,11 +204,11 @@ impl<'ctx> Optimize<'ctx> {
     /// # See also:
     ///
     /// - [`Optimize::get_model()`]
-    pub fn check(&self, assumptions: &[Bool<'ctx>]) -> SatResult {
+    pub fn check(&self, assumptions: &[Bool]) -> SatResult {
         let assumptions: Vec<Z3_ast> = assumptions.iter().map(|a| a.z3_ast).collect();
         match unsafe {
             Z3_optimize_check(
-                self.ctx.z3_ctx,
+                self.ctx.z3_ctx.0,
                 self.z3_opt,
                 assumptions.len().try_into().unwrap(),
                 assumptions.as_ptr(),
@@ -221,25 +226,25 @@ impl<'ctx> Optimize<'ctx> {
     /// The error handler is invoked if a model is not available because
     /// the commands above were not invoked for the given optimization
     /// solver, or if the result was [`SatResult::Unsat`].
-    pub fn get_model(&self) -> Option<Model<'ctx>> {
+    pub fn get_model(&self) -> Option<Model> {
         Model::of_optimize(self)
     }
 
     /// Retrieve the objectives for the last [`Optimize::check()`].
     ///
     /// This contains maximize/minimize objectives and grouped soft constraints.
-    pub fn get_objectives(&self) -> Vec<Dynamic<'ctx>> {
+    pub fn get_objectives(&self) -> Vec<Dynamic> {
         let (z3_objectives, len) = unsafe {
-            let objectives = Z3_optimize_get_objectives(self.ctx.z3_ctx, self.z3_opt);
-            let len = Z3_ast_vector_size(self.ctx.z3_ctx, objectives);
+            let objectives = Z3_optimize_get_objectives(self.ctx.z3_ctx.0, self.z3_opt);
+            let len = Z3_ast_vector_size(self.ctx.z3_ctx.0, objectives);
             (objectives, len)
         };
 
         let mut objectives = Vec::with_capacity(len as usize);
 
         for i in 0..len {
-            let elem = unsafe { Z3_ast_vector_get(self.ctx.z3_ctx, z3_objectives, i) };
-            let elem = unsafe { Dynamic::wrap(self.ctx, elem) };
+            let elem = unsafe { Z3_ast_vector_get(self.ctx.z3_ctx.0, z3_objectives, i) };
+            let elem = unsafe { Dynamic::wrap(&self.ctx, elem) };
             objectives.push(elem);
         }
 
@@ -250,7 +255,7 @@ impl<'ctx> Optimize<'ctx> {
     ///
     /// Use this method when [`Optimize::check()`] returns [`SatResult::Unknown`].
     pub fn get_reason_unknown(&self) -> Option<String> {
-        let p = unsafe { Z3_optimize_get_reason_unknown(self.ctx.z3_ctx, self.z3_opt) };
+        let p = unsafe { Z3_optimize_get_reason_unknown(self.ctx.z3_ctx.0, self.z3_opt) };
         if p.is_null() {
             return None;
         }
@@ -261,24 +266,24 @@ impl<'ctx> Optimize<'ctx> {
     }
 
     /// Configure the parameters for this Optimize.
-    pub fn set_params(&self, params: &Params<'ctx>) {
-        unsafe { Z3_optimize_set_params(self.ctx.z3_ctx, self.z3_opt, params.z3_params) };
+    pub fn set_params(&self, params: &Params) {
+        unsafe { Z3_optimize_set_params(self.ctx.z3_ctx.0, self.z3_opt, params.z3_params) };
     }
 
     /// Retrieve the statistics for the last [`Optimize::check()`].
-    pub fn get_statistics(&self) -> Statistics<'ctx> {
+    pub fn get_statistics(&self) -> Statistics {
         unsafe {
             Statistics::wrap(
-                self.ctx,
-                Z3_optimize_get_statistics(self.ctx.z3_ctx, self.z3_opt),
+                &self.ctx,
+                Z3_optimize_get_statistics(self.ctx.z3_ctx.0, self.z3_opt),
             )
         }
     }
 }
 
-impl fmt::Display for Optimize<'_> {
+impl fmt::Display for Optimize {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_optimize_to_string(self.ctx.z3_ctx, self.z3_opt) };
+        let p = unsafe { Z3_optimize_to_string(self.ctx.z3_ctx.0, self.z3_opt) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -289,15 +294,15 @@ impl fmt::Display for Optimize<'_> {
     }
 }
 
-impl fmt::Debug for Optimize<'_> {
+impl fmt::Debug for Optimize {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         <Self as fmt::Display>::fmt(self, f)
     }
 }
 
-impl Drop for Optimize<'_> {
+impl Drop for Optimize {
     fn drop(&mut self) {
-        unsafe { Z3_optimize_dec_ref(self.ctx.z3_ctx, self.z3_opt) };
+        unsafe { Z3_optimize_dec_ref(self.ctx.z3_ctx.0, self.z3_opt) };
     }
 }
 

--- a/z3/src/params.rs
+++ b/z3/src/params.rs
@@ -5,25 +5,25 @@ use z3_sys::*;
 
 use crate::{Context, Params, Symbol};
 
-impl<'ctx> Params<'ctx> {
-    unsafe fn wrap(ctx: &'ctx Context, z3_params: Z3_params) -> Params<'ctx> {
+impl Params {
+    unsafe fn wrap(ctx: & Context, z3_params: Z3_params) -> Params {
         unsafe {
-            Z3_params_inc_ref(ctx.z3_ctx, z3_params);
+            Z3_params_inc_ref(ctx.z3_ctx.0, z3_params);
         }
-        Params { ctx, z3_params }
+        Params { ctx: ctx.clone(), z3_params }
     }
 
-    pub fn new(ctx: &'ctx Context) -> Params<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_params(ctx.z3_ctx)) }
+    pub fn new(ctx: & Context) -> Params {
+        unsafe { Self::wrap(ctx, Z3_mk_params(ctx.z3_ctx.0)) }
     }
 
     pub fn set_symbol<K: Into<Symbol>, V: Into<Symbol>>(&mut self, k: K, v: V) {
         unsafe {
             Z3_params_set_symbol(
-                self.ctx.z3_ctx,
+                self.ctx.z3_ctx.0,
                 self.z3_params,
-                k.into().as_z3_symbol(self.ctx),
-                v.into().as_z3_symbol(self.ctx),
+                k.into().as_z3_symbol(&self.ctx),
+                v.into().as_z3_symbol(&self.ctx),
             );
         };
     }
@@ -31,9 +31,9 @@ impl<'ctx> Params<'ctx> {
     pub fn set_bool<K: Into<Symbol>>(&mut self, k: K, v: bool) {
         unsafe {
             Z3_params_set_bool(
-                self.ctx.z3_ctx,
+                self.ctx.z3_ctx.0,
                 self.z3_params,
-                k.into().as_z3_symbol(self.ctx),
+                k.into().as_z3_symbol(&self.ctx),
                 v,
             );
         };
@@ -42,9 +42,9 @@ impl<'ctx> Params<'ctx> {
     pub fn set_f64<K: Into<Symbol>>(&mut self, k: K, v: f64) {
         unsafe {
             Z3_params_set_double(
-                self.ctx.z3_ctx,
+                self.ctx.z3_ctx.0,
                 self.z3_params,
-                k.into().as_z3_symbol(self.ctx),
+                k.into().as_z3_symbol(&self.ctx),
                 v,
             );
         };
@@ -53,9 +53,9 @@ impl<'ctx> Params<'ctx> {
     pub fn set_u32<K: Into<Symbol>>(&mut self, k: K, v: u32) {
         unsafe {
             Z3_params_set_uint(
-                self.ctx.z3_ctx,
+                self.ctx.z3_ctx.0,
                 self.z3_params,
-                k.into().as_z3_symbol(self.ctx),
+                k.into().as_z3_symbol(&self.ctx),
                 v,
             );
         };
@@ -101,9 +101,9 @@ pub fn reset_all_global_params() {
     unsafe { Z3_global_param_reset_all() };
 }
 
-impl fmt::Display for Params<'_> {
+impl fmt::Display for Params {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_params_to_string(self.ctx.z3_ctx, self.z3_params) };
+        let p = unsafe { Z3_params_to_string(self.ctx.z3_ctx.0, self.z3_params) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -114,14 +114,14 @@ impl fmt::Display for Params<'_> {
     }
 }
 
-impl fmt::Debug for Params<'_> {
+impl fmt::Debug for Params {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         <Self as fmt::Display>::fmt(self, f)
     }
 }
 
-impl Drop for Params<'_> {
+impl Drop for Params {
     fn drop(&mut self) {
-        unsafe { Z3_params_dec_ref(self.ctx.z3_ctx, self.z3_params) };
+        unsafe { Z3_params_dec_ref(self.ctx.z3_ctx.0, self.z3_params) };
     }
 }

--- a/z3/src/params.rs
+++ b/z3/src/params.rs
@@ -6,14 +6,17 @@ use z3_sys::*;
 use crate::{Context, Params, Symbol};
 
 impl Params {
-    unsafe fn wrap(ctx: & Context, z3_params: Z3_params) -> Params {
+    unsafe fn wrap(ctx: &Context, z3_params: Z3_params) -> Params {
         unsafe {
             Z3_params_inc_ref(ctx.z3_ctx.0, z3_params);
         }
-        Params { ctx: ctx.clone(), z3_params }
+        Params {
+            ctx: ctx.clone(),
+            z3_params,
+        }
     }
 
-    pub fn new(ctx: & Context) -> Params {
+    pub fn new(ctx: &Context) -> Params {
         unsafe { Self::wrap(ctx, Z3_mk_params(ctx.z3_ctx.0)) }
     }
 

--- a/z3/src/probe.rs
+++ b/z3/src/probe.rs
@@ -7,12 +7,15 @@ use z3_sys::*;
 
 use crate::{Context, Goal, Probe};
 
-impl<'ctx> Probe<'ctx> {
-    unsafe fn wrap(ctx: &'ctx Context, z3_probe: Z3_probe) -> Probe<'ctx> {
+impl Probe {
+    unsafe fn wrap(ctx: &Context, z3_probe: Z3_probe) -> Probe {
         unsafe {
-            Z3_probe_inc_ref(ctx.z3_ctx, z3_probe);
+            Z3_probe_inc_ref(ctx.z3_ctx.0, z3_probe);
         }
-        Probe { ctx, z3_probe }
+        Probe {
+            ctx: ctx.clone(),
+            z3_probe,
+        }
     }
 
     /// Iterate through the valid probe names.
@@ -27,21 +30,19 @@ impl<'ctx> Probe<'ctx> {
     /// let probes: Vec<_> = Probe::list_all(&ctx).filter_map(|r| r.ok()).collect();
     /// assert!(probes.contains(&"is-quasi-pb"));
     /// ```
-    pub fn list_all(
-        ctx: &'ctx Context,
-    ) -> impl Iterator<Item = std::result::Result<&'ctx str, Utf8Error>> {
-        let p = unsafe { Z3_get_num_probes(ctx.z3_ctx) };
+    pub fn list_all(ctx: &Context) -> impl Iterator<Item = std::result::Result<&str, Utf8Error>> {
+        let p = unsafe { Z3_get_num_probes(ctx.z3_ctx.0) };
         (0..p).map(move |n| {
-            let t = unsafe { Z3_get_probe_name(ctx.z3_ctx, n) };
+            let t = unsafe { Z3_get_probe_name(ctx.z3_ctx.0, n) };
             unsafe { CStr::from_ptr(t) }.to_str()
         })
     }
 
     /// Return a string containing a description of the probe with
     /// the given `name`.
-    pub fn describe(ctx: &'ctx Context, name: &str) -> std::result::Result<&'ctx str, Utf8Error> {
+    pub fn describe<'a>(ctx: &'a Context, name: &str) -> std::result::Result<&'a str, Utf8Error> {
         let probe_name = CString::new(name).unwrap();
-        unsafe { CStr::from_ptr(Z3_probe_get_descr(ctx.z3_ctx, probe_name.as_ptr())).to_str() }
+        unsafe { CStr::from_ptr(Z3_probe_get_descr(ctx.z3_ctx.0, probe_name.as_ptr())).to_str() }
     }
 
     /// Return a probe associated with the given `name`.
@@ -55,17 +56,17 @@ impl<'ctx> Probe<'ctx> {
     /// let ctx = Context::new(&cfg);
     /// let probe = Probe::new(&ctx, "is-qfbv");
     /// ```
-    pub fn new(ctx: &'ctx Context, name: &str) -> Probe<'ctx> {
+    pub fn new(ctx: &Context, name: &str) -> Probe {
         let probe_name = CString::new(name).unwrap();
-        unsafe { Self::wrap(ctx, Z3_mk_probe(ctx.z3_ctx, probe_name.as_ptr())) }
+        unsafe { Self::wrap(ctx, Z3_mk_probe(ctx.z3_ctx.0, probe_name.as_ptr())) }
     }
 
     /// Execute the probe over the goal.
     ///
     /// The probe always produce a double value. "Boolean" probes return
     /// `0.0` for `false`, and a value different from `0.0` for `true`.
-    pub fn apply(&self, goal: &'ctx Goal) -> f64 {
-        unsafe { Z3_probe_apply(self.ctx.z3_ctx, self.z3_probe, goal.z3_goal) }
+    pub fn apply(&self, goal: &Goal) -> f64 {
+        unsafe { Z3_probe_apply(self.ctx.z3_ctx.0, self.z3_probe, goal.z3_goal) }
     }
 
     /// Return a probe that always evaluates to val.
@@ -76,121 +77,121 @@ impl<'ctx> Probe<'ctx> {
     /// let ctx = Context::new(&cfg);
     /// let probe = Probe::constant(&ctx, 1.0);
     /// ```
-    pub fn constant(ctx: &'ctx Context, val: f64) -> Probe<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_probe_const(ctx.z3_ctx, val)) }
+    pub fn constant(ctx: &Context, val: f64) -> Probe {
+        unsafe { Self::wrap(ctx, Z3_probe_const(ctx.z3_ctx.0, val)) }
     }
 
     /// Return a probe that evaluates to "true" when the value returned
     /// by `self` is less than the value returned by `p`.
     ///
     /// NOTE: For probes, "true" is any value different from 0.0.
-    pub fn lt(&self, p: &Probe) -> Probe<'ctx> {
+    pub fn lt(&self, p: &Probe) -> Probe {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_probe_lt(self.ctx.z3_ctx, self.z3_probe, p.z3_probe),
+                &self.ctx,
+                Z3_probe_lt(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe),
             )
         }
     }
 
     /// Return a probe that evaluates to "true" when the value returned
     /// by `self` is greater than the value returned by `p`.
-    pub fn gt(&self, p: &Probe) -> Probe<'ctx> {
+    pub fn gt(&self, p: &Probe) -> Probe {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_probe_gt(self.ctx.z3_ctx, self.z3_probe, p.z3_probe),
+                &self.ctx,
+                Z3_probe_gt(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe),
             )
         }
     }
 
     /// Return a probe that evaluates to "true" when the value returned
     /// by `self` is less than or equal to the value returned by `p`.
-    pub fn le(&self, p: &Probe) -> Probe<'ctx> {
+    pub fn le(&self, p: &Probe) -> Probe {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_probe_le(self.ctx.z3_ctx, self.z3_probe, p.z3_probe),
+                &self.ctx,
+                Z3_probe_le(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe),
             )
         }
     }
 
     /// Return a probe that evaluates to "true" when the value returned
     /// by `self` is greater than or equal to the value returned by `p`.
-    pub fn ge(&self, p: &Probe) -> Probe<'ctx> {
+    pub fn ge(&self, p: &Probe) -> Probe {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_probe_ge(self.ctx.z3_ctx, self.z3_probe, p.z3_probe),
+                &self.ctx,
+                Z3_probe_ge(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe),
             )
         }
     }
 
     /// Return a probe that evaluates to "true" when the value returned
     /// by `self` is equal to the value returned by `p`.
-    pub fn eq(&self, p: &Probe) -> Probe<'ctx> {
+    pub fn eq(&self, p: &Probe) -> Probe {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_probe_eq(self.ctx.z3_ctx, self.z3_probe, p.z3_probe),
+                &self.ctx,
+                Z3_probe_eq(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe),
             )
         }
     }
 
     /// Return a probe that evaluates to "true" when `self` and `p` evaluates to true.
-    pub fn and(&self, p: &Probe) -> Probe<'ctx> {
+    pub fn and(&self, p: &Probe) -> Probe {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_probe_and(self.ctx.z3_ctx, self.z3_probe, p.z3_probe),
+                &self.ctx,
+                Z3_probe_and(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe),
             )
         }
     }
 
     /// Return a probe that evaluates to "true" when `p1` or `p2` evaluates to true.
-    pub fn or(&self, p: &Probe) -> Probe<'ctx> {
+    pub fn or(&self, p: &Probe) -> Probe {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_probe_or(self.ctx.z3_ctx, self.z3_probe, p.z3_probe),
+                &self.ctx,
+                Z3_probe_or(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe),
             )
         }
     }
 
     /// Return a probe that evaluates to "true" when `p` does not evaluate to true.
-    pub fn not(&self) -> Probe<'ctx> {
-        unsafe { Self::wrap(self.ctx, Z3_probe_not(self.ctx.z3_ctx, self.z3_probe)) }
+    pub fn not(&self) -> Probe {
+        unsafe { Self::wrap(&self.ctx, Z3_probe_not(self.ctx.z3_ctx.0, self.z3_probe)) }
     }
 
     /// Return a probe that evaluates to "true" when the value returned
     /// by `self` is not equal to the value returned by `p`.
-    pub fn ne(&self, p: &Probe) -> Probe<'ctx> {
+    pub fn ne(&self, p: &Probe) -> Probe {
         self.eq(p).not()
     }
 }
 
-impl Clone for Probe<'_> {
+impl Clone for Probe {
     fn clone(&self) -> Self {
-        unsafe { Self::wrap(self.ctx, self.z3_probe) }
+        unsafe { Self::wrap(&self.ctx, self.z3_probe) }
     }
 }
 
-impl fmt::Display for Probe<'_> {
+impl fmt::Display for Probe {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "<z3.probe>")
     }
 }
 
-impl fmt::Debug for Probe<'_> {
+impl fmt::Debug for Probe {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         <Self as fmt::Display>::fmt(self, f)
     }
 }
 
-impl Drop for Probe<'_> {
+impl Drop for Probe {
     fn drop(&mut self) {
         unsafe {
-            Z3_probe_dec_ref(self.ctx.z3_ctx, self.z3_probe);
+            Z3_probe_dec_ref(self.ctx.z3_ctx.0, self.z3_probe);
         }
     }
 }

--- a/z3/src/rec_func_decl.rs
+++ b/z3/src/rec_func_decl.rs
@@ -10,17 +10,18 @@ use crate::{Context, FuncDecl, RecFuncDecl, Sort, Symbol, ast, ast::Ast};
 impl RecFuncDecl {
     pub(crate) unsafe fn wrap(ctx: &Context, z3_func_decl: Z3_func_decl) -> Self {
         unsafe {
-            Z3_inc_ref(ctx.z3_ctx.0, Z3_func_decl_to_ast(ctx.z3_ctx.0, z3_func_decl));
+            Z3_inc_ref(
+                ctx.z3_ctx.0,
+                Z3_func_decl_to_ast(ctx.z3_ctx.0, z3_func_decl),
+            );
         }
-        Self { ctx: ctx.clone(), z3_func_decl }
+        Self {
+            ctx: ctx.clone(),
+            z3_func_decl,
+        }
     }
 
-    pub fn new<S: Into<Symbol>>(
-        ctx: &Context,
-        name: S,
-        domain: &[&Sort],
-        range: &Sort,
-    ) -> Self {
+    pub fn new<S: Into<Symbol>>(ctx: &Context, name: S, domain: &[&Sort], range: &Sort) -> Self {
         assert!(domain.iter().all(|s| s.ctx.z3_ctx == ctx.z3_ctx));
         assert_eq!(ctx.z3_ctx.0, range.ctx.z3_ctx.0);
 

--- a/z3/src/rec_func_decl.rs
+++ b/z3/src/rec_func_decl.rs
@@ -7,22 +7,22 @@ use z3_sys::*;
 
 use crate::{Context, FuncDecl, RecFuncDecl, Sort, Symbol, ast, ast::Ast};
 
-impl<'ctx> RecFuncDecl<'ctx> {
-    pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_func_decl: Z3_func_decl) -> Self {
+impl RecFuncDecl {
+    pub(crate) unsafe fn wrap(ctx: &Context, z3_func_decl: Z3_func_decl) -> Self {
         unsafe {
-            Z3_inc_ref(ctx.z3_ctx, Z3_func_decl_to_ast(ctx.z3_ctx, z3_func_decl));
+            Z3_inc_ref(ctx.z3_ctx.0, Z3_func_decl_to_ast(ctx.z3_ctx.0, z3_func_decl));
         }
-        Self { ctx, z3_func_decl }
+        Self { ctx: ctx.clone(), z3_func_decl }
     }
 
     pub fn new<S: Into<Symbol>>(
-        ctx: &'ctx Context,
+        ctx: &Context,
         name: S,
-        domain: &[&Sort<'ctx>],
-        range: &Sort<'ctx>,
+        domain: &[&Sort],
+        range: &Sort,
     ) -> Self {
         assert!(domain.iter().all(|s| s.ctx.z3_ctx == ctx.z3_ctx));
-        assert_eq!(ctx.z3_ctx, range.ctx.z3_ctx);
+        assert_eq!(ctx.z3_ctx.0, range.ctx.z3_ctx.0);
 
         let domain: Vec<_> = domain.iter().map(|s| s.z3_sort).collect();
 
@@ -30,7 +30,7 @@ impl<'ctx> RecFuncDecl<'ctx> {
             Self::wrap(
                 ctx,
                 Z3_mk_rec_func_decl(
-                    ctx.z3_ctx,
+                    ctx.z3_ctx.0,
                     name.into().as_z3_symbol(ctx),
                     domain.len().try_into().unwrap(),
                     domain.as_ptr(),
@@ -74,19 +74,19 @@ impl<'ctx> RecFuncDecl<'ctx> {
     /// ```
     ///
     /// Note that `args` should have the types corresponding to the `domain` of the `RecFuncDecl`.
-    pub fn add_def(&self, args: &[&dyn ast::Ast<'ctx>], body: &dyn Ast<'ctx>) {
+    pub fn add_def(&self, args: &[&dyn ast::Ast], body: &dyn Ast) {
         assert!(args.iter().all(|arg| arg.get_ctx() == body.get_ctx()));
-        assert_eq!(self.ctx, body.get_ctx());
+        assert_eq!(&self.ctx, body.get_ctx());
 
         let mut args: Vec<_> = args.iter().map(|s| s.get_z3_ast()).collect();
         unsafe {
             assert_eq!(
                 body.get_sort().z3_sort,
-                Z3_get_range(self.ctx.z3_ctx, self.z3_func_decl)
+                Z3_get_range(self.ctx.z3_ctx.0, self.z3_func_decl)
             );
 
             Z3_add_rec_def(
-                self.ctx.z3_ctx,
+                self.ctx.z3_ctx.0,
                 self.z3_func_decl,
                 self.arity() as u32,
                 args.as_mut_ptr(),
@@ -96,9 +96,9 @@ impl<'ctx> RecFuncDecl<'ctx> {
     }
 }
 
-impl fmt::Display for RecFuncDecl<'_> {
+impl fmt::Display for RecFuncDecl {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_func_decl_to_string(self.ctx.z3_ctx, self.z3_func_decl) };
+        let p = unsafe { Z3_func_decl_to_string(self.ctx.z3_ctx.0, self.z3_func_decl) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -109,25 +109,25 @@ impl fmt::Display for RecFuncDecl<'_> {
     }
 }
 
-impl fmt::Debug for RecFuncDecl<'_> {
+impl fmt::Debug for RecFuncDecl {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         <Self as fmt::Display>::fmt(self, f)
     }
 }
 
-impl Drop for RecFuncDecl<'_> {
+impl Drop for RecFuncDecl {
     fn drop(&mut self) {
         unsafe {
             Z3_dec_ref(
-                self.ctx.z3_ctx,
-                Z3_func_decl_to_ast(self.ctx.z3_ctx, self.z3_func_decl),
+                self.ctx.z3_ctx.0,
+                Z3_func_decl_to_ast(self.ctx.z3_ctx.0, self.z3_func_decl),
             );
         }
     }
 }
 
-impl<'ctx> Deref for RecFuncDecl<'ctx> {
-    type Target = FuncDecl<'ctx>;
+impl Deref for RecFuncDecl {
+    type Target = FuncDecl;
 
     fn deref(&self) -> &Self::Target {
         unsafe { &*(self as *const _ as *const Self::Target) }

--- a/z3/src/solver.rs
+++ b/z3/src/solver.rs
@@ -13,7 +13,10 @@ impl Solver {
         unsafe {
             Z3_solver_inc_ref(ctx.z3_ctx.0, z3_slv);
         }
-        Solver { ctx: ctx.clone(), z3_slv }
+        Solver {
+            ctx: ctx.clone(),
+            z3_slv,
+        }
     }
 
     /// Create a new solver. This solver is a "combined solver"

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -6,74 +6,74 @@ use z3_sys::*;
 
 use crate::{Context, FuncDecl, Sort, SortDiffers, Symbol};
 
-impl<'ctx> Sort<'ctx> {
-    pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_sort: Z3_sort) -> Sort<'ctx> {
+impl Sort {
+    pub(crate) unsafe fn wrap(ctx: &Context, z3_sort: Z3_sort) -> Sort {
         unsafe {
-            Z3_inc_ref(ctx.z3_ctx, Z3_sort_to_ast(ctx.z3_ctx, z3_sort));
+            Z3_inc_ref(ctx.z3_ctx.0, Z3_sort_to_ast(ctx.z3_ctx.0, z3_sort));
         }
-        Sort { ctx, z3_sort }
+        Sort { ctx: ctx.clone(), z3_sort }
     }
 
     pub fn get_z3_sort(&self) -> Z3_sort {
         self.z3_sort
     }
 
-    pub fn uninterpreted(ctx: &'ctx Context, name: Symbol) -> Sort<'ctx> {
+    pub fn uninterpreted(ctx: &Context, name: Symbol) -> Sort {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_uninterpreted_sort(ctx.z3_ctx, name.as_z3_symbol(ctx)),
+                Z3_mk_uninterpreted_sort(ctx.z3_ctx.0, name.as_z3_symbol(ctx)),
             )
         }
     }
 
-    pub fn bool(ctx: &'ctx Context) -> Sort<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_bool_sort(ctx.z3_ctx)) }
+    pub fn bool(ctx: &Context) -> Sort {
+        unsafe { Self::wrap(ctx, Z3_mk_bool_sort(ctx.z3_ctx.0)) }
     }
 
-    pub fn int(ctx: &'ctx Context) -> Sort<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_int_sort(ctx.z3_ctx)) }
+    pub fn int(ctx: &Context) -> Sort {
+        unsafe { Self::wrap(ctx, Z3_mk_int_sort(ctx.z3_ctx.0)) }
     }
 
-    pub fn real(ctx: &'ctx Context) -> Sort<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_real_sort(ctx.z3_ctx)) }
+    pub fn real(ctx: &Context) -> Sort {
+        unsafe { Self::wrap(ctx, Z3_mk_real_sort(ctx.z3_ctx.0)) }
     }
 
-    pub fn float(ctx: &'ctx Context, ebits: u32, sbits: u32) -> Sort<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx, ebits, sbits)) }
+    pub fn float(ctx: &Context, ebits: u32, sbits: u32) -> Sort {
+        unsafe { Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.0, ebits, sbits)) }
     }
 
-    pub fn float32(ctx: &'ctx Context) -> Sort<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx, 8, 24)) }
+    pub fn float32(ctx: &Context) -> Sort {
+        unsafe { Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.0, 8, 24)) }
     }
 
-    pub fn double(ctx: &'ctx Context) -> Sort<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx, 11, 53)) }
+    pub fn double(ctx: &Context) -> Sort {
+        unsafe { Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.0, 11, 53)) }
     }
 
-    pub fn string(ctx: &'ctx Context) -> Sort<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_string_sort(ctx.z3_ctx)) }
+    pub fn string(ctx: &Context) -> Sort {
+        unsafe { Self::wrap(ctx, Z3_mk_string_sort(ctx.z3_ctx.0)) }
     }
 
-    pub fn bitvector(ctx: &'ctx Context, sz: u32) -> Sort<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_bv_sort(ctx.z3_ctx, sz as ::std::os::raw::c_uint)) }
+    pub fn bitvector(ctx: &Context, sz: u32) -> Sort {
+        unsafe { Self::wrap(ctx, Z3_mk_bv_sort(ctx.z3_ctx.0, sz as ::std::os::raw::c_uint)) }
     }
 
-    pub fn array(ctx: &'ctx Context, domain: &Sort<'ctx>, range: &Sort<'ctx>) -> Sort<'ctx> {
+    pub fn array(ctx: &Context, domain: &Sort, range: &Sort) -> Sort {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_array_sort(ctx.z3_ctx, domain.z3_sort, range.z3_sort),
+                Z3_mk_array_sort(ctx.z3_ctx.0, domain.z3_sort, range.z3_sort),
             )
         }
     }
 
-    pub fn set(ctx: &'ctx Context, elt: &Sort<'ctx>) -> Sort<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_set_sort(ctx.z3_ctx, elt.z3_sort)) }
+    pub fn set(ctx: &Context, elt: &Sort) -> Sort {
+        unsafe { Self::wrap(ctx, Z3_mk_set_sort(ctx.z3_ctx.0, elt.z3_sort)) }
     }
 
-    pub fn seq(ctx: &'ctx Context, elt: &Sort<'ctx>) -> Sort<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_mk_seq_sort(ctx.z3_ctx, elt.z3_sort)) }
+    pub fn seq(ctx: &Context, elt: &Sort) -> Sort {
+        unsafe { Self::wrap(ctx, Z3_mk_seq_sort(ctx.z3_ctx.0, elt.z3_sort)) }
     }
 
     /// Create an enumeration sort.
@@ -111,10 +111,10 @@ impl<'ctx> Sort<'ctx> {
     /// assert!(model.eval(&eq, true).unwrap().as_bool().unwrap().as_bool().unwrap());
     /// ```
     pub fn enumeration(
-        ctx: &'ctx Context,
+        ctx: &Context,
         name: Symbol,
         enum_names: &[Symbol],
-    ) -> (Sort<'ctx>, Vec<FuncDecl<'ctx>>, Vec<FuncDecl<'ctx>>) {
+    ) -> (Sort, Vec<FuncDecl>, Vec<FuncDecl>) {
         let enum_names: Vec<_> = enum_names.iter().map(|s| s.as_z3_symbol(ctx)).collect();
         let mut enum_consts = vec![std::ptr::null_mut(); enum_names.len()];
         let mut enum_testers = vec![std::ptr::null_mut(); enum_names.len()];
@@ -123,7 +123,7 @@ impl<'ctx> Sort<'ctx> {
             Self::wrap(
                 ctx,
                 Z3_mk_enumeration_sort(
-                    ctx.z3_ctx,
+                    ctx.z3_ctx.0,
                     name.as_z3_symbol(ctx),
                     enum_names.len().try_into().unwrap(),
                     enum_names.as_ptr(),
@@ -136,12 +136,12 @@ impl<'ctx> Sort<'ctx> {
         // increase ref counts
         for i in &enum_consts {
             unsafe {
-                Z3_inc_ref(ctx.z3_ctx, *i as Z3_ast);
+                Z3_inc_ref(ctx.z3_ctx.0, *i as Z3_ast);
             }
         }
         for i in &enum_testers {
             unsafe {
-                Z3_inc_ref(ctx.z3_ctx, *i as Z3_ast);
+                Z3_inc_ref(ctx.z3_ctx.0, *i as Z3_ast);
             }
         }
 
@@ -149,14 +149,14 @@ impl<'ctx> Sort<'ctx> {
         let enum_consts: Vec<_> = enum_consts
             .iter()
             .map(|z3_func_decl| FuncDecl {
-                ctx,
+                ctx: ctx.clone(),
                 z3_func_decl: *z3_func_decl,
             })
             .collect();
         let enum_testers: Vec<_> = enum_testers
             .iter()
             .map(|z3_func_decl| FuncDecl {
-                ctx,
+                ctx: ctx.clone(),
                 z3_func_decl: *z3_func_decl,
             })
             .collect();
@@ -165,14 +165,14 @@ impl<'ctx> Sort<'ctx> {
     }
 
     pub fn kind(&self) -> SortKind {
-        unsafe { Z3_get_sort_kind(self.ctx.z3_ctx, self.z3_sort) }
+        unsafe { Z3_get_sort_kind(self.ctx.z3_ctx.0, self.z3_sort) }
     }
 
     /// Returns `Some(e)` where `e` is the number of exponent bits if the sort
     /// is a `FloatingPoint` and `None` otherwise.
     pub fn float_exponent_size(&self) -> Option<u32> {
         if self.kind() == SortKind::FloatingPoint {
-            Some(unsafe { Z3_fpa_get_ebits(self.ctx.z3_ctx, self.z3_sort) })
+            Some(unsafe { Z3_fpa_get_ebits(self.ctx.z3_ctx.0, self.z3_sort) })
         } else {
             None
         }
@@ -182,7 +182,7 @@ impl<'ctx> Sort<'ctx> {
     /// is a `FloatingPoint` and `None` otherwise.
     pub fn float_significand_size(&self) -> Option<u32> {
         if self.kind() == SortKind::FloatingPoint {
-            Some(unsafe { Z3_fpa_get_sbits(self.ctx.z3_ctx, self.z3_sort) })
+            Some(unsafe { Z3_fpa_get_sbits(self.ctx.z3_ctx.0, self.z3_sort) })
         } else {
             None
         }
@@ -226,14 +226,14 @@ impl<'ctx> Sort<'ctx> {
     /// assert!(int_sort.array_domain().is_none());
     /// assert!(bool_sort.array_domain().is_none());
     /// ```
-    pub fn array_domain(&self) -> Option<Sort<'ctx>> {
+    pub fn array_domain(&self) -> Option<Sort> {
         if self.is_array() {
             unsafe {
-                let domain_sort = Z3_get_array_sort_domain(self.ctx.z3_ctx, self.z3_sort);
+                let domain_sort = Z3_get_array_sort_domain(self.ctx.z3_ctx.0, self.z3_sort);
                 if domain_sort.is_null() {
                     None
                 } else {
-                    Some(Self::wrap(self.ctx, domain_sort))
+                    Some(Self::wrap(&self.ctx, domain_sort))
                 }
             }
         } else {
@@ -260,14 +260,14 @@ impl<'ctx> Sort<'ctx> {
     /// assert!(int_sort.array_range().is_none());
     /// assert!(bool_sort.array_range().is_none());
     /// ```
-    pub fn array_range(&self) -> Option<Sort<'ctx>> {
+    pub fn array_range(&self) -> Option<Sort> {
         if self.is_array() {
             unsafe {
-                let range_sort = Z3_get_array_sort_range(self.ctx.z3_ctx, self.z3_sort);
+                let range_sort = Z3_get_array_sort_range(self.ctx.z3_ctx.0, self.z3_sort);
                 if range_sort.is_null() {
                     None
                 } else {
-                    Some(Self::wrap(self.ctx, range_sort))
+                    Some(Self::wrap(&self.ctx, range_sort))
                 }
             }
         } else {
@@ -276,15 +276,15 @@ impl<'ctx> Sort<'ctx> {
     }
 }
 
-impl Clone for Sort<'_> {
+impl Clone for Sort {
     fn clone(&self) -> Self {
-        unsafe { Self::wrap(self.ctx, self.z3_sort) }
+        unsafe { Self::wrap(&self.ctx, self.z3_sort) }
     }
 }
 
-impl fmt::Display for Sort<'_> {
+impl fmt::Display for Sort {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_sort_to_string(self.ctx.z3_ctx, self.z3_sort) };
+        let p = unsafe { Z3_sort_to_string(self.ctx.z3_ctx.0, self.z3_sort) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -295,46 +295,46 @@ impl fmt::Display for Sort<'_> {
     }
 }
 
-impl fmt::Debug for Sort<'_> {
+impl fmt::Debug for Sort {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         <Self as fmt::Display>::fmt(self, f)
     }
 }
 
-impl<'ctx> PartialEq<Sort<'ctx>> for Sort<'ctx> {
-    fn eq(&self, other: &Sort<'ctx>) -> bool {
-        unsafe { Z3_is_eq_sort(self.ctx.z3_ctx, self.z3_sort, other.z3_sort) }
+impl PartialEq<Sort> for Sort {
+    fn eq(&self, other: &Sort) -> bool {
+        unsafe { Z3_is_eq_sort(self.ctx.z3_ctx.0, self.z3_sort, other.z3_sort) }
     }
 }
 
-impl Eq for Sort<'_> {}
+impl Eq for Sort {}
 
-impl Drop for Sort<'_> {
+impl Drop for Sort {
     fn drop(&mut self) {
         unsafe {
             Z3_dec_ref(
-                self.ctx.z3_ctx,
-                Z3_sort_to_ast(self.ctx.z3_ctx, self.z3_sort),
+                self.ctx.z3_ctx.0,
+                Z3_sort_to_ast(self.ctx.z3_ctx.0, self.z3_sort),
             );
         }
     }
 }
 
-impl<'ctx> SortDiffers<'ctx> {
-    pub fn new(left: Sort<'ctx>, right: Sort<'ctx>) -> Self {
+impl SortDiffers {
+    pub fn new(left: Sort, right: Sort) -> Self {
         Self { left, right }
     }
 
-    pub fn left(&self) -> &Sort<'_> {
+    pub fn left(&self) -> &Sort {
         &self.left
     }
 
-    pub fn right(&self) -> &Sort<'_> {
+    pub fn right(&self) -> &Sort {
         &self.right
     }
 }
 
-impl fmt::Display for SortDiffers<'_> {
+impl fmt::Display for SortDiffers {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(
             f,

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -11,7 +11,10 @@ impl Sort {
         unsafe {
             Z3_inc_ref(ctx.z3_ctx.0, Z3_sort_to_ast(ctx.z3_ctx.0, z3_sort));
         }
-        Sort { ctx: ctx.clone(), z3_sort }
+        Sort {
+            ctx: ctx.clone(),
+            z3_sort,
+        }
     }
 
     pub fn get_z3_sort(&self) -> Z3_sort {
@@ -56,7 +59,12 @@ impl Sort {
     }
 
     pub fn bitvector(ctx: &Context, sz: u32) -> Sort {
-        unsafe { Self::wrap(ctx, Z3_mk_bv_sort(ctx.z3_ctx.0, sz as ::std::os::raw::c_uint)) }
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_bv_sort(ctx.z3_ctx.0, sz as ::std::os::raw::c_uint),
+            )
+        }
     }
 
     pub fn array(ctx: &Context, domain: &Sort, range: &Sort) -> Sort {

--- a/z3/src/statistics.rs
+++ b/z3/src/statistics.rs
@@ -28,13 +28,13 @@ pub struct StatisticsEntry {
     pub value: StatisticsValue,
 }
 
-impl<'ctx> Statistics<'ctx> {
+impl Statistics {
     /// Wrap a raw [`Z3_stats`], managing refcounts.
-    pub(crate) unsafe fn wrap(ctx: &'ctx Context, z3_stats: Z3_stats) -> Statistics<'ctx> {
+    pub(crate) unsafe fn wrap(ctx: &Context, z3_stats: Z3_stats) -> Statistics {
         unsafe {
-            Z3_stats_inc_ref(ctx.z3_ctx, z3_stats);
+            Z3_stats_inc_ref(ctx.z3_ctx.0, z3_stats);
         }
-        Statistics { ctx, z3_stats }
+        Statistics { ctx: ctx.clone(), z3_stats }
     }
 
     /// Get the statistics value at the given index.
@@ -44,11 +44,11 @@ impl<'ctx> Statistics<'ctx> {
     /// This assumes that `idx` is a valid index.
     unsafe fn value_at_idx(&self, idx: u32) -> StatisticsValue {
         unsafe {
-            if Z3_stats_is_uint(self.ctx.z3_ctx, self.z3_stats, idx) {
-                StatisticsValue::UInt(Z3_stats_get_uint_value(self.ctx.z3_ctx, self.z3_stats, idx))
+            if Z3_stats_is_uint(self.ctx.z3_ctx.0, self.z3_stats, idx) {
+                StatisticsValue::UInt(Z3_stats_get_uint_value(self.ctx.z3_ctx.0, self.z3_stats, idx))
             } else {
                 StatisticsValue::Double(Z3_stats_get_double_value(
-                    self.ctx.z3_ctx,
+                    self.ctx.z3_ctx.0,
                     self.z3_stats,
                     idx,
                 ))
@@ -59,9 +59,9 @@ impl<'ctx> Statistics<'ctx> {
     /// Get the statistics value for the given `key`.
     pub fn value(&self, key: &str) -> Option<StatisticsValue> {
         unsafe {
-            let size = Z3_stats_size(self.ctx.z3_ctx, self.z3_stats);
+            let size = Z3_stats_size(self.ctx.z3_ctx.0, self.z3_stats);
             for idx in 0..size {
-                let k = CStr::from_ptr(Z3_stats_get_key(self.ctx.z3_ctx, self.z3_stats, idx));
+                let k = CStr::from_ptr(Z3_stats_get_key(self.ctx.z3_ctx.0, self.z3_stats, idx));
                 if k.to_str().unwrap() == key {
                     return Some(self.value_at_idx(idx));
                 }
@@ -72,9 +72,9 @@ impl<'ctx> Statistics<'ctx> {
 
     /// Iterate over all of the entries in this set of statistics.
     pub fn entries(&self) -> impl Iterator<Item = StatisticsEntry> + '_ {
-        let p = unsafe { Z3_stats_size(self.ctx.z3_ctx, self.z3_stats) };
+        let p = unsafe { Z3_stats_size(self.ctx.z3_ctx.0, self.z3_stats) };
         (0..p).map(move |n| unsafe {
-            let t = Z3_stats_get_key(self.ctx.z3_ctx, self.z3_stats, n);
+            let t = Z3_stats_get_key(self.ctx.z3_ctx.0, self.z3_stats, n);
             StatisticsEntry {
                 key: CStr::from_ptr(t).to_str().unwrap().to_owned(),
                 value: self.value_at_idx(n),
@@ -83,19 +83,19 @@ impl<'ctx> Statistics<'ctx> {
     }
 }
 
-impl Clone for Statistics<'_> {
+impl Clone for Statistics {
     fn clone(&self) -> Self {
-        unsafe { Self::wrap(self.ctx, self.z3_stats) }
+        unsafe { Self::wrap(&self.ctx, self.z3_stats) }
     }
 }
 
-impl fmt::Display for Statistics<'_> {
+impl fmt::Display for Statistics {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "<z3.stats>")
     }
 }
 
-impl fmt::Debug for Statistics<'_> {
+impl fmt::Debug for Statistics {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let mut s = f.debug_struct("Statistics");
         for e in self.entries() {
@@ -108,10 +108,10 @@ impl fmt::Debug for Statistics<'_> {
     }
 }
 
-impl Drop for Statistics<'_> {
+impl Drop for Statistics {
     fn drop(&mut self) {
         unsafe {
-            Z3_stats_dec_ref(self.ctx.z3_ctx, self.z3_stats);
+            Z3_stats_dec_ref(self.ctx.z3_ctx.0, self.z3_stats);
         }
     }
 }

--- a/z3/src/statistics.rs
+++ b/z3/src/statistics.rs
@@ -34,7 +34,10 @@ impl Statistics {
         unsafe {
             Z3_stats_inc_ref(ctx.z3_ctx.0, z3_stats);
         }
-        Statistics { ctx: ctx.clone(), z3_stats }
+        Statistics {
+            ctx: ctx.clone(),
+            z3_stats,
+        }
     }
 
     /// Get the statistics value at the given index.
@@ -45,7 +48,11 @@ impl Statistics {
     unsafe fn value_at_idx(&self, idx: u32) -> StatisticsValue {
         unsafe {
             if Z3_stats_is_uint(self.ctx.z3_ctx.0, self.z3_stats, idx) {
-                StatisticsValue::UInt(Z3_stats_get_uint_value(self.ctx.z3_ctx.0, self.z3_stats, idx))
+                StatisticsValue::UInt(Z3_stats_get_uint_value(
+                    self.ctx.z3_ctx.0,
+                    self.z3_stats,
+                    idx,
+                ))
             } else {
                 StatisticsValue::Double(Z3_stats_get_double_value(
                     self.ctx.z3_ctx.0,

--- a/z3/src/symbol.rs
+++ b/z3/src/symbol.rs
@@ -7,11 +7,13 @@ use crate::{Context, Symbol};
 impl Symbol {
     pub fn as_z3_symbol(&self, ctx: &Context) -> Z3_symbol {
         match self {
-            Symbol::Int(i) => unsafe { Z3_mk_int_symbol(ctx.z3_ctx, *i as ::std::os::raw::c_int) },
+            Symbol::Int(i) => unsafe {
+                Z3_mk_int_symbol(ctx.z3_ctx.0, *i as ::std::os::raw::c_int)
+            },
             Symbol::String(s) => {
                 let ss = CString::new(s.clone()).unwrap();
                 let p = ss.as_ptr();
-                unsafe { Z3_mk_string_symbol(ctx.z3_ctx, p) }
+                unsafe { Z3_mk_string_symbol(ctx.z3_ctx.0, p) }
             }
         }
     }

--- a/z3/src/tactic.rs
+++ b/z3/src/tactic.rs
@@ -10,38 +10,38 @@ use z3_sys::*;
 
 use crate::{ApplyResult, Context, Goal, Params, Probe, Solver, Tactic};
 
-impl<'ctx> ApplyResult<'ctx> {
-    unsafe fn wrap(ctx: &'ctx Context, z3_apply_result: Z3_apply_result) -> ApplyResult<'ctx> {
+impl ApplyResult {
+    unsafe fn wrap(ctx: & Context, z3_apply_result: Z3_apply_result) -> ApplyResult {
         unsafe {
-            Z3_apply_result_inc_ref(ctx.z3_ctx, z3_apply_result);
+            Z3_apply_result_inc_ref(ctx.z3_ctx.0, z3_apply_result);
         }
         ApplyResult {
-            ctx,
+            ctx: ctx.clone(),
             z3_apply_result,
         }
     }
 
-    pub fn list_subgoals(self) -> impl Iterator<Item = Goal<'ctx>> {
+    pub fn list_subgoals(self) -> impl Iterator<Item = Goal> {
         let num_subgoals =
-            unsafe { Z3_apply_result_get_num_subgoals(self.ctx.z3_ctx, self.z3_apply_result) };
+            unsafe { Z3_apply_result_get_num_subgoals(self.ctx.z3_ctx.0, self.z3_apply_result) };
         (0..num_subgoals).map(move |i| unsafe {
             Goal::wrap(
-                self.ctx,
-                Z3_apply_result_get_subgoal(self.ctx.z3_ctx, self.z3_apply_result, i),
+                &self.ctx,
+                Z3_apply_result_get_subgoal(self.ctx.z3_ctx.0, self.z3_apply_result, i),
             )
         })
     }
 }
 
-impl Drop for ApplyResult<'_> {
+impl Drop for ApplyResult {
     fn drop(&mut self) {
         unsafe {
-            Z3_apply_result_dec_ref(self.ctx.z3_ctx, self.z3_apply_result);
+            Z3_apply_result_dec_ref(self.ctx.z3_ctx.0, self.z3_apply_result);
         }
     }
 }
 
-impl<'ctx> Tactic<'ctx> {
+impl Tactic {
     /// Iterate through the valid tactic names.
     ///
     /// # Example
@@ -55,20 +55,20 @@ impl<'ctx> Tactic<'ctx> {
     /// assert!(tactics.contains(&"ufbv"));
     /// ```
     pub fn list_all(
-        ctx: &'ctx Context,
-    ) -> impl Iterator<Item = std::result::Result<&'ctx str, Utf8Error>> {
-        let p = unsafe { Z3_get_num_tactics(ctx.z3_ctx) };
+        ctx: &Context,
+    ) -> impl Iterator<Item = std::result::Result<&str, Utf8Error>> {
+        let p = unsafe { Z3_get_num_tactics(ctx.z3_ctx.0) };
         (0..p).map(move |n| {
-            let t = unsafe { Z3_get_tactic_name(ctx.z3_ctx, n) };
+            let t = unsafe { Z3_get_tactic_name(ctx.z3_ctx.0, n) };
             unsafe { CStr::from_ptr(t) }.to_str()
         })
     }
 
-    unsafe fn wrap(ctx: &'ctx Context, z3_tactic: Z3_tactic) -> Tactic<'ctx> {
+    unsafe fn wrap(ctx: & Context, z3_tactic: Z3_tactic) -> Tactic {
         unsafe {
-            Z3_tactic_inc_ref(ctx.z3_ctx, z3_tactic);
+            Z3_tactic_inc_ref(ctx.z3_ctx.0, z3_tactic);
         }
-        Tactic { ctx, z3_tactic }
+        Tactic { ctx: ctx.clone(), z3_tactic }
     }
 
     /// Create a tactic by name.
@@ -86,11 +86,11 @@ impl<'ctx> Tactic<'ctx> {
     /// # See also
     ///
     /// - [`Tactic::list_all()`]
-    pub fn new(ctx: &'ctx Context, name: &str) -> Tactic<'ctx> {
+    pub fn new(ctx: & Context, name: &str) -> Tactic {
         let tactic_name = CString::new(name).unwrap();
 
         unsafe {
-            let tactic = Z3_mk_tactic(ctx.z3_ctx, tactic_name.as_ptr());
+            let tactic = Z3_mk_tactic(ctx.z3_ctx.0, tactic_name.as_ptr());
             if tactic.is_null() {
                 panic!("{name} is an invalid tactic");
             } else {
@@ -100,73 +100,73 @@ impl<'ctx> Tactic<'ctx> {
     }
 
     /// Return a tactic that just return the given goal.
-    pub fn create_skip(ctx: &'ctx Context) -> Tactic<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_tactic_skip(ctx.z3_ctx)) }
+    pub fn create_skip(ctx: & Context) -> Tactic {
+        unsafe { Self::wrap(ctx, Z3_tactic_skip(ctx.z3_ctx.0)) }
     }
 
     /// Return a tactic that always fails.
-    pub fn create_fail(ctx: &'ctx Context) -> Tactic<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_tactic_fail(ctx.z3_ctx)) }
+    pub fn create_fail(ctx: & Context) -> Tactic {
+        unsafe { Self::wrap(ctx, Z3_tactic_fail(ctx.z3_ctx.0)) }
     }
 
     /// Return a tactic that keeps applying `t` until the goal is not modified anymore or the maximum
     /// number of iterations `max` is reached.
-    pub fn repeat(ctx: &'ctx Context, t: &Tactic<'ctx>, max: u32) -> Tactic<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_tactic_repeat(ctx.z3_ctx, t.z3_tactic, max)) }
+    pub fn repeat(ctx: & Context, t: &Tactic, max: u32) -> Tactic {
+        unsafe { Self::wrap(ctx, Z3_tactic_repeat(ctx.z3_ctx.0, t.z3_tactic, max)) }
     }
 
     /// Return a tactic that applies the current tactic to a given goal, failing
     /// if it doesn't terminate within the period specified by `timeout`.
-    pub fn try_for(&self, timeout: Duration) -> Tactic<'ctx> {
+    pub fn try_for(&self, timeout: Duration) -> Tactic {
         let timeout_ms = c_uint::try_from(timeout.as_millis()).unwrap_or(c_uint::MAX);
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_tactic_try_for(self.ctx.z3_ctx, self.z3_tactic, timeout_ms),
+                &self.ctx,
+                Z3_tactic_try_for(self.ctx.z3_ctx.0, self.z3_tactic, timeout_ms),
             )
         }
     }
 
     /// Return a tactic that applies the current tactic to a given goal and
     /// the `then_tactic` to every subgoal produced by the original tactic.
-    pub fn and_then(&self, then_tactic: &Tactic<'ctx>) -> Tactic<'ctx> {
+    pub fn and_then(&self, then_tactic: &Tactic) -> Tactic {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_tactic_and_then(self.ctx.z3_ctx, self.z3_tactic, then_tactic.z3_tactic),
+                &self.ctx,
+                Z3_tactic_and_then(self.ctx.z3_ctx.0, self.z3_tactic, then_tactic.z3_tactic),
             )
         }
     }
 
     /// Return a tactic that current tactic to a given goal,
     /// if it fails then returns the result of `else_tactic` applied to the given goal.
-    pub fn or_else(&self, else_tactic: &Tactic<'ctx>) -> Tactic<'ctx> {
+    pub fn or_else(&self, else_tactic: &Tactic) -> Tactic {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_tactic_or_else(self.ctx.z3_ctx, self.z3_tactic, else_tactic.z3_tactic),
+                &self.ctx,
+                Z3_tactic_or_else(self.ctx.z3_ctx.0, self.z3_tactic, else_tactic.z3_tactic),
             )
         }
     }
 
     /// Return a tactic that applies self to a given goal if the probe `p` evaluates to true,
     /// and `t` if `p` evaluates to false.
-    pub fn probe_or_else(&self, p: &Probe<'ctx>, t: &Tactic<'ctx>) -> Tactic<'ctx> {
+    pub fn probe_or_else(&self, p: &Probe, t: &Tactic) -> Tactic {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_tactic_cond(self.ctx.z3_ctx, p.z3_probe, self.z3_tactic, t.z3_tactic),
+                &self.ctx,
+                Z3_tactic_cond(self.ctx.z3_ctx.0, p.z3_probe, self.z3_tactic, t.z3_tactic),
             )
         }
     }
 
     /// Return a tactic that applies itself to a given goal if the probe `p` evaluates to true.
     /// If `p` evaluates to false, then the new tactic behaves like the skip tactic.
-    pub fn when(&self, p: &Probe<'ctx>) -> Tactic<'ctx> {
+    pub fn when(&self, p: &Probe) -> Tactic {
         unsafe {
             Self::wrap(
-                self.ctx,
-                Z3_tactic_when(self.ctx.z3_ctx, p.z3_probe, self.z3_tactic),
+                &self.ctx,
+                Z3_tactic_when(self.ctx.z3_ctx.0, p.z3_probe, self.z3_tactic),
             )
         }
     }
@@ -174,22 +174,22 @@ impl<'ctx> Tactic<'ctx> {
     /// Return a tactic that applies `t1` to a given goal if the probe `p` evaluates to true,
     /// and `t2` if `p` evaluates to false.
     pub fn cond(
-        ctx: &'ctx Context,
-        p: &Probe<'ctx>,
-        t1: &Tactic<'ctx>,
-        t2: &Tactic<'ctx>,
-    ) -> Tactic<'ctx> {
+        ctx: & Context,
+        p: &Probe,
+        t1: &Tactic,
+        t2: &Tactic,
+    ) -> Tactic {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_tactic_cond(ctx.z3_ctx, p.z3_probe, t1.z3_tactic, t2.z3_tactic),
+                Z3_tactic_cond(ctx.z3_ctx.0, p.z3_probe, t1.z3_tactic, t2.z3_tactic),
             )
         }
     }
 
     /// Return a tactic that fails if the probe `p` evaluates to false.
-    pub fn fail_if(ctx: &'ctx Context, p: &Probe<'ctx>) -> Tactic<'ctx> {
-        unsafe { Self::wrap(ctx, Z3_tactic_fail_if(ctx.z3_ctx, p.z3_probe)) }
+    pub fn fail_if(ctx: & Context, p: &Probe) -> Tactic {
+        unsafe { Self::wrap(ctx, Z3_tactic_fail_if(ctx.z3_ctx.0, p.z3_probe)) }
     }
 
     /// Attempts to apply the tactic to `goal`. If the tactic succeeds, returns
@@ -197,27 +197,27 @@ impl<'ctx> Tactic<'ctx> {
     /// an error message describing why.
     pub fn apply(
         &self,
-        goal: &Goal<'ctx>,
-        params: Option<&Params<'ctx>>,
-    ) -> Result<ApplyResult<'ctx>, String> {
+        goal: &Goal,
+        params: Option<&Params>,
+    ) -> Result<ApplyResult, String> {
         unsafe {
             let z3_apply_result = match params {
-                None => Z3_tactic_apply(self.ctx.z3_ctx, self.z3_tactic, goal.z3_goal),
+                None => Z3_tactic_apply(self.ctx.z3_ctx.0, self.z3_tactic, goal.z3_goal),
                 Some(params) => Z3_tactic_apply_ex(
-                    self.ctx.z3_ctx,
+                    self.ctx.z3_ctx.0,
                     self.z3_tactic,
                     goal.z3_goal,
                     params.z3_params,
                 ),
             };
             if z3_apply_result.is_null() {
-                let code = Z3_get_error_code(self.ctx.z3_ctx);
-                let msg = Z3_get_error_msg(self.ctx.z3_ctx, code);
+                let code = Z3_get_error_code(self.ctx.z3_ctx.0);
+                let msg = Z3_get_error_msg(self.ctx.z3_ctx.0, code);
                 Err(String::from(CStr::from_ptr(msg).to_str().unwrap_or(
                     "Couldn't retrieve error message from z3: got invalid UTF-8",
                 )))
             } else {
-                Ok(ApplyResult::wrap(self.ctx, z3_apply_result))
+                Ok(ApplyResult::wrap(&self.ctx, z3_apply_result))
             }
         }
     }
@@ -241,19 +241,19 @@ impl<'ctx> Tactic<'ctx> {
     /// assert_eq!(solver.check(), SatResult::Sat);
     /// ```
     ///
-    pub fn solver(&self) -> Solver<'ctx> {
+    pub fn solver(&self) -> Solver {
         unsafe {
             Solver::wrap(
-                self.ctx,
-                Z3_mk_solver_from_tactic(self.ctx.z3_ctx, self.z3_tactic),
+                &self.ctx,
+                Z3_mk_solver_from_tactic(self.ctx.z3_ctx.0, self.z3_tactic),
             )
         }
     }
 }
 
-impl fmt::Display for Tactic<'_> {
+impl fmt::Display for Tactic {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_tactic_get_help(self.ctx.z3_ctx, self.z3_tactic) };
+        let p = unsafe { Z3_tactic_get_help(self.ctx.z3_ctx.0, self.z3_tactic) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -264,16 +264,16 @@ impl fmt::Display for Tactic<'_> {
     }
 }
 
-impl fmt::Debug for Tactic<'_> {
+impl fmt::Debug for Tactic {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         <Self as fmt::Display>::fmt(self, f)
     }
 }
 
-impl Drop for Tactic<'_> {
+impl Drop for Tactic {
     fn drop(&mut self) {
         unsafe {
-            Z3_tactic_dec_ref(self.ctx.z3_ctx, self.z3_tactic);
+            Z3_tactic_dec_ref(self.ctx.z3_ctx.0, self.z3_tactic);
         }
     }
 }

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -128,7 +128,7 @@ fn test_cloning_ast() {
     assert_eq!(yv, 0);
 }
 
-fn get_some_solver_assertions(ctx: &Context) -> Vec<ast::Bool<'_>> {
+fn get_some_solver_assertions(ctx: &Context) -> Vec<ast::Bool> {
     let s = Solver::new(ctx);
     let x = ast::Int::new_const(ctx, "x");
     let y = ast::Int::new_const(ctx, "y");

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1663,7 +1663,7 @@ fn test_ast_safe_eq() {
     let other_bool: ast::Dynamic = ast::Bool::new_const(ctx, "c").into();
     let other_string: ast::Dynamic = ast::String::from_str(ctx, "d").unwrap().into();
 
-    let sd: SortDiffers<'_> = SortDiffers::new(other_bool.get_sort(), other_string.get_sort());
+    let sd: SortDiffers = SortDiffers::new(other_bool.get_sort(), other_string.get_sort());
 
     let result = x._safe_eq(&y);
     assert!(result.is_err());

--- a/z3/tests/ops.rs
+++ b/z3/tests/ops.rs
@@ -269,7 +269,7 @@ fn test_bool_ops() {
     test_unary_op!(!);
 }
 
-fn assert_bool_child<'c>(node: &impl Ast, idx: usize, expected: &Bool) {
+fn assert_bool_child(node: &impl Ast, idx: usize, expected: &Bool) {
     assert_eq!(&node.nth_child(idx).unwrap().as_bool().unwrap(), expected);
 }
 

--- a/z3/tests/ops.rs
+++ b/z3/tests/ops.rs
@@ -269,7 +269,7 @@ fn test_bool_ops() {
     test_unary_op!(!);
 }
 
-fn assert_bool_child<'c>(node: &impl Ast<'c>, idx: usize, expected: &Bool<'c>) {
+fn assert_bool_child<'c>(node: &impl Ast, idx: usize, expected: &Bool) {
     assert_eq!(&node.nth_child(idx).unwrap().as_bool().unwrap(), expected);
 }
 

--- a/z3/tests/ops.rs
+++ b/z3/tests/ops.rs
@@ -313,7 +313,7 @@ fn test_ast_children() {
     assert_eq!(children[2].as_bool().unwrap(), c);
 }
 
-fn assert_ast_attributes<'c, T: Ast<'c>>(expr: &T, is_const: bool) {
+fn assert_ast_attributes<T: Ast>(expr: &T, is_const: bool) {
     assert_eq!(expr.kind(), AstKind::App);
     assert!(expr.is_app());
     assert_eq!(expr.is_const(), is_const);


### PR DESCRIPTION
This PR makes `Context` internally refcounted on the Rust side with an `Rc` around a `pub(crate)` wrapper implementing `Drop`. This has a couple effects:

* All other z3 types (e.g. all `Ast`s, `Solver`s, etc) _own_ their (refcounted) `Context` handle, removing almost all instances of the `'ctx` lifetime (with the exception of those associated with the `ContextHandle` type).
* The `Context` is refcounted on the rust side any time an `Ast`/`Solver`/etc is cloned and decremented any time it is dropped.

Simple consuming code will mostly be unchanged due the compiler eliding lifetimes in the old version. Removing the occasional lifetime argument was the only change required for the existing test suite.


This is a *BREAKING* change: consuming code with types wrapping `z3.rs` types must be migrated to remove the `'ctx` lifetime.

So:

```rust
struct MyStruct<'ctx>{
    a: BV<'ctx>,
    b: BV<'ctx>,
}
```

becomes:

```rust
struct MyStruct{
    a: BV,
    b: BV,
}