### PR TITLE
chore: release

### DIFF
--- a/z3-sys/CHANGELOG.md
+++ b/z3-sys/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.9](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.10.8...z3-sys-v0.10.9) - 2026-03-13
+
+### Other
+
+- Update zip dependency to latest ([#515](https://github.com/prove-rs/z3.rs/pull/515)) (by @ThomasTNO) - #515
+
+### Contributors
+
+* @ThomasTNO
+
 ## [0.10.8](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.10.7...z3-sys-v0.10.8) - 2026-03-06
 
 ### Fixed

--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "z3-sys"
 rust-version = "1.85.0"
-version = "0.10.8"
+version = "0.10.9"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>", "Mark DenHoed <mark.denhoed@cs.ox.ac.uk>"]
 build = "build.rs"
 edition = "2024"

--- a/z3/CHANGELOG.md
+++ b/z3/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.14](https://github.com/prove-rs/z3.rs/compare/z3-v0.19.13...z3-v0.19.14) - 2026-03-13
+
+### Other
+
+- internal refactoring of datatype builder ([#517](https://github.com/prove-rs/z3.rs/pull/517)) (by @toolCHAINZ) - #517
+
+### Contributors
+
+* @toolCHAINZ
+
 ## [0.19.13](https://github.com/prove-rs/z3.rs/compare/z3-v0.19.12...z3-v0.19.13) - 2026-03-06
 
 ### Other

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "z3"
 rust-version = "1.85.0"
-version = "0.19.13"
+version = "0.19.14"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>", "Mark DenHoed <mark.denhoed@cs.ox.ac.uk>"]
 
 description = "High-level rust bindings for the Z3 SMT solver from Microsoft Research"
@@ -45,5 +45,5 @@ rayon = "1.10.0"
 
 [dependencies.z3-sys]
 path = "../z3-sys"
-version = "0.10.8"
+version = "0.10.9"
 


### PR DESCRIPTION



## 🤖 New release

* `z3-sys`: 0.10.8 -> 0.10.9 (✓ API compatible changes)
* `z3`: 0.19.13 -> 0.19.14 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `z3-sys`

<blockquote>

## [0.10.9](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.10.8...z3-sys-v0.10.9) - 2026-03-13

### Other

- Update zip dependency to latest ([#515](https://github.com/prove-rs/z3.rs/pull/515)) (by @ThomasTNO) - #515

### Contributors

* @ThomasTNO
</blockquote>

## `z3`

<blockquote>

## [0.19.14](https://github.com/prove-rs/z3.rs/compare/z3-v0.19.13...z3-v0.19.14) - 2026-03-13

### Other

- internal refactoring of datatype builder ([#517](https://github.com/prove-rs/z3.rs/pull/517)) (by @toolCHAINZ) - #517

### Contributors

* @toolCHAINZ
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).