### PR TITLE
Add model handler to `Optimize`

### DIFF
--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -81,7 +81,6 @@
 #![deny(missing_debug_implementations)]
 
 use std::cell::RefCell;
-use std::collections::BTreeSet;
 use std::ffi::CString;
 use z3_sys::*;
 pub use z3_sys::{AstKind, GoalPrec, SortKind};
@@ -199,8 +198,8 @@ pub struct Model {
 pub struct Optimize {
     ctx: Context,
     z3_opt: Z3_optimize,
-    // Stores IDs of model handlers associated with this `Optimize` solver.
-    registered_handlers: RefCell<BTreeSet<u32>>,
+    // Stores ID of a model handler associated with this `Optimize` solver.
+    registered_model_handler: RefCell<Option<u32>>,
 }
 
 /// Context for Horn clause / Datalog solving.

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -80,6 +80,8 @@
 #![warn(clippy::doc_markdown)]
 #![deny(missing_debug_implementations)]
 
+use std::cell::RefCell;
+use std::collections::BTreeSet;
 use std::ffi::CString;
 use z3_sys::*;
 pub use z3_sys::{AstKind, GoalPrec, SortKind};
@@ -197,6 +199,8 @@ pub struct Model {
 pub struct Optimize {
     ctx: Context,
     z3_opt: Z3_optimize,
+    // Stores IDs of model handlers associated with this `Optimize` solver.
+    registered_handlers: RefCell<BTreeSet<u32>>,
 }
 
 /// Context for Horn clause / Datalog solving.

--- a/z3/src/model.rs
+++ b/z3/src/model.rs
@@ -7,6 +7,19 @@ use crate::{
 };
 
 impl Model {
+    /// A new instance of an *empty* model, not tied to any particular solver. Internally used
+    /// by [`Optimize::register_model_handler`].
+    ///
+    /// Note: [`Model::of_optimize`] cannot be used here because it assumes the solver already
+    /// has a model, whereas [`Optimize::register_model_handler`] is called before the solver
+    /// has found any model at all.
+    pub(crate) fn new_empty(ctx: &Context) -> Model {
+        unsafe {
+            let m = Z3_mk_model(ctx.z3_ctx.0).expect("Cannot allocate new Z3_model.");
+            Self::wrap(ctx, m)
+        }
+    }
+
     unsafe fn wrap(ctx: &Context, z3_mdl: Z3_model) -> Model {
         unsafe {
             Z3_model_inc_ref(ctx.z3_ctx.0, z3_mdl);

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -1,10 +1,12 @@
 use log::debug;
 use std::borrow::Borrow;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::convert::TryInto;
-use std::ffi::{CStr, CString};
+use std::ffi::{CStr, CString, c_void};
 use std::fmt;
 use std::iter::FusedIterator;
-
+use std::sync::atomic::AtomicU32;
 use z3_sys::*;
 
 #[cfg(feature = "z3_4_16")]
@@ -29,6 +31,7 @@ impl Optimize {
         Optimize {
             ctx: ctx.clone(),
             z3_opt,
+            registered_handlers: Default::default(),
         }
     }
 
@@ -363,6 +366,53 @@ impl Optimize {
         };
         av.try_into().expect("solver assertions are always Bool")
     }
+
+    /// Register a new model handler that is invoked for every incrementally improved model
+    /// produced by the optimization process.
+    ///
+    /// Note that each handler invocation receives **the same instance** of [`Model`], but
+    /// its internal state is updated by the solver between invocations. Accessing such [`Model`]
+    /// is still completely memory safe; it can only be modified by the Z3 solver running on the
+    /// same thread, hence it can never change while being accessed by safe Rust code. However,
+    /// keep in mind that if you want to store the values from the model, you need to make
+    /// a deep copy into some dedicated data structure; i.e. you can't just make a reference to
+    /// the model every time the handler is invoked, since all such models will point to
+    /// the same data.
+    pub fn register_model_handler<F: Fn(&Model) + 'static>(&self, callback: F) {
+        unsafe {
+            // Make an "empty" model into which the result will be placed.
+            let model = Model::new_empty(&self.ctx);
+            let z3_model = model.z3_mdl;
+
+            // Register the callback within the thread-local map.
+            let id = THREAD_MODEL_HANDLER_COUNTER
+                .with(|it| it.fetch_add(1, std::sync::atomic::Ordering::SeqCst));
+            let callback: DynamicModelHandler = Box::new(callback);
+            THREAD_MODEL_HANDLER_REGISTRY.with_borrow_mut(|map| {
+                if let Some(_old) = map.insert(id, (callback, model)) {
+                    panic!("Correctness violation: Callback with this ID was already registered.");
+                }
+            });
+
+            // Register the callback within solver-specific map (to allow eventual deallocation).
+            {
+                let mut registry = self
+                    .registered_handlers
+                    .try_borrow_mut()
+                    .expect("Correctness violation: Concurrent access to handler registrations.");
+                registry.insert(id);
+            }
+
+            // Register the callback internally within Z3
+            Z3_optimize_register_model_eh(
+                self.ctx.z3_ctx.0,
+                self.z3_opt,
+                z3_model,
+                id as *mut c_void,
+                Some(global_model_callback),
+            );
+        }
+    }
 }
 
 struct OptimizeIterator<T> {
@@ -415,6 +465,17 @@ impl fmt::Debug for Optimize {
 
 impl Drop for Optimize {
     fn drop(&mut self) {
+        // Drop model handlers from the global handler registry.
+        THREAD_MODEL_HANDLER_REGISTRY.with_borrow_mut(|map| {
+            let registered = self
+                .registered_handlers
+                .try_borrow()
+                .expect("Correctness violation: Concurrent access to handler registrations.");
+            for id in registered.iter() {
+                map.remove(id);
+            }
+        });
+
         unsafe { Z3_optimize_dec_ref(self.ctx.z3_ctx.0, self.z3_opt) };
     }
 }
@@ -530,4 +591,28 @@ macro_rules! impl_sealed {
 
 impl_sealed! {
     u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize
+}
+
+/// The type of model handlers that can be registered in [`THREAD_MODEL_HANDLER_REGISTRY`].
+type DynamicModelHandler = Box<dyn Fn(&Model) + 'static>;
+
+thread_local! {
+    /// A global thread safe registry for storing all model handlers that are currently registered.
+    static THREAD_MODEL_HANDLER_REGISTRY: RefCell<BTreeMap<u32, (DynamicModelHandler, Model)>> = RefCell::new(BTreeMap::new());
+    /// A utility counter used to assign unique IDs to model handlers in the thread model registry.
+    static THREAD_MODEL_HANDLER_COUNTER: AtomicU32 = const { AtomicU32::new(0) };
+}
+
+/// A global model handler which is called via registrations from
+/// [`Optimize::register_model_callback`] and dispatches the callback to
+/// the respective anonymous functions.
+extern "C" fn global_model_callback(ctx: *mut c_void) {
+    // Invariant: global_model_callback is always called with `ctx` being an u32 callback ID.
+    let id = ctx as u32;
+    THREAD_MODEL_HANDLER_REGISTRY.with_borrow(|map| {
+        let Some((callback, model)) = map.get(&id) else {
+            panic!("Correctness violation: Callback `ID={id}` called but not registered.")
+        };
+        callback(model);
+    });
 }

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -31,7 +31,7 @@ impl Optimize {
         Optimize {
             ctx: ctx.clone(),
             z3_opt,
-            registered_handlers: Default::default(),
+            registered_model_handler: Default::default(),
         }
     }
 
@@ -383,24 +383,39 @@ impl Optimize {
         }
     }
 
-    /// Register a new model handler that is invoked for every incrementally improved model
-    /// produced by the optimization process.
+    /// Register a model handler that is invoked for every incrementally improved model
+    /// produced by the optimization process. Only one model handler can be registered within
+    /// each optimization solver.
     ///
-    /// Note that each handler invocation receives **the same instance** of [`Model`], but
-    /// its internal state is updated by the solver between invocations. Accessing such [`Model`]
-    /// is still completely memory safe; it can only be modified by the Z3 solver running on the
-    /// same thread, hence it can never change while being accessed by safe Rust code. However,
-    /// keep in mind that if you want to store the values from the model, you need to make
-    /// a deep copy into some dedicated data structure; i.e. you can't just make a reference to
-    /// the model every time the handler is invoked, since all such models will point to
-    /// the same data.
-    pub fn register_model_handler<F: Fn(&Model) + 'static>(&self, callback: F) {
+    /// Note that the [`Model`] instance received by the handler is always the same object,
+    /// internally mutated by the solver. There is no risk of concurrent reads and writes; the
+    /// model is only modified by the solver, running on the same thread as the handler. But
+    /// to save each model returned by individual handler invocations, you need some kind
+    /// of deep copy mechanism (otherwise all models that you'll save will just
+    /// be the same model instance).
+    pub fn set_model_handler<F: Fn(&Model) + 'static>(&self, callback: F) {
+        /*
+           Implementation notes: The C handler cannot be `Fn` (must be `fn`). As such,
+           we instead register a single "global handler" (`global_model_callback`),
+           and then forward the callback to the right handler saved within
+           a thread local map. Because the callback will be called by the solver on the same
+           thread as other Z3 methods, we know there won't be any concurrent access to these
+           data structures and the handler will be present in the thread local map.
+           To support interior mutability, we thus rely on `RefCell`, but we don't need
+           additional synchronization. When the solver is dropped, we remove
+           the handler from the thread local map.
+        */
+
+        self.clear_model_handler(); // First, remove any pre-existing handler.
+
         unsafe {
-            // Make an "empty" model into which the result will be placed.
+            // Make an "empty" model into which the result will be placed. The model lives
+            // as long as the handler is registered.
             let model = Model::new_empty(&self.ctx);
             let z3_model = model.z3_mdl;
 
-            // Register the callback within the thread-local map.
+            // Register the given handler within the thread-local map so that it can be
+            // accessed by the global handler.
             let id = THREAD_MODEL_HANDLER_COUNTER
                 .with(|it| it.fetch_add(1, std::sync::atomic::Ordering::SeqCst));
             let callback: DynamicModelHandler = Box::new(callback);
@@ -412,11 +427,12 @@ impl Optimize {
 
             // Register the callback within solver-specific map (to allow eventual deallocation).
             {
-                let mut registry = self
-                    .registered_handlers
+                let mut registered_id = self
+                    .registered_model_handler
                     .try_borrow_mut()
                     .expect("Correctness violation: Concurrent access to handler registrations.");
-                registry.insert(id);
+                // Invariant: at this point, the `registered_id` should be `None`.
+                *registered_id = Some(id);
             }
 
             // Register the callback internally within Z3
@@ -427,6 +443,22 @@ impl Optimize {
                 id as *mut c_void,
                 Some(global_model_callback),
             );
+        }
+    }
+
+    /// Clear a model handler previously set by [`Optimize::set_model_handler`]
+    /// (assuming it exists).
+    pub fn clear_model_handler(&self) {
+        let mut registered_id = self
+            .registered_model_handler
+            .try_borrow_mut()
+            .expect("Correctness violation: Concurrent access to handler registrations.");
+
+        if let Some(id) = *registered_id {
+            *registered_id = None;
+            THREAD_MODEL_HANDLER_REGISTRY.with_borrow_mut(|map| {
+                map.remove(&id);
+            });
         }
     }
 }
@@ -481,16 +513,8 @@ impl fmt::Debug for Optimize {
 
 impl Drop for Optimize {
     fn drop(&mut self) {
-        // Drop model handlers from the global handler registry.
-        THREAD_MODEL_HANDLER_REGISTRY.with_borrow_mut(|map| {
-            let registered = self
-                .registered_handlers
-                .try_borrow()
-                .expect("Correctness violation: Concurrent access to handler registrations.");
-            for id in registered.iter() {
-                map.remove(id);
-            }
-        });
+        // Drop model handler from the global handler registry.
+        self.clear_model_handler();
 
         unsafe { Z3_optimize_dec_ref(self.ctx.z3_ctx.0, self.z3_opt) };
     }
@@ -623,7 +647,8 @@ thread_local! {
 /// [`Optimize::register_model_callback`] and dispatches the callback to
 /// the respective anonymous functions.
 extern "C" fn global_model_callback(ctx: *mut c_void) {
-    // Invariant: global_model_callback is always called with `ctx` being an u32 callback ID.
+    // Invariant: global_model_callback is always called with `ctx` being an u32 callback ID,
+    // as long as handlers are registered by our code.
     let id = ctx as u32;
     THREAD_MODEL_HANDLER_REGISTRY.with_borrow(|map| {
         let Some((callback, model)) = map.get(&id) else {

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -363,6 +363,22 @@ impl Optimize {
         };
         av.try_into().expect("solver assertions are always Bool")
     }
+
+    /// Retrieve the lower bound value or approximation for the i-th optimization objective.
+    pub fn get_lower(&self, objective_id: u32) -> Option<Dynamic> {
+        unsafe {
+            Z3_optimize_get_lower(self.ctx.z3_ctx.0, self.z3_opt, objective_id)
+                .map(|ast| Dynamic::wrap(&self.ctx, ast))
+        }
+    }
+
+    /// Retrieve the upper bound value or approximation for the i-th optimization objective.
+    pub fn get_upper(&self, objective_id: u32) -> Option<Dynamic> {
+        unsafe {
+            Z3_optimize_get_upper(self.ctx.z3_ctx.0, self.z3_opt, objective_id)
+                .map(|ast| Dynamic::wrap(&self.ctx, ast))
+        }
+    }
 }
 
 struct OptimizeIterator<T> {


### PR DESCRIPTION
In `Optimize`, it is possible to register a "model handler" that's invoked every time the solver finds a better (not necessarily optimal) solution. This PR adds the option to register such handler from safe bindings. The solution is somewhat technical because it needs to safely "forward" the C-style `fn` handler call to a rust `Fn` callback, plus the handling of `Model` instances is also a bit unusual. As far as I recall, this is inspired by a similar implementation in the Python Z3 bindings.

It is probably not ideal, but if there are some other options of how to implement this feature, I'd be happy to update the PR.