### PR TITLE
fix: Ast::ne -> Bool is now defined and preferred over PartialEq::ne

### DIFF
--- a/z3/src/ast/mod.rs
+++ b/z3/src/ast/mod.rs
@@ -207,6 +207,10 @@ pub trait Ast: fmt::Debug {
     where
         Self: Sized;
 
+    fn ne<T: IntoAst<Self>>(&self, other: T) -> Bool
+    where
+        Self: Sized;
+
     /// Performs substitution on the `Ast`. The slice `substitutions` contains a
     /// list of pairs with a "from" `Ast` that will be substituted by a "to" `Ast`.
     fn substitute<T: Ast>(&self, substitutions: &[(&T, &T)]) -> Self
@@ -373,6 +377,13 @@ macro_rules! impl_ast {
                 self.eq(other)
             }
 
+            fn ne<T: IntoAst<Self>>(&self, other: T) -> Bool
+            where
+                Self: Sized,
+            {
+                self.ne(other)
+            }
+
             fn get_ctx(&self) -> &Context {
                 &self.ctx
             }
@@ -404,6 +415,13 @@ macro_rules! impl_ast {
                 Self: Sized,
             {
                 self.eq(other)
+            }
+
+            pub fn ne<T: IntoAst<Self>>(&self, other: T) -> Bool
+            where
+                Self: Sized,
+            {
+                self.eq(other).not()
             }
 
             /// Compare this `Ast` with another `Ast`, and get a [`Bool`]

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1789,9 +1789,8 @@ fn test_round_towards_nearest_even() {
     assert_eq!(solver.check(), SatResult::Sat);
 }
 
-
 #[test]
-fn test_compare_trait_resolution(){
+fn test_compare_trait_resolution() {
     let a = ast::Int::new_const("a");
     let b = ast::Int::new_const("b");
     let test_bool = Bool::new_const("test_bool");

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1788,3 +1788,18 @@ fn test_round_towards_nearest_even() {
 
     assert_eq!(solver.check(), SatResult::Sat);
 }
+
+
+#[test]
+fn test_compare_trait_resolution(){
+    let a = ast::Int::new_const("a");
+    let b = ast::Int::new_const("b");
+    let test_bool = Bool::new_const("test_bool");
+    // ensure that we are returning `Bool`s here
+    // the test here is that this compiles, if PartialEq
+    // was being used, this would fail to compile
+    assert!(!test_bool.eq(a.eq(&b)).is_const());
+    assert!(!test_bool.eq(a.ne(&b)).is_const());
+    assert!(!test_bool.ne(a.eq(&b)).is_const());
+    assert!(!test_bool.ne(a.ne(&b)).is_const());
+}


### PR DESCRIPTION
…t types