### PR TITLE
chore: release

### DIFF
--- a/z3-sys/CHANGELOG.md
+++ b/z3-sys/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.12.0...z3-sys-v0.13.0) - 2026-08-28
+
+### Added
+
+- [**breaking**] auto-detect z3 version ([#583](https://github.com/prove-rs/z3.rs/pull/583)) (by @toolCHAINZ) - #583
+
+### Other
+
+- bump z3-sys to use 5.1.0 by default ([#585](https://github.com/prove-rs/z3.rs/pull/585)) (by @toolCHAINZ) - #585
+
+### Contributors
+
+* @toolCHAINZ
+
 ## [0.12.0](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.11.0...z3-sys-v0.12.0) - 2026-07-23
 
 This release updates the generated FFI bindings to target Z3 5.0.0. The high-level `z3` crate is **not** being updated in lockstep because, at the time of this writing, Z3 5.0.0 is still making its way into package repositories; once it is a little more widely distributed, a `z3` release will follow targeting `z3-sys` 0.12.0 and Z3 5.0.0.

--- a/z3-sys/Cargo.toml
+++ b/z3-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "z3-sys"
 rust-version = "1.85.0"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>", "Mark DenHoed <mark.denhoed@cs.ox.ac.uk>"]
 build = "build.rs"
 edition = "2024"

--- a/z3/CHANGELOG.md
+++ b/z3/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.3](https://github.com/prove-rs/z3.rs/compare/z3-v0.20.2...z3-v0.20.3) - 2026-07-23
+
+### Other
+
+- bump z3 to use z3-sys 0.12.0 ([#575](https://github.com/prove-rs/z3.rs/pull/575)) (by @toolCHAINZ) - #575
+
+### Contributors
+
+* @toolCHAINZ
+
 ## [0.20.2](https://github.com/prove-rs/z3.rs/compare/z3-v0.20.1...z3-v0.20.2) - 2026-06-26
 
 ### Added

--- a/z3/CHANGELOG.md
+++ b/z3/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0](https://github.com/prove-rs/z3.rs/compare/z3-v0.20.2...z3-v0.21.0) - 2026-08-28
+
+### Added
+
+- [**breaking**] auto-detect z3 version ([#583](https://github.com/prove-rs/z3.rs/pull/583)) (by @toolCHAINZ) - #583
+- Optimize::set_model_handler ([#577](https://github.com/prove-rs/z3.rs/pull/577)) (by @toolCHAINZ) - #577
+
+### Fixed
+
+- add missing inc_ref to ApplyResult's Clone ([#578](https://github.com/prove-rs/z3.rs/pull/578)) (by @Ollie-Pearce) - #578
+
+### Other
+
+- bump z3 to use z3-sys 0.12.0 ([#575](https://github.com/prove-rs/z3.rs/pull/575)) (by @toolCHAINZ) - #575
+
+### Contributors
+
+* @toolCHAINZ
+* @Ollie-Pearce
+
 ## [0.20.2](https://github.com/prove-rs/z3.rs/compare/z3-v0.20.1...z3-v0.20.2) - 2026-06-26
 
 ### Added

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "z3"
 rust-version = "1.85.0"
-version = "0.20.2"
+version = "0.20.3"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>", "Mark DenHoed <mark.denhoed@cs.ox.ac.uk>"]
 
 description = "High-level rust bindings for the Z3 SMT solver from Microsoft Research"

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "z3"
 rust-version = "1.85.0"
-version = "0.20.2"
+version = "0.21.0"
 build = "build.rs"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>", "Mark DenHoed <mark.denhoed@cs.ox.ac.uk>"]
 
@@ -41,4 +41,4 @@ rayon = "1.10.0"
 
 [dependencies.z3-sys]
 path = "../z3-sys"
-version = "0.12.0"
+version = "0.13.0"


### PR DESCRIPTION



## 🤖 New release

* `z3-sys`: 0.12.0 -> 0.13.0 (✓ API compatible changes)
* `z3`: 0.20.2 -> 0.21.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `z3-sys`

<blockquote>

## [0.13.0](https://github.com/prove-rs/z3.rs/compare/z3-sys-v0.12.0...z3-sys-v0.13.0) - 2026-08-28

### Added

- [**breaking**] auto-detect z3 version ([#583](https://github.com/prove-rs/z3.rs/pull/583)) (by @toolCHAINZ) - #583

### Other

- bump z3-sys to use 5.1.0 by default ([#585](https://github.com/prove-rs/z3.rs/pull/585)) (by @toolCHAINZ) - #585

### Contributors

* @toolCHAINZ
</blockquote>

## `z3`

<blockquote>

## [0.21.0](https://github.com/prove-rs/z3.rs/compare/z3-v0.20.2...z3-v0.21.0) - 2026-08-28

### Added

- [**breaking**] auto-detect z3 version ([#583](https://github.com/prove-rs/z3.rs/pull/583)) (by @toolCHAINZ) - #583
- Optimize::set_model_handler ([#577](https://github.com/prove-rs/z3.rs/pull/577)) (by @toolCHAINZ) - #577

### Fixed

- add missing inc_ref to ApplyResult's Clone ([#578](https://github.com/prove-rs/z3.rs/pull/578)) (by @Ollie-Pearce) - #578

### Other

- bump z3 to use z3-sys 0.12.0 ([#575](https://github.com/prove-rs/z3.rs/pull/575)) (by @toolCHAINZ) - #575

### Contributors

* @toolCHAINZ
* @Ollie-Pearce
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).