### PR TITLE
chore: release

### DIFF
--- a/z3-sys/CHANGELOG.md
+++ b/z3-sys/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.6](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.10.5...z3-sys-v0.10.6) - 2026-02-21
+
+### Fixed
+
+- add rerun-if-env-changed for Z3_SYS_BUNDLED_DIR_OVERRIDE ([#496](https://github.com/prove-rs/z3.rs/pull/496)) (by @toolCHAINZ) - #496
+
+### Other
+
+- expand build flag documentation ([#499](https://github.com/prove-rs/z3.rs/pull/499)) (by @toolCHAINZ) - #499
+
+### Contributors
+
+* @toolCHAINZ
+
 ## [0.10.5](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.10.4...z3-sys-v0.10.5) - 2026-02-13
 
 ### Fixed

--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "z3-sys"
 rust-version = "1.85.0"
-version = "0.10.5"
+version = "0.10.6"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>", "Mark DenHoed <mark.denhoed@cs.ox.ac.uk>"]
 build = "build.rs"
 edition = "2024"

--- a/z3/CHANGELOG.md
+++ b/z3/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.9](https://github.com/prove-rs/z3.rs/compare/z3-v0.19.8...z3-v0.19.9) - 2026-02-21
+
+### Other
+
+- expand build flag documentation ([#499](https://github.com/prove-rs/z3.rs/pull/499)) (by @toolCHAINZ) - #499
+
+### Contributors
+
+* @toolCHAINZ
+
 ## [0.19.8](https://github.com/prove-rs/z3.rs/compare/z3-v0.19.7...z3-v0.19.8) - 2026-02-13
 
 ### Other

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "z3"
 rust-version = "1.85.0"
-version = "0.19.8"
+version = "0.19.9"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>", "Mark DenHoed <mark.denhoed@cs.ox.ac.uk>"]
 
 description = "High-level rust bindings for the Z3 SMT solver from Microsoft Research"
@@ -45,5 +45,5 @@ rayon = "1.10.0"
 
 [dependencies.z3-sys]
 path = "../z3-sys"
-version = "0.10.5"
+version = "0.10.6"
 


### PR DESCRIPTION



## 🤖 New release

* `z3-sys`: 0.10.5 -> 0.10.6 (✓ API compatible changes)
* `z3`: 0.19.8 -> 0.19.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `z3-sys`

<blockquote>

## [0.10.6](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.10.5...z3-sys-v0.10.6) - 2026-02-21

### Fixed

- add rerun-if-env-changed for Z3_SYS_BUNDLED_DIR_OVERRIDE ([#496](https://github.com/prove-rs/z3.rs/pull/496)) (by @toolCHAINZ) - #496

### Other

- expand build flag documentation ([#499](https://github.com/prove-rs/z3.rs/pull/499)) (by @toolCHAINZ) - #499

### Contributors

* @toolCHAINZ
</blockquote>

## `z3`

<blockquote>

## [0.19.9](https://github.com/prove-rs/z3.rs/compare/z3-v0.19.8...z3-v0.19.9) - 2026-02-21

### Other

- expand build flag documentation ([#499](https://github.com/prove-rs/z3.rs/pull/499)) (by @toolCHAINZ) - #499

### Contributors

* @toolCHAINZ
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).