### PR TITLE
feat: gate newer Z3 APIs behind features

### DIFF
--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -24,9 +24,13 @@ gh-release = ["z3-sys/gh-release"]
 # This is a legacy feature here for short term compatibility.
 static-link-z3 = ["z3-sys/bundled", "z3-sys/deprecated-static-link-z3"]
 
-# Features requiring a minimum Z3 version of 4.8.15
+# Features requiring a minimum Z3 version.
+# By default we use features present in 4.8.13 and up, but these features
+# allow for turning off these bindings.
 # Once ubuntu stops distributing 4.8.12, we can remove this for convenience.
-z3_4_8_15 = []
+z3_4_8_15 = ["z3_4_8_14"]
+z3_4_8_14 = ["z3_4_8_13"]
+z3_4_8_13 = []
 
 [dependencies]
 log = "0.4"

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -16,13 +16,17 @@ edition = "2024"
 
 
 [features]
-default = []
+default = ["z3_4_8_15"]
 bundled = ["z3-sys/bundled"]
 vcpkg = ["z3-sys/vcpkg"]
 gh-release = ["z3-sys/gh-release"]
 
 # This is a legacy feature here for short term compatibility.
 static-link-z3 = ["z3-sys/bundled", "z3-sys/deprecated-static-link-z3"]
+
+# Features requiring a minimum Z3 version of 4.8.15
+# Once ubuntu stops distributing 4.8.12, we can remove this for convenience.
+z3_4_8_15 = []
 
 [dependencies]
 log = "0.4"

--- a/z3/src/ast/regexp.rs
+++ b/z3/src/ast/regexp.rs
@@ -98,7 +98,7 @@ impl Regexp {
 
     /// Creates a regular expression that accepts all singleton sequences of the characters
     /// Requires Z3 4.8.13 or later.
-    #[cfg(feature = "z3_4_8_15")]
+    #[cfg(feature = "z3_4_8_13")]
     pub fn allchar() -> Self {
         let ctx = &Context::thread_local();
         unsafe {
@@ -136,7 +136,7 @@ impl Regexp {
        /// Creates a regular expression that optionally accepts this regular expression (e.g. `a?`)
        option(Z3_mk_re_option, Self);
     }
-    #[cfg(feature = "z3_4_8_15")]
+    #[cfg(feature = "z3_4_8_14")]
     binop! {
         /// Creates a difference regular expression
         /// Requires Z3 4.8.14 or later.

--- a/z3/src/ast/regexp.rs
+++ b/z3/src/ast/regexp.rs
@@ -74,6 +74,7 @@ impl Regexp {
     /// Creates a regular expression that recognizes this regular expression
     /// n number of times
     /// Requires Z3 4.8.15 or later.
+    #[cfg(feature = "z3_4_8_15")]
     pub fn power(&self, n: u32) -> Self {
         unsafe {
             Self::wrap(&self.ctx, {
@@ -97,6 +98,7 @@ impl Regexp {
 
     /// Creates a regular expression that accepts all singleton sequences of the characters
     /// Requires Z3 4.8.13 or later.
+    #[cfg(feature = "z3_4_8_15")]
     pub fn allchar() -> Self {
         let ctx = &Context::thread_local();
         unsafe {
@@ -134,6 +136,7 @@ impl Regexp {
        /// Creates a regular expression that optionally accepts this regular expression (e.g. `a?`)
        option(Z3_mk_re_option, Self);
     }
+    #[cfg(feature = "z3_4_8_15")]
     binop! {
         /// Creates a difference regular expression
         /// Requires Z3 4.8.14 or later.


### PR DESCRIPTION
This PR adds features to the z3 crate which selectively enables high-level APIs based on their usage of the low-level Z3 API.

Specifically, a few APIs that were added in 4.8.13, 4.8.14, and 4.8.15 (all after the version shipped with ubuntu, 4.8.12) are now gated behind features.

This PR makes `z3_4_8_15` a default feature, so the APIs will not be disables unless a user opts out through `default-features = false`. This is necessary to build on ubuntu 24.04 LTS without linking path nonsense.
