### PR TITLE
feat: impl Translate for FuncDecl

### DIFF
--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -266,9 +266,9 @@ unsafe impl Translate for FuncDecl {
     fn translate(&self, dest: &Context) -> Self {
         unsafe {
             let func_decl_ast = Z3_func_decl_to_ast(self.ctx.z3_ctx.0, self.z3_func_decl);
-            Self::wrap(dest, {
-                Z3_translate(self.ctx.z3_ctx.0, func_decl_ast, dest.z3_ctx.0) as Z3_func_decl
-            })
+            let translated = Z3_translate(self.ctx.z3_ctx.0, func_decl_ast, dest.z3_ctx.0);
+            let func_decl = Z3_to_func_decl(self.ctx.z3_ctx.0, translated);
+            Self::wrap(dest, func_decl)
         }
     }
 }


### PR DESCRIPTION
Per https://z3prover.github.io/api/html/classz3_1_1func__decl.html, `FuncDecl` inherits from `Ast`, and so can be used with `Z3_translate`.

In the Rust bindings, `FuncDecl` is represented separately from all the `Ast`s, and so does not inherit the `Ast` `Translate` implementation.

This PR adds in a `Translate` impl for `FuncDecl` that coerces the underlying pointer to/from `Z3_ast`. I've added a unit test to demonstrate that this works.

I would have preferred to have just been able to implement `Ast` on `FuncDecl`, but `Ast` includes lots of things that don't apply to `FuncDecl`, such as `eq`, `simplify`, `substitute`, etc. 

Longer term, it would be good to separate these out of the `Ast` trait, so that it only encompasses "things having an ast pointer" and put these other things in other traits that relevant types can additionally implement.