### PR TITLE
doc: A first pass at documenting how to define recursive datatypes

### DIFF
--- a/z3/src/datatype_builder.rs
+++ b/z3/src/datatype_builder.rs
@@ -12,8 +12,8 @@
 //! ```rust
 //! use z3::{Sort, DatatypeAccessor, DatatypeBuilder, Symbol};
 //! let dt = DatatypeBuilder::new("my_datatype")
-//!     .variant("case1", vec![("field1", DatatypeAccessor::Sort(Sort::int()))])
-//!     .variant("case2", vec![("field2", DatatypeAccessor::Datatype(Symbol::String("my_datatype".to_string())))])
+//!     .variant("case1", vec![("field1", DatatypeAccessor::sort(Sort::int()))])
+//!     .variant("case2", vec![("field2", DatatypeAccessor::datatype("my_datatype"))])
 //!     .finish();
 //! ```
 //!
@@ -23,11 +23,11 @@
 //! use z3::{Sort, DatatypeAccessor, DatatypeBuilder, Symbol, datatype_builder::create_datatypes};
 //! let my_tree = DatatypeBuilder::new("my_tree")
 //!     .variant("leaf", vec![])
-//!     .variant("node", vec![("children", DatatypeAccessor::Datatype(Symbol::String("my_list".to_string())))]);
+//!     .variant("node", vec![("children", DatatypeAccessor::datatype("my_list"))]);
 //!
 //! let my_list = DatatypeBuilder::new("my_list")
 //!     .variant("nil", vec![])
-//!     .variant("cons", vec![("hd", DatatypeAccessor::Datatype(Symbol::String("my_tree".to_string()))), ("tl", DatatypeAccessor::Datatype(Symbol::String("my_list".to_string())))]);
+//!     .variant("cons", vec![("hd", DatatypeAccessor::datatype("my_tree")), ("tl", DatatypeAccessor::datatype("my_list"))]);
 //!
 //! let dts = create_datatypes(vec![my_tree, my_list]);
 //! ```
@@ -36,10 +36,7 @@
 use std::{convert::TryInto, ptr::null_mut};
 use z3_sys::*;
 
-use crate::{
-    Context, DatatypeAccessor, DatatypeBuilder, DatatypeSort, DatatypeVariant, FuncDecl, Sort,
-    Symbol,
-};
+use crate::{Context, DatatypeBuilder, DatatypeSort, DatatypeVariant, FuncDecl, Sort, Symbol};
 impl DatatypeBuilder {
     pub fn new<S: Into<Symbol>>(name: S) -> Self {
         let ctx = &Context::thread_local();
@@ -228,4 +225,21 @@ pub fn create_datatypes(datatype_builders: Vec<DatatypeBuilder>) -> Vec<Datatype
     }
 
     datatype_sorts
+}
+
+/// Wrapper which can point to a sort (by value) or to a custom datatype (by name).
+#[derive(Debug)]
+pub enum DatatypeAccessor {
+    Sort(Sort),
+    Datatype(Symbol),
+}
+
+impl DatatypeAccessor {
+    pub fn sort<S: Into<Sort>>(s: S) -> Self {
+        Self::Sort(s.into())
+    }
+
+    pub fn datatype<S: Into<Symbol>>(s: S) -> Self {
+        Self::Datatype(s.into())
+    }
 }

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -36,10 +36,10 @@ mod version;
 pub use crate::params::{get_global_param, reset_all_global_params, set_global_param};
 pub use crate::statistics::{StatisticsEntry, StatisticsValue};
 pub use crate::translate::Translate;
+pub use crate::translate::synchronization::*;
 pub use crate::version::{Version, full_version, version};
 pub use context::Context;
-
-pub use crate::translate::synchronization::*;
+pub use datatype_builder::DatatypeAccessor;
 /// Configuration used to initialize [logical contexts](Context).
 ///
 /// # See also:
@@ -208,13 +208,6 @@ pub struct DatatypeBuilder {
     ctx: Context,
     name: Symbol,
     constructors: Vec<(String, Vec<(String, DatatypeAccessor)>)>,
-}
-
-/// Wrapper which can point to a sort (by value) or to a custom datatype (by name).
-#[derive(Debug)]
-pub enum DatatypeAccessor {
-    Sort(Sort),
-    Datatype(Symbol),
 }
 
 /// Inner variant for a custom [datatype sort](DatatypeSort).

--- a/z3/src/symbol.rs
+++ b/z3/src/symbol.rs
@@ -25,6 +25,12 @@ impl From<u32> for Symbol {
     }
 }
 
+impl From<i32> for Symbol {
+    fn from(val: i32) -> Self {
+        Symbol::Int(val as u32)
+    }
+}
+
 impl From<String> for Symbol {
     fn from(val: String) -> Self {
         Symbol::String(val)


### PR DESCRIPTION
Fixes #419 

I did a rough pass on how I think one is supposed to define recursive sorts(both a single sort and mutually recursive sorts). I've implemented it as a doc test so there is some checking, but I didn't attempt to invoke the solver here(there is supposedly a proper test for that).

I don't love the way the docs are shown in docs.rs since this module only shows the create_datatypes function and the DatatypeBuilder is on a separate page. (The new documentation would go here https://docs.rs/z3/latest/z3/datatype_builder/index.html where as the builder is on the top level https://docs.rs/z3/latest/z3/struct.DatatypeBuilder.html ).

Open to any suggestions(or one can make the changes themself, I won't be offended).