### PR TITLE
feat: Add bindings for `get_lower`/`get_upper` in the `Optimize` solver.

### DIFF
--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -363,6 +363,22 @@ impl Optimize {
         };
         av.try_into().expect("solver assertions are always Bool")
     }
+
+    /// Retrieve the lower bound value or approximation for the i-th optimization objective.
+    pub fn get_lower(&self, objective_id: u32) -> Option<Dynamic> {
+        unsafe {
+            Z3_optimize_get_lower(self.ctx.z3_ctx.0, self.z3_opt, objective_id)
+                .map(|ast| Dynamic::wrap(&self.ctx, ast))
+        }
+    }
+
+    /// Retrieve the upper bound value or approximation for the i-th optimization objective.
+    pub fn get_upper(&self, objective_id: u32) -> Option<Dynamic> {
+        unsafe {
+            Z3_optimize_get_upper(self.ctx.z3_ctx.0, self.z3_opt, objective_id)
+                .map(|ast| Dynamic::wrap(&self.ctx, ast))
+        }
+    }
 }
 
 struct OptimizeIterator<T> {


### PR DESCRIPTION
A relatively minor change, allows extracting current optimization bounds from the `Optimize` solver using existing `z3-sys` methods.