### PR TITLE
feat: Use native-tls-vendored feature of reqwest, removing build dependency on libssl-dev

### DIFF
--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -21,7 +21,7 @@ bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
 cmake = { version = "0.1.54", optional = true }
 zip = { version = "4.3", optional = true }
 pkg-config = "0.3.32"
-reqwest = { version = "0.12.22", default-features = false, features = ["blocking", "default-tls"], optional = true }
+reqwest = { version = "0.12.22", default-features = false, features = ["blocking", "native-tls-vendored"], optional = true }
 serde_json = { version = "1.0.140", optional = true }
 vcpkg = { version = "0.2.15", optional = true }
 


### PR DESCRIPTION
Building `z3-sys` with the `bundled` or `gh-release` feature requires `openssl-sys` (via `reqwest`), which in turn introduces a dependency on the system package `libssl-dev` (in case of Ubuntu) or similar.

Changing the `reqwest` feature `default-tls` (which is equal to `native-tls`) to `native-tls-vendored`, makes `reqwest` use the `vendored` version of `openssl`, allowing `z3-sys` to be built on systems that do not have `libssl-dev`. This makes the package more versatile.