### PR TITLE
chore: release z3-src (Z3 5.0.0)

### DIFF
--- a/z3-src/Cargo.toml
+++ b/z3-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "z3-src"
-version = "416.0.2"
+version = "500.0.0"
 edition = "2024"
 description = "Source distribution of the Z3 SMT solver, for use as a build dependency"
 license = "MIT"


### PR DESCRIPTION
Automated release PR. Review the submodule pointer and Cargo.toml version, then merge to publish.