### PR TITLE
Use FnOnce for closures that are run once

### DIFF
--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -391,7 +391,7 @@ pub struct Statistics {
 /// # See also
 ///
 /// - [`with_z3_config`]
-pub fn with_z3_context<T: Fn() -> R + Send + Sync, R: Send + Sync>(
+pub fn with_z3_context<T: FnOnce() -> R + Send + Sync, R: Send + Sync>(
     ctx: &Context,
     callback: T,
 ) -> R {
@@ -431,6 +431,9 @@ pub fn with_z3_context<T: Fn() -> R + Send + Sync, R: Send + Sync>(
 /// # See also
 ///
 /// - [`with_z3_context`]
-pub fn with_z3_config<T: Fn() -> R + Send + Sync, R: Send + Sync>(cfg: &Config, callback: T) -> R {
+pub fn with_z3_config<T: FnOnce() -> R + Send + Sync, R: Send + Sync>(
+    cfg: &Config,
+    callback: T,
+) -> R {
     with_z3_context(&Context::new(cfg), callback)
 }


### PR DESCRIPTION
We only use these closures once, so they can be `FnOnce` closures that consume their captures.

I specifically want this because I build a string from some non `Sync` data and then pass that to `solver.from_string`, so without this I need to clone that string for no reason.