### PR TITLE
fix(Real): from_rational must not truncate i64 args to i32

### DIFF
--- a/z3/src/ast/real.rs
+++ b/z3/src/ast/real.rs
@@ -66,12 +66,10 @@ impl Real {
         let ctx = &Context::thread_local();
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_real(
-                    ctx.z3_ctx.0,
-                    num as ::std::os::raw::c_int,
-                    den as ::std::os::raw::c_int,
-                )
-                .unwrap()
+                // Use the int64 fraction API, not Z3_mk_real (which takes C `int`):
+                // casting the i64 args to c_int silently truncates any value outside
+                // the i32 range (e.g. 634909090909091/100000000000 wrapped to garbage).
+                Z3_mk_real_int64(ctx.z3_ctx.0, num, den).unwrap()
             })
         }
     }

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -475,6 +475,26 @@ fn test_arbitrary_size_real() {
 }
 
 #[test]
+fn test_from_rational_beyond_i32() {
+    // Regression: from_rational must not truncate its i64 args to C `int`.
+    // 634909090909091 / 100000000000 = 6349.09090909091; both num and den
+    // exceed i32::MAX, so the old `as c_int` cast wrapped this to ~1.03.
+    let solver = Solver::new();
+    let num = 634909090909091_i64;
+    let den = 100000000000_i64;
+    let r = ast::Real::from_rational(num, den);
+    // r must equal the exact rational built via the string API (no truncation).
+    let exact = ast::Real::from_rational_str("634909090909091", "100000000000").unwrap();
+    solver.assert(r.eq(&exact));
+    assert_eq!(solver.check(), SatResult::Sat);
+    // And it must NOT equal the value the truncating path produced (~1.0326).
+    let solver2 = Solver::new();
+    let wrong = ast::Real::from_rational_str("1255410595", "1215752192").unwrap();
+    solver2.assert(ast::Real::from_rational(num, den).eq(&wrong));
+    assert_eq!(solver2.check(), SatResult::Unsat);
+}
+
+#[test]
 fn test_arbitrary_size_int() {
     let solver = Solver::new();
 


### PR DESCRIPTION
Real::from_rational takes i64 num/den but lowered them via Z3_mk_real, whose C signature is (int, int). Casting the i64 args to c_int silently truncated any value outside the i32 range: e.g. 634909090909091/100000000000 (= 6349.09090909091) wrapped to ~1.0326, producing a wrong-but-valid Real with no error. This corrupts any consumer building rationals with large numerators/denominators (common when a decimal like 6349.09090909091 is expressed as digits/10^k).

Use Z3_mk_real_int64(num, den), the int64 fraction API, which preserves the full i64 range. Negatives still work (covered by algebraic_tests' from_rational(-7,4)).

Adds a regression test asserting a >i32 rational lowers exactly and not to the old truncated value.