### PR TITLE
feat: impl Default for Context

### DIFF
--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -125,6 +125,14 @@ impl Context {
     }
 }
 
+/// The default [`Context`] uses [`Config::default`]
+impl Default for Context {
+    fn default() -> Self {
+        let cfg = Config::default();
+        Context::new(&cfg)
+    }
+}
+
 impl ContextHandle<'_> {
     /// Interrupt a solver performing a satisfiability test, a tactic processing a goal, or simplify functions.
     pub fn interrupt(&self) {


### PR DESCRIPTION
Most `z3` Rust code has the following boilerplate to make a context:

```rust
let cfg = Config::default();
let ctx = Context::new(&cfg);
```

To streamline this a bit, this just defines `Default` for `Context` to use `Config::default()`.