### PR TITLE
Fix UAF bug in ApplyResult

### DIFF
--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -338,7 +338,7 @@ pub struct Pattern {
 }
 
 /// Collection of subgoals resulting from applying of a tactic to a goal.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ApplyResult {
     ctx: Context,
     z3_apply_result: Z3_apply_result,

--- a/z3/src/tactic.rs
+++ b/z3/src/tactic.rs
@@ -32,6 +32,12 @@ impl ApplyResult {
     }
 }
 
+impl Clone for ApplyResult {
+    fn clone(&self) -> Self {
+        unsafe { Self::wrap(&self.ctx, self.z3_apply_result) }
+    }
+}
+
 impl Drop for ApplyResult {
     fn drop(&mut self) {
         unsafe {


### PR DESCRIPTION
The `ApplyResult` type contains a raw pointer to a C++ memory object in libz3 and has a derived `Clone` implementation. If `Clone` is called on `ApplyResult` a reference to the libz3 memory object is created without incrementing the associated reference counter. 

```rust
#[derive(Clone, Debug)]
pub struct ApplyResult {
    ctx: Context,
    z3_apply_result: Z3_apply_result,   // Pointer to libz3 object
}
```

When `Drop` is called on an instance of `ApplyResult` the reference counter is decremented. Creating an instance of `ApplyResult`, cloning that instance and then dropping both the clone and original causes a UAF. This bug can be triggered from safe code. 

```rust
impl Drop for ApplyResult {
    fn drop(&mut self) {
        unsafe {
            Z3_apply_result_dec_ref(self.ctx.z3_ctx.0, self.z3_apply_result);
        }
    }
}
```

## Reproduction:

### Test case
```rust
use z3::{Goal, Tactic};

#[test]
fn clone_then_drop_both_owners() {
    let goal = Goal::new(false, false, false);
    let a = Tactic::new("skip").apply(&goal, None).unwrap();
    let b = a.clone();
    drop(a);
    drop(b);
}
```

### Verification
```
cargo test -p z3 --test apply_result_clone_drop --no-run
valgrind --leak-check=no ./target/debug/deps/apply_result_clone_drop-21a20d95342baf41
```

### Valgrind output:
```
==65755== Thread 2 clone_then_drop:
==65755== Invalid read of size 4
==65755==    at 0x547012E: ??? (in /usr/lib/x86_64-linux-gnu/libz3.so.4)
==65755==    by 0x547044E: Z3_del_context (in /usr/lib/x86_64-linux-gnu/libz3.so.4)
==65755==    by 0x18444D: <z3::context::ContextInternal as core::ops::drop::Drop>::drop (context.rs:17)
==65755==    by 0x183F0A: core::ptr::drop_in_place<z3::context::ContextInternal> (mod.rs:805)
==65755==    by 0x1851A1: alloc::rc::Rc<T,A>::drop_slow (rc.rs:396)
==65755==    by 0x18428B: <alloc::rc::Rc<T,A> as core::ops::drop::Drop>::drop (rc.rs:2472)
==65755==    by 0x183FFA: core::ptr::drop_in_place<alloc::rc::Rc<z3::context::ContextInternal>> (mod.rs:805)
==65755==    by 0x183DEA: core::ptr::drop_in_place<z3::context::Context> (mod.rs:805)
==65755==    by 0x18400A: core::ptr::drop_in_place<core::cell::UnsafeCell<z3::context::Context>> (mod.rs:805)
==65755==    by 0x183FDE: core::ptr::drop_in_place<core::cell::RefCell<z3::context::Context>> (mod.rs:805)
==65755==    by 0x187FB8: assume_init_drop<core::cell::RefCell<z3::context::Context>> (maybe_uninit.rs:814)
==65755==    by 0x187FB8: std::sys::thread_local::native::lazy::destroy::{{closure}} (lazy.rs:121)
==65755==    by 0x188001: std::sys::thread_local::abort_on_dtor_unwind (mod.rs:210)
==65755==  Address 0x5e5e780 is 16 bytes inside a block of size 192 free'd
==65755==    at 0x484988F: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==65755==    by 0x4A53148: ??? (in /usr/lib/x86_64-linux-gnu/libz3.so.4)
==65755==    by 0x54A957F: Z3_apply_result_dec_ref (in /usr/lib/x86_64-linux-gnu/libz3.so.4)
==65755==    by 0x183B31: z3::tactic::<impl core::ops::drop::Drop for z3::ApplyResult>::drop (tactic.rs:38)
==65755==    by 0x183D96: core::ptr::drop_in_place<z3::ApplyResult> (mod.rs:805)
==65755==    by 0x143D28: core::mem::drop (mod.rs:975)
==65755==    by 0x14399D: apply_result_clone_drop::clone_then_drop_both_owners (apply_result_clone_drop.rs:13)
==65755==    by 0x143E46: apply_result_clone_drop::clone_then_drop_both_owners::{{closure}} (apply_result_clone_drop.rs:8)
==65755==    by 0x143BF5: core::ops::function::FnOnce::call_once (function.rs:250)
==65755==    by 0x14400A: call_once<fn() -> core::result::Result<(), alloc::string::String>, ()> (function.rs:250)
==65755==    by 0x14400A: test::__rust_begin_short_backtrace::<core::result::Result<(), alloc::string::String>, fn() -> core::result::Result<(), alloc::string::String>> (lib.rs:663)
==65755==    by 0x1509FA: {closure#0} (lib.rs:686)
==65755==    by 0x1509FA: call_once<core::result::Result<(), alloc::string::String>, test::run_test_in_process::{closure_env#0}> (unwind_safe.rs:274)
==65755==    by 0x1509FA: do_call<core::panic::unwind_safe::AssertUnwindSafe<test::run_test_in_process::{closure_env#0}>, core::result::Result<(), alloc::string::String>> (panicking.rs:581)
==65755==    by 0x1509FA: catch_unwind<core::result::Result<(), alloc::string::String>, core::panic::unwind_safe::AssertUnwindSafe<test::run_test_in_process::{closure_env#0}>> (panicking.rs:544)
==65755==    by 0x1509FA: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<test::run_test_in_process::{closure_env#0}>, core::result::Result<(), alloc::string::String>> (panic.rs:359)
==65755==    by 0x1509FA: run_test_in_process (lib.rs:686)
==65755==    by 0x1509FA: test::run_test::{closure#0} (lib.rs:607)
==65755==    by 0x14C113: {closure#1} (lib.rs:637)
==65755==    by 0x14C113: std::sys::backtrace::__rust_begin_short_backtrace::<test::run_test::{closure#1}, ()> (backtrace.rs:166)
==65755==  Block was alloc'd at
==65755==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==65755==    by 0x4A53316: ??? (in /usr/lib/x86_64-linux-gnu/libz3.so.4)
==65755==    by 0x54B5D37: ??? (in /usr/lib/x86_64-linux-gnu/libz3.so.4)
==65755==    by 0x54B613C: Z3_tactic_apply (in /usr/lib/x86_64-linux-gnu/libz3.so.4)
==65755==    by 0x182DE8: z3::tactic::<impl z3::Tactic>::apply (tactic.rs:219)
==65755==    by 0x1437A6: apply_result_clone_drop::clone_then_drop_both_owners (apply_result_clone_drop.rs:10)
==65755==    by 0x143E46: apply_result_clone_drop::clone_then_drop_both_owners::{{closure}} (apply_result_clone_drop.rs:8)
==65755==    by 0x143BF5: core::ops::function::FnOnce::call_once (function.rs:250)
==65755==    by 0x14400A: call_once<fn() -> core::result::Result<(), alloc::string::String>, ()> (function.rs:250)
==65755==    by 0x14400A: test::__rust_begin_short_backtrace::<core::result::Result<(), alloc::string::String>, fn() -> core::result::Result<(), alloc::string::String>> (lib.rs:663)
==65755==    by 0x1509FA: {closure#0} (lib.rs:686)
==65755==    by 0x1509FA: call_once<core::result::Result<(), alloc::string::String>, test::run_test_in_process::{closure_env#0}> (unwind_safe.rs:274)
==65755==    by 0x1509FA: do_call<core::panic::unwind_safe::AssertUnwindSafe<test::run_test_in_process::{closure_env#0}>, core::result::Result<(), alloc::string::String>> (panicking.rs:581)
==65755==    by 0x1509FA: catch_unwind<core::result::Result<(), alloc::string::String>, core::panic::unwind_safe::AssertUnwindSafe<test::run_test_in_process::{closure_env#0}>> (panicking.rs:544)
==65755==    by 0x1509FA: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<test::run_test_in_process::{closure_env#0}>, core::result::Result<(), alloc::string::String>> (panic.rs:359)
==65755==    by 0x1509FA: run_test_in_process (lib.rs:686)
==65755==    by 0x1509FA: test::run_test::{closure#0} (lib.rs:607)
==65755==    by 0x14C113: {closure#1} (lib.rs:637)
==65755==    by 0x14C113: std::sys::backtrace::__rust_begin_short_backtrace::<test::run_test::{closure#1}, ()> (backtrace.rs:166)
==65755==    by 0x153601: {closure#0}<test::run_test::{closure_env#1}, ()> (lifecycle.rs:91)
==65755==    by 0x153601: call_once<(), std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<test::run_test::{closure_env#1}, ()>> (unwind_safe.rs:274)
==65755==    by 0x153601: do_call<core::panic::unwind_safe::AssertUnwindSafe<std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<test::run_test::{closure_env#1}, ()>>, ()> (panicking.rs:581)
==65755==    by 0x153601: catch_unwind<(), core::panic::unwind_safe::AssertUnwindSafe<std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<test::run_test::{closure_env#1}, ()>>> (panicking.rs:544)
==65755==    by 0x153601: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<test::run_test::{closure_env#1}, ()>>, ()> (panic.rs:359)
==65755==    by 0x153601: {closure#1}<test::run_test::{closure_env#1}, ()> (lifecycle.rs:89)
==65755==    by 0x153601: <std::thread::lifecycle::spawn_unchecked<test::run_test::{closure#1}, ()>::{closure#1} as core::ops::function::FnOnce<()>>::call_once::{shim:vtable#0} (function.rs:250)
==65755==
```

## Fix: 
- Remove `#[derive(Clone)]` from `ApplyResult` type
- Add an overloaded `Clone` implementation which delegates to `wrap` to increment the reference counter
 
The overloaded `Clone` calling `wrap` pattern is correctly implemented for other types such as `probe` and `sort`
