### PR TITLE
feat: add `with` method to Tactic

### DIFF
--- a/z3/src/tactic.rs
+++ b/z3/src/tactic.rs
@@ -199,6 +199,17 @@ impl Tactic {
         }
     }
 
+    /// Return a tactic that applies the current tactic using the given set of parameters.
+    pub fn with(&self, params: &Params) -> Tactic {
+        unsafe {
+            Self::wrap(
+                &self.ctx,
+                Z3_tactic_using_params(self.ctx.z3_ctx.0, self.z3_tactic, params.z3_params)
+                    .unwrap(),
+            )
+        }
+    }
+
     /// Attempts to apply the tactic to `goal`. If the tactic succeeds, returns
     /// `Ok(_)` with a `ApplyResult`. If the tactic fails, returns `Err(_)` with
     /// an error message describing why.

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1298,6 +1298,32 @@ fn test_tactic_or_else() {
 }
 
 #[test]
+fn test_tactic_with() {
+    let mut params = Params::new();
+    params.set_u32("add_bound_lower", 1);
+    params.set_u32("add_bound_upper", 1000);
+
+    let x = ast::Int::new_const("x");
+
+    let goal = Goal::new(false, false, false);
+    goal.assert(&x.eq(&x));
+
+    let tactic = Tactic::new("add-bounds").with(&params);
+
+    // Test that `with` succesfully applied the parameter set
+    let apply_results = tactic.apply(&goal, Some(&Params::new()));
+    let goal_results = apply_results
+        .unwrap()
+        .list_subgoals()
+        .collect::<Vec<Goal>>();
+    let goal_result = goal_results.first().unwrap();
+    assert_eq!(
+        format!("{goal_result}"),
+        "(goal\n  (= x x)\n  (<= x 1000)\n  (>= x 1))"
+    );
+}
+
+#[test]
 fn test_goal_apply_tactic() {
     pub fn test_apply_tactic(goal: Goal, before_formulas: Vec<Bool>, after_formulas: Vec<Bool>) {
         assert_eq!(goal.get_formulas(), before_formulas);


### PR DESCRIPTION
Adds a binding to `Z3_tactic_using_params` so parameter sets can be provided to tactics directly.