### PR TITLE
Revert "chore: bump z3 to use z3-sys 0.12.0 (#575)"

### DIFF
--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -45,4 +45,4 @@ rayon = "1.10.0"
 
 [dependencies.z3-sys]
 path = "../z3-sys"
-version = "0.12.0"
+version = "0.11.0"


### PR DESCRIPTION
This reverts commit e717cdd1275333e6b3529b60b8d12d12ab121853.

Reverting this to let me do a non-breaking patch release without bumping to Z3 5.0.0.