### PR TITLE
refactor: remove unused imports in z3::ast

### DIFF
--- a/z3/src/ast/bool.rs
+++ b/z3/src/ast/bool.rs
@@ -1,4 +1,3 @@
-use crate::ast::IntoAst;
 use crate::ast::{Ast, binop, unop, varop};
 use crate::{Context, Sort, Symbol};
 use std::ffi::CString;

--- a/z3/src/ast/int.rs
+++ b/z3/src/ast/int.rs
@@ -1,5 +1,5 @@
 use crate::ast::{Ast, BV, Real, binop};
-use crate::ast::{Bool, IntoAst, unop, varop};
+use crate::ast::{Bool, unop, varop};
 use crate::{Context, Sort, Symbol};
 use num::BigInt;
 use std::ffi::CString;

--- a/z3/src/ast/mod.rs
+++ b/z3/src/ast/mod.rs
@@ -67,7 +67,7 @@ macro_rules! binop {
     ) => {
         $(
             $( #[ $attr ] )*
-            pub fn $f<T: IntoAst<Self>>(&self, other: T) -> $retty {
+            pub fn $f<T: crate::ast::IntoAst<Self>>(&self, other: T) -> $retty {
                 let ast = other.into_ast(self);
                 unsafe {
                     <$retty>::wrap(&self.ctx, {
@@ -87,7 +87,7 @@ macro_rules! trinop {
     ) => {
         $(
             $( #[ $attr ] )*
-            pub fn $f<A: Into<$retty>, B: IntoAst<$retty>>(&self, a: A, b: B) -> $retty {
+            pub fn $f<A: Into<$retty>, B: crate::ast::IntoAst<$retty>>(&self, a: A, b: B) -> $retty {
                 let a = a.into();
                 let b = b.into_ast(&a);
                 unsafe {

--- a/z3/src/ast/real.rs
+++ b/z3/src/ast/real.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Ast, IntoAst};
+use crate::ast::Ast;
 use crate::ast::{Bool, Int, binop, unop, varop};
 use crate::{Context, Sort, Symbol};
 use num::BigRational;

--- a/z3/src/ast/regexp.rs
+++ b/z3/src/ast/regexp.rs
@@ -1,6 +1,5 @@
 use crate::Context;
-use crate::ast::{Ast, binop, varop};
-use crate::ast::{IntoAst, unop};
+use crate::ast::Ast;
 use std::ffi::CString;
 use z3_sys::*;
 
@@ -131,7 +130,7 @@ impl Regexp {
         }
     }
 
-    unop! {
+    crate::ast::unop! {
        /// Creates a regular expression that recognizes this regular expression one or more times (e.g. `a+`)
        plus(Z3_mk_re_plus, Self);
        /// Creates a regular expression that recognizes this regular expression any number of times
@@ -144,12 +143,12 @@ impl Regexp {
        option(Z3_mk_re_option, Self);
     }
     #[cfg(feature = "z3_4_8_14")]
-    binop! {
+    crate::ast::binop! {
         /// Creates a difference regular expression
         /// Requires Z3 4.8.14 or later.
         diff(Z3_mk_re_diff, Self);
     }
-    varop! {
+    crate::ast::varop! {
        /// Concatenates regular expressions
         concat(Z3_mk_re_concat, Self);
        /// Creates a regular expression that recognizes sequences that any of the regular

--- a/z3/src/ast/rounding_mode.rs
+++ b/z3/src/ast/rounding_mode.rs
@@ -1,5 +1,4 @@
 use crate::Context;
-use crate::ast::IntoAst;
 use crate::ast::{Ast, Float, trinop};
 use z3_sys::*;
 

--- a/z3/src/ast/set.rs
+++ b/z3/src/ast/set.rs
@@ -1,4 +1,3 @@
-use crate::ast::IntoAst;
 use crate::ast::{Ast, Bool, binop, unop, varop};
 use crate::{Context, Sort, Symbol};
 use std::ffi::CString;


### PR DESCRIPTION
Clippy warns about unused imports `IntoAst` and `binop` in `z3::ast::regexp`, caused by the only use of binop (which uses IntoAst) being behind `#[cfg(feature = "z3_4_8_14")]`.

Here I put the macro import behind the same feature flag, and make the path to `IntoAst` in the macro definition absolute to avoid it having to be present in the expanding context. I think making the path absolute is the best way to fix the conditional dependency but let me know if there's a better way. This fixes the clippy warnings for me.