### PR TITLE
chore: release

### DIFF
--- a/z3-sys/CHANGELOG.md
+++ b/z3-sys/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.8](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.9.7...z3-sys-v0.9.8) - 2025-08-25
+
+### Fixed
+
+- use proper header path on overridden build ([#423](https://github.com/prove-rs/z3.rs/pull/423)) (by @toolCHAINZ) - #423
+
+### Contributors
+
+* @toolCHAINZ
+
 ## [0.9.7](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.9.6...z3-sys-v0.9.7) - 2025-08-19
 
 ### Added

--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "z3-sys"
 rust-version = "1.85.0"
-version = "0.9.7"
+version = "0.9.8"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>"]
 build = "build.rs"
 edition = "2024"

--- a/z3/CHANGELOG.md
+++ b/z3/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.2](https://github.com/prove-rs/z3.rs/compare/z3-v0.16.1...z3-v0.16.2) - 2025-08-25
+
+### Other
+
+- updated the following local packages: z3-sys
+
 ## [0.16.1](https://github.com/prove-rs/z3.rs/compare/z3-v0.16.0...z3-v0.16.1) - 2025-08-23
 
 ### Other

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "z3"
 rust-version = "1.85.0"
-version = "0.16.1"
+version = "0.16.2"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>"]
 
 description = "High-level rust bindings for the Z3 SMT solver from Microsoft Research"
@@ -37,5 +37,5 @@ rayon = "1.10.0"
 
 [dependencies.z3-sys]
 path = "../z3-sys"
-version = "0.9.7"
+version = "0.9.8"
 


### PR DESCRIPTION



## 🤖 New release

* `z3-sys`: 0.9.7 -> 0.9.8 (✓ API compatible changes)
* `z3`: 0.16.1 -> 0.16.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `z3-sys`

<blockquote>

## [0.9.8](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.9.7...z3-sys-v0.9.8) - 2025-08-25

### Fixed

- use proper header path on overridden build ([#423](https://github.com/prove-rs/z3.rs/pull/423)) (by @toolCHAINZ) - #423

### Contributors

* @toolCHAINZ
</blockquote>

## `z3`

<blockquote>

## [0.16.2](https://github.com/prove-rs/z3.rs/compare/z3-v0.16.1...z3-v0.16.2) - 2025-08-25

### Other

- updated the following local packages: z3-sys
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).