### PR TITLE
chore: release

### DIFF
--- a/z3-sys/CHANGELOG.md
+++ b/z3-sys/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.10.1...z3-sys-v0.10.2) - 2025-11-17
+
+### Fixed
+
+- do not scrape GitHub when submodule exists ([#468](https://github.com/prove-rs/z3.rs/pull/468)) (by @toolCHAINZ) - #468
+
+### Other
+
+- bump bundled z3 ([#470](https://github.com/prove-rs/z3.rs/pull/470)) (by @toolCHAINZ) - #470
+
+### Contributors
+
+* @toolCHAINZ
+
 ## [0.10.1](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.10.0...z3-sys-v0.10.1) - 2025-11-16
 
 ### Added

--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "z3-sys"
 rust-version = "1.85.0"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>", "Mark DenHoed <mark.denhoed@cs.ox.ac.uk>"]
 build = "build.rs"
 edition = "2024"

--- a/z3/CHANGELOG.md
+++ b/z3/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.4](https://github.com/prove-rs/z3.rs/compare/z3-v0.19.3...z3-v0.19.4) - 2025-11-17
+
+### Other
+
+- updated the following local packages: z3-sys
+
 ## [0.19.3](https://github.com/prove-rs/z3.rs/compare/z3-v0.19.2...z3-v0.19.3) - 2025-11-16
 
 ### Added

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "z3"
 rust-version = "1.85.0"
-version = "0.19.3"
+version = "0.19.4"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>", "Mark DenHoed <mark.denhoed@cs.ox.ac.uk>"]
 
 description = "High-level rust bindings for the Z3 SMT solver from Microsoft Research"
@@ -45,5 +45,5 @@ rayon = "1.10.0"
 
 [dependencies.z3-sys]
 path = "../z3-sys"
-version = "0.10.1"
+version = "0.10.2"
 


### PR DESCRIPTION



## 🤖 New release

* `z3-sys`: 0.10.1 -> 0.10.2 (✓ API compatible changes)
* `z3`: 0.19.3 -> 0.19.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `z3-sys`

<blockquote>

## [0.10.2](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.10.1...z3-sys-v0.10.2) - 2025-11-17

### Fixed

- do not scrape GitHub when submodule exists ([#468](https://github.com/prove-rs/z3.rs/pull/468)) (by @toolCHAINZ) - #468

### Other

- bump bundled z3 ([#470](https://github.com/prove-rs/z3.rs/pull/470)) (by @toolCHAINZ) - #470

### Contributors

* @toolCHAINZ
</blockquote>

## `z3`

<blockquote>

## [0.19.4](https://github.com/prove-rs/z3.rs/compare/z3-v0.19.3...z3-v0.19.4) - 2025-11-17

### Other

- updated the following local packages: z3-sys
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).