### PR TITLE
chore: bump z3 to use z3-sys 0.12.0

### DIFF
--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -45,4 +45,4 @@ rayon = "1.10.0"
 
 [dependencies.z3-sys]
 path = "../z3-sys"
-version = "0.11.0"
+version = "0.12.0"


### PR DESCRIPTION
This PR is to make local package resolution work.

Once homebrew updates z3 to 5.0, we can make an actual release of the z3 crate targeting it. For now, the latest release still targets z3-sys 0.11.0 and z3 4.16.0