### PR TITLE
fix: decrement vectors after get_consequences is done with them

### DIFF
--- a/z3/src/solver.rs
+++ b/z3/src/solver.rs
@@ -273,6 +273,11 @@ impl Solver {
                 let val = Z3_ast_vector_get(self.ctx.z3_ctx.0, consequences, i);
                 cons.push(ast::Bool::wrap(&self.ctx, val));
             }
+
+            Z3_ast_vector_dec_ref(self.ctx.z3_ctx.0, _assumptions);
+            Z3_ast_vector_dec_ref(self.ctx.z3_ctx.0, _variables);
+            Z3_ast_vector_dec_ref(self.ctx.z3_ctx.0, consequences);
+
             cons
         }
     }


### PR DESCRIPTION
I noticed while looking at the action logs(https://github.com/prove-rs/z3.rs/actions/runs/16981741818/job/48142880062#step:6:179) for the bundled feature that it was giving a warning about uncollected memory. I think I narrowed it down to the get_consequences function where multiple vectors are created, incremented, but never decremented.

Not sure why we don't see this outside of the bundled runs. I guess different z3 versions?