### PR TITLE
Parametrize the type of `DatatypeBuilder` field names

### DIFF
--- a/z3/src/datatype_builder.rs
+++ b/z3/src/datatype_builder.rs
@@ -22,11 +22,11 @@
 //! ```rust
 //! use z3::{Sort, DatatypeAccessor, DatatypeBuilder, Symbol, datatype_builder::create_datatypes};
 //! let my_tree = DatatypeBuilder::new("my_tree")
-//!     .variant("leaf", vec![])
+//!     .variant::<&str>("leaf", vec![])
 //!     .variant("node", vec![("children", DatatypeAccessor::datatype("my_list"))]);
 //!
 //! let my_list = DatatypeBuilder::new("my_list")
-//!     .variant("nil", vec![])
+//!     .variant::<&str>("nil", vec![])
 //!     .variant("cons", vec![("hd", DatatypeAccessor::datatype("my_tree")), ("tl", DatatypeAccessor::datatype("my_list"))]);
 //!
 //! let dts = create_datatypes(vec![my_tree, my_list]);
@@ -47,7 +47,7 @@ impl DatatypeBuilder {
         }
     }
 
-    pub fn variant(mut self, name: &str, fields: Vec<(&str, DatatypeAccessor)>) -> Self {
+    pub fn variant<S: ToString>(mut self, name: &str, fields: Vec<(S, DatatypeAccessor)>) -> Self {
         let mut accessor_vec: Vec<(String, DatatypeAccessor)> = Vec::new();
         for (accessor_name, accessor) in fields {
             accessor_vec.push((accessor_name.to_string(), accessor));

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -253,7 +253,7 @@ pub use z3_sys::DeclKind;
 /// # let solver = Solver::new();
 /// // Like Rust's Option<int> type
 /// let option_int = DatatypeBuilder::new("OptionInt")
-/// .variant("None", vec![])
+/// .variant::<&str>("None", vec![])
 /// .variant(
 ///     "Some",
 ///     vec![("value", DatatypeAccessor::Sort(Sort::int()))],

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -752,7 +752,7 @@ fn test_datatype_builder() {
     let solver = Solver::new();
 
     let maybe_int = DatatypeBuilder::new("MaybeInt")
-        .variant("Nothing", vec![])
+        .variant::<&str>("Nothing", vec![])
         .variant("Just", vec![("int", DatatypeAccessor::Sort(Sort::int()))])
         .finish();
 
@@ -815,7 +815,7 @@ fn test_recursive_datatype() {
     let solver = Solver::new();
 
     let list_sort = DatatypeBuilder::new("List")
-        .variant("nil", vec![])
+        .variant::<&str>("nil", vec![])
         .variant(
             "cons",
             vec![
@@ -887,7 +887,7 @@ fn test_mutually_recursive_datatype() {
         );
 
     let tree_list_builder = DatatypeBuilder::new("TreeList")
-        .variant("nil", vec![])
+        .variant::<&str>("nil", vec![])
         .variant(
             "cons",
             vec![


### PR DESCRIPTION
Hi! I'm working with `DatatypeBuilder`s, and it'd be really nice if you could construct a variant's fields with `Vec<String, DatatypeAccessor>` as well as the existing `Vec<&str, DatatypeAccessor>`. Requiring string slices can be more restrictive, and unnecessarily so when the `variant` function eventually just needs to call `.to_string()` on the slice anyways.

I do realize that this now requires type annotations when calling `variant` w/ no fields, which would make it a breaking change, so I'd appreciate feedback if you know of other ways to implement this which wouldn't break any existing code.