### PR TITLE
enable "num" feature for z3 docs.rs build

### DIFF
--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -14,6 +14,8 @@ homepage = "https://github.com/prove-rs/z3.rs"
 repository = "https://github.com/prove-rs/z3.rs.git"
 edition = "2024"
 
+[package.metadata.docs.rs]
+features = ["num"]
 
 [features]
 vendored = ["z3-sys/vendored"]


### PR DESCRIPTION
This adds `z3::ast::Int::from_big_int` and related functions back to the docs.rs