### PR TITLE
chore: release

### DIFF
--- a/z3-sys/CHANGELOG.md
+++ b/z3-sys/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.9](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.9.8...z3-sys-v0.9.9) - 2025-09-03
+
+### Added
+
+- *(z3-sys)* do not depend on std ([#425](https://github.com/prove-rs/z3.rs/pull/425)) (by @lucascool12)
+
+### Contributors
+
+* @lucascool12
+
 ## [0.9.8](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.9.7...z3-sys-v0.9.8) - 2025-08-25
 
 ### Fixed

--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "z3-sys"
 rust-version = "1.85.0"
-version = "0.9.8"
+version = "0.9.9"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>"]
 build = "build.rs"
 edition = "2024"

--- a/z3/CHANGELOG.md
+++ b/z3/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.3](https://github.com/prove-rs/z3.rs/compare/z3-v0.16.2...z3-v0.16.3) - 2025-09-03
+
+### Added
+
+- Add the ability to iterate over solutions from a `Solver` ([#431](https://github.com/prove-rs/z3.rs/pull/431)) (by @toolCHAINZ) - #431
+
+### Changed
+
+- rename `_eq` to `eq` and `*_real_*` to `*_rational_*` ([#305](https://github.com/prove-rs/z3.rs/pull/305)) (by @dragazo) - #305
+- deprecate legacy Context APIs ([#427](https://github.com/prove-rs/z3.rs/pull/427)) (by @toolCHAINZ) - #427
+
+### Contributors
+
+* @toolCHAINZ
+* @dragazo
+
 ## [0.16.2](https://github.com/prove-rs/z3.rs/compare/z3-v0.16.1...z3-v0.16.2) - 2025-08-25
 
 ### Other

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "z3"
 rust-version = "1.85.0"
-version = "0.16.2"
+version = "0.16.3"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>"]
 
 description = "High-level rust bindings for the Z3 SMT solver from Microsoft Research"
@@ -37,5 +37,5 @@ rayon = "1.10.0"
 
 [dependencies.z3-sys]
 path = "../z3-sys"
-version = "0.9.8"
+version = "0.9.9"
 


### PR DESCRIPTION



## 🤖 New release

* `z3-sys`: 0.9.8 -> 0.9.9 (✓ API compatible changes)
* `z3`: 0.16.2 -> 0.16.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `z3-sys`

<blockquote>

## [0.9.9](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.9.8...z3-sys-v0.9.9) - 2025-09-03

### Added

- *(z3-sys)* do not depend on std ([#425](https://github.com/prove-rs/z3.rs/pull/425)) (by @lucascool12)

### Contributors

* @lucascool12
</blockquote>

## `z3`

<blockquote>

## [0.16.3](https://github.com/prove-rs/z3.rs/compare/z3-v0.16.2...z3-v0.16.3) - 2025-09-03

### Added

- Add the ability to iterate over solutions from a `Solver` ([#431](https://github.com/prove-rs/z3.rs/pull/431)) (by @toolCHAINZ) - #431

### Changed

- rename `_eq` to `eq` and `*_real_*` to `*_rational_*` ([#305](https://github.com/prove-rs/z3.rs/pull/305)) (by @dragazo) - #305
- deprecate legacy Context APIs ([#427](https://github.com/prove-rs/z3.rs/pull/427)) (by @toolCHAINZ) - #427

### Contributors

* @toolCHAINZ
* @dragazo
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).