### PR TITLE
feat!: auto-detect z3 version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,6 @@ jobs:
         run: cargo test --workspace --features num
 
   build_on_wasm:
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -92,7 +91,6 @@ jobs:
           CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
 
   build_with_vendored_z3:
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         build: [linux, macos, windows]
@@ -137,7 +135,6 @@ jobs:
           SCCACHE_MSVC_Z7: "1"
 
   build_with_vcpkg_installed_z3:
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         build: [linux, macos, windows]
@@ -203,7 +200,6 @@ jobs:
         run: cargo clippy --workspace --all-targets --features num
 
   build_with_gh_release_z3:
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         build: [linux, macos, windows]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,6 +51,7 @@ jobs:
         run: cargo test --workspace --features num
 
   build_on_wasm:
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -91,6 +92,7 @@ jobs:
           CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
 
   build_with_vendored_z3:
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         build: [linux, macos, windows]
@@ -135,6 +137,7 @@ jobs:
           SCCACHE_MSVC_Z7: "1"
 
   build_with_vcpkg_installed_z3:
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         build: [linux, macos, windows]
@@ -200,6 +203,7 @@ jobs:
         run: cargo clippy --workspace --all-targets --features num
 
   build_with_gh_release_z3:
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         build: [linux, macos, windows]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ failing — so `cargo check`/rust-analyzer keep working on a fresh checkout.
 APIs that require a newer Z3 than the minimum are gated behind auto-derived `cfg`s instead of
 Cargo features, so no manual opt-in is needed and editor tooling picks them up correctly.
 **`Optimize::translate` and `Optimize::clone` require Z3 ≥ 4.16.0** (`Z3_optimize_translate` was
-added in that release) and are gated behind `#[cfg(z3_4_16)]`, which `z3/build.rs` sets
+added in that release) and are gated behind `#[cfg(z3_4_16_0)]`, which `z3/build.rs` sets
 automatically once it observes a linked Z3 ≥ 4.16.0 — no feature flag or configuration needed.
 
 Z3 has, on occasion, inserted new variants into the middle of a C enum instead of appending them

--- a/README.md
+++ b/README.md
@@ -68,11 +68,14 @@ added in that release) and are gated behind `#[cfg(z3_ge_4_16)]`, which `z3/buil
 automatically once it observes a linked Z3 ≥ 4.16.0 — no feature flag or configuration needed.
 
 Z3 has, on occasion, inserted new variants into the middle of a C enum instead of appending them
-(e.g. Z3 4.8.16 inserted `Z3_OP_RECURSIVE` into `Z3_decl_kind`, and 4.8.17 inserted
-`SeqMap`/`SeqMapi`/`SeqFoldl`/`SeqFoldli`, in both cases shifting the numeric value of every
-later variant). `z3-sys/build.rs` keeps a hand-maintained table of such known changes
-(`z3-sys/enum_compat.rs`) and warns if the detected version falls outside a recorded safe range;
-none of the currently-known cases affect any version at or above the 4.13.3 minimum.
+(e.g. Z3 4.8.16 inserted `Z3_OP_RECURSIVE` into `Z3_decl_kind`, 4.13.2 inserted
+`SeqMap`/`SeqMapi`/`SeqFoldl`/`SeqFoldli`, 4.14.1 inserted `Z3_OP_SBV2INT`, and 5.0.0 inserted
+13 `Z3_OP_FINITE_SET_*` variants, each shifting the numeric value of every later variant).
+`z3-sys/build.rs` keeps a hand-maintained table of such known changes (`z3-sys/enum_compat.rs`)
+and warns if the detected version falls outside a recorded safe range. The 4.13.2 and 4.14.1
+breaks are both below the current bundled/committed numbering (Z3 5.0.0), so a linked Z3 anywhere
+from the 4.13.3 minimum up to (but not including) 5.0.0 has incorrect `Z3_OP_INTERNAL`,
+`Z3_OP_RECURSIVE`, and `Z3_OP_UNINTERPRETED` values — `enum_compat.rs` will warn in that case.
 
 FFI bindings can be regenerated for new Z3 versions by running
 `cargo xtask gen-bindings`.

--- a/README.md
+++ b/README.md
@@ -33,57 +33,27 @@ The [`z3-src` crate][z3-src] contains the Z3 source distribution and logic to ha
 
 ## Z3 Version Compatibility
 
-Starting with version 0.20.0, z3-rs aims to track the latest Z3 release and stay up-to-date with API changes.
+> [!IMPORTANT]
+> Starting with version `0.21.0`, the `z3` and `z3-sys` crates have a minimum supported Z3 versions of 4.13.3.
 
-| z3      | z3-sys   | upstream Z3                                          |
-|---------|----------|-------------------------------------------------------|
-| ≤0.19.x | ≤0.10.x  | ≥4.8.12                                              |
-| ≥0.20.0 | ≥0.11.0  | ≥4.13.3 (auto-detected; ≥4.16.0 for `Optimize::translate`/`Clone`) |
+Z3 incompatibility has two causes:
 
-### ≤0.19.x (z3-sys ≤0.10.x): broad version support
+* Z3 sometimes adds APIs, making new C FFI targets, and causing linker errors if naively attempting to link against a too-new symbol in an old Z3 version.
+* Z3 sometimes shuffles existing enum values while adding new ones.
 
-Function and opaque structure FFI bindings were generated and committed sometime around Z3 4.8.12
-and updated ad-hoc, but enum bindings were re-generated via bindgen on every build.
-This let the enums track whatever Z3 version was linked, giving broad 4.8.12–4.16.0 support. The cost was
-that new high-level Z3 APIs could not easily be defined without feature-gating, and were often
-omitted entirely.
+The first issue means that using some z3 features imposes a minimum supported version. The second issue means that
+`z3-sys` has a separate range of compatibility based on enum changes, independent of what high-level Z3 versions are used.
 
-### ≥0.20.0 (z3-sys ≥0.11.0): static generated bindings
+Starting with version `0.21.0`, this crate attempts to auto-detect the linked Z3 version and automatically enables all compatible features (without requiring user-enabled features). If
+this version detection fails, it assumes the minimum supported version (4.13.3) and warns.
 
-Both functions and enums are tracked in version control
-(`z3-sys/src/generated/functions.rs` and `z3-sys/src/generated/enums.rs`). There is by default no
-dynamic bindgen step on every build.
-
-The minimum supported upstream Z3 version is **4.13.3** (the version shipped by Ubuntu 26.04),
-enforced automatically: `z3-sys`'s build script detects the linked Z3 version (from
-`z3_version.h`, pkg-config, vcpkg, or the `Z3_SYS_Z3_VERSION` env var, in that priority order)
-and fails the build with an actionable error if it's below the minimum. If the version can't be
-detected at all (e.g. no Z3 installed yet), the build assumes the minimum and warns, rather than
-failing — so `cargo check`/rust-analyzer keep working on a fresh checkout.
-
-APIs that require a newer Z3 than the minimum are gated behind auto-derived `cfg`s instead of
-Cargo features, so no manual opt-in is needed and editor tooling picks them up correctly.
-**`Optimize::translate` and `Optimize::clone` require Z3 ≥ 4.16.0** (`Z3_optimize_translate` was
-added in that release) and are gated behind `#[cfg(z3_4_16_0)]`, which `z3/build.rs` sets
-automatically once it observes a linked Z3 ≥ 4.16.0 — no feature flag or configuration needed.
-
-Z3 has, on occasion, inserted new variants into the middle of a C enum instead of appending them
-(e.g. Z3 4.8.16 inserted `Z3_OP_RECURSIVE` into `Z3_decl_kind`, 4.13.2 inserted
-`SeqMap`/`SeqMapi`/`SeqFoldl`/`SeqFoldli`, 4.14.1 inserted `Z3_OP_SBV2INT`, and 5.0.0 inserted
-13 `Z3_OP_FINITE_SET_*` variants, each shifting the numeric value of every later variant).
-`z3-sys/build.rs` keeps a hand-maintained table of such known changes (`z3-sys/enum_compat.rs`)
-and warns if the detected version falls outside a recorded safe range. The 4.13.2 and 4.14.1
-breaks are both below the current bundled/committed numbering (Z3 5.0.0), so a linked Z3 anywhere
-from the 4.13.3 minimum up to (but not including) 5.0.0 has incorrect `Z3_OP_INTERNAL`,
-`Z3_OP_RECURSIVE`, and `Z3_OP_UNINTERPRETED` values — `enum_compat.rs` will warn in that case.
-
-FFI bindings can be regenerated for new Z3 versions by running
-`cargo xtask gen-bindings`.
-
-Users who wish to generate FFI bindings at build-time for their system's Z3 can build with
-the `bindgen` feature enabled; note though that while the low-level bindings may work,
-the high-level bindings will not be able to link against (old) versions of z3 that do not
-export the necessary symbols.
+> [!TIP]
+> The `z3-sys` crate will display a warning if you attempt to link against an incompatible Z3 version. Use `--features bindgen` or update Z3 to fix this.
+> ```
+> ~/R/z3.rs ❯❯❯ Z3_SYS_Z3_VERSION=4.16.0 cargo test --features gh-release
+>    Compiling z3-sys v0.13.0 (/repos/z3.rs/z3-sys)
+> warning: z3-sys@0.13.0: z3-sys: attempting to link against Z3 4.16.0 with `z3-sys` bindings for Z3 >= 5.0.0; enum numbering (e.g. Z3_decl_kind) may differ across these versions. Consider updating Z3 or else enabling the `bindgen` feature to ensure compatibility.
+> ```
 
 ## When should I use `z3-sys` instead of `z3`?
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ The [`z3-src` crate][z3-src] contains the Z3 source distribution and logic to ha
 
 Starting with version 0.20.0, z3-rs aims to track the latest Z3 release and stay up-to-date with API changes.
 
-| z3      | z3-sys   | upstream Z3                                         |
-|---------|----------|-----------------------------------------------------|
-| ≤0.19.x | ≤0.10.x  | ≥4.8.12                                             |
-| ≥0.20.0 | ≥0.11.0  | ≥4.8.17 (≥4.16.0 for `Optimize::translate`/`Clone`) |
+| z3      | z3-sys   | upstream Z3                                          |
+|---------|----------|-------------------------------------------------------|
+| ≤0.19.x | ≤0.10.x  | ≥4.8.12                                              |
+| ≥0.20.0 | ≥0.11.0  | ≥4.13.3 (auto-detected; ≥4.16.0 for `Optimize::translate`/`Clone`) |
 
 ### ≤0.19.x (z3-sys ≤0.10.x): broad version support
 
@@ -54,21 +54,25 @@ Both functions and enums are tracked in version control
 (`z3-sys/src/generated/functions.rs` and `z3-sys/src/generated/enums.rs`). There is by default no
 dynamic bindgen step on every build.
 
-The baseline minimum upstream Z3 version is **4.8.17**. This floor is set by two constraints:
+The minimum supported upstream Z3 version is **4.13.3** (the version shipped by Ubuntu 26.04),
+enforced automatically: `z3-sys`'s build script detects the linked Z3 version (from
+`z3_version.h`, pkg-config, vcpkg, or the `Z3_SYS_Z3_VERSION` env var, in that priority order)
+and fails the build with an actionable error if it's below the minimum. If the version can't be
+detected at all (e.g. no Z3 installed yet), the build assumes the minimum and warns, rather than
+failing — so `cargo check`/rust-analyzer keep working on a fresh checkout.
 
-- **API surface**: `Regexp::power`, `Regexp::allchar`, and `Regexp::diff` require Z3 ≥ 4.8.15.
-- **`DeclKind` enum correctness**: Z3 4.8.17 inserted `SeqMap`/`SeqMapi`/`SeqFoldl`/`SeqFoldli`
-  into the sequence range (values 1569–1572), shifting all string operation variants up by four.
-  Using these bindings against Z3 < 4.8.17 will return incorrect `DeclKind` values for string
-  operations (`StrToInt` etc.) when calling `FuncDecl::kind()`.
+APIs that require a newer Z3 than the minimum are gated behind auto-derived `cfg`s instead of
+Cargo features, so no manual opt-in is needed and editor tooling picks them up correctly.
+**`Optimize::translate` and `Optimize::clone` require Z3 ≥ 4.16.0** (`Z3_optimize_translate` was
+added in that release) and are gated behind `#[cfg(z3_ge_4_16)]`, which `z3/build.rs` sets
+automatically once it observes a linked Z3 ≥ 4.16.0 — no feature flag or configuration needed.
 
-**`Optimize::translate` and `Optimize::clone` require Z3 ≥ 4.16.0** (`Z3_optimize_translate`
-was added in that release) and are temporarily gated behind the `z3_4_16` feature flag:
-
-```toml
-[dependencies]
-z3 = { version = "0.20", features = ["z3_4_16"] }
-```
+Z3 has, on occasion, inserted new variants into the middle of a C enum instead of appending them
+(e.g. Z3 4.8.16 inserted `Z3_OP_RECURSIVE` into `Z3_decl_kind`, and 4.8.17 inserted
+`SeqMap`/`SeqMapi`/`SeqFoldl`/`SeqFoldli`, in both cases shifting the numeric value of every
+later variant). `z3-sys/build.rs` keeps a hand-maintained table of such known changes
+(`z3-sys/enum_compat.rs`) and warns if the detected version falls outside a recorded safe range;
+none of the currently-known cases affect any version at or above the 4.13.3 minimum.
 
 FFI bindings can be regenerated for new Z3 versions by running
 `cargo xtask gen-bindings`.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ failing — so `cargo check`/rust-analyzer keep working on a fresh checkout.
 APIs that require a newer Z3 than the minimum are gated behind auto-derived `cfg`s instead of
 Cargo features, so no manual opt-in is needed and editor tooling picks them up correctly.
 **`Optimize::translate` and `Optimize::clone` require Z3 ≥ 4.16.0** (`Z3_optimize_translate` was
-added in that release) and are gated behind `#[cfg(z3_ge_4_16)]`, which `z3/build.rs` sets
+added in that release) and are gated behind `#[cfg(z3_4_16)]`, which `z3/build.rs` sets
 automatically once it observes a linked Z3 ≥ 4.16.0 — no feature flag or configuration needed.
 
 Z3 has, on occasion, inserted new variants into the middle of a C enum instead of appending them

--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -2,6 +2,7 @@ use std::env;
 #[cfg(feature = "gh-release")]
 use std::path::PathBuf;
 
+#[cfg(not(feature = "bindgen"))]
 mod enum_compat;
 mod version;
 
@@ -93,6 +94,9 @@ fn emit_version_metadata(version: Option<version::Version>) {
     println!("cargo:min_supported_minor={}", min.minor);
     println!("cargo:min_supported_patch={}", min.patch);
 
+    // With `bindgen`, enums are regenerated fresh from the actual linked header on every
+    // build, so the static compatibility table doesn't apply.
+    #[cfg(not(feature = "bindgen"))]
     enum_compat::warn_on_mismatches(version);
 }
 

--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -66,16 +66,20 @@ fn main() {
 
 /// Emits the detected Z3 version (or the assumed minimum, if detection
 /// failed) as `links`-passthrough metadata for downstream crates (see
-/// `DEP_Z3_VERSION_*` / `DEP_Z3_MIN_SUPPORTED_*` in `z3/build.rs`), and
-/// enforces the minimum supported version.
+/// `DEP_Z3_VERSION_*` / `DEP_Z3_MIN_SUPPORTED_*` in `z3/build.rs`), and warns
+/// if it's below the minimum supported version.
 fn emit_version_metadata(version: Option<version::Version>) {
     let min = version::MIN_SUPPORTED;
     let version = match version {
-        Some(v) if v < min => panic!(
-            "Detected Z3 {v}, but z3-sys requires Z3 >= {min}. Upgrade your Z3 installation, \
-             or if this detection is wrong, override with Z3_SYS_Z3_VERSION=<version> (must \
-             still satisfy the minimum)."
-        ),
+        Some(v) if v < min => {
+            println!(
+                "cargo:warning=z3-sys: detected Z3 {v}, but z3-sys requires Z3 >= {min}. \
+                 Upgrade your Z3 installation, or if this detection is wrong, override with \
+                 Z3_SYS_Z3_VERSION=<version> (must still satisfy the minimum). Proceeding with \
+                 the detected version; the build may fail or behave incorrectly."
+            );
+            v
+        }
         Some(v) => v,
         None => {
             println!(

--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -40,7 +40,8 @@ fn main() {
             let detected = pkg_config::Config::new()
                 .probe("z3")
                 .ok()
-                .and_then(|lib| detect_pkg_config_version(&lib));
+                .and_then(|lib| detect_pkg_config_version(&lib))
+                .or_else(detect_cli_version);
             println!("cargo:rerun-if-env-changed=Z3_LIBRARY_PATH_OVERRIDE");
             if let Ok(lib_path) = env::var("Z3_LIBRARY_PATH_OVERRIDE") {
                 println!("cargo:rustc-link-search=native={lib_path}");
@@ -101,6 +102,20 @@ fn detect_pkg_config_version(lib: &pkg_config::Library) -> Option<version::Versi
             .iter()
             .find_map(|dir| version::parse_header(&dir.join("z3_version.h")))
     })
+}
+
+/// Falls back to shelling out to the `z3` CLI binary for version detection
+/// when no pkg-config metadata is available (e.g. Z3 installed from a
+/// prebuilt release archive, which ships no `.pc` file).
+fn detect_cli_version() -> Option<version::Version> {
+    let output = std::process::Command::new("z3")
+        .arg("--version")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    version::parse_cli_output(&String::from_utf8_lossy(&output.stdout))
 }
 
 #[cfg(feature = "vendored")]

--- a/z3-sys/build.rs
+++ b/z3-sys/build.rs
@@ -2,6 +2,9 @@ use std::env;
 #[cfg(feature = "gh-release")]
 use std::path::PathBuf;
 
+mod enum_compat;
+mod version;
+
 macro_rules! assert_one_of_features {
     ($($feature:literal),*) => {{
         let mut active_count = 0;
@@ -24,19 +27,29 @@ fn main() {
     let active_feature = assert_one_of_features!("vendored", "vcpkg", "gh-release");
 
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=Z3_SYS_Z3_VERSION");
+    let override_version = env::var("Z3_SYS_Z3_VERSION")
+        .ok()
+        .and_then(|s| version::parse_dotted(&s));
 
-    match active_feature {
+    let detected_version = match active_feature {
         Some("vendored") => build_from_source(),
         Some("gh-release") => install_from_gh_release(),
         Some("vcpkg") => find_library_by_vcpkg(),
         _ => {
-            pkg_config::Config::new().probe("z3").ok();
+            let detected = pkg_config::Config::new()
+                .probe("z3")
+                .ok()
+                .and_then(|lib| detect_pkg_config_version(&lib));
             println!("cargo:rerun-if-env-changed=Z3_LIBRARY_PATH_OVERRIDE");
             if let Ok(lib_path) = env::var("Z3_LIBRARY_PATH_OVERRIDE") {
                 println!("cargo:rustc-link-search=native={lib_path}");
             }
+            detected
         }
-    }
+    };
+
+    emit_version_metadata(override_version.or(detected_version));
 
     #[cfg(feature = "bundled")]
     println!(
@@ -49,14 +62,56 @@ fn main() {
     generate_bindings();
 }
 
+/// Emits the detected Z3 version (or the assumed minimum, if detection
+/// failed) as `links`-passthrough metadata for downstream crates (see
+/// `DEP_Z3_VERSION_*` / `DEP_Z3_MIN_SUPPORTED_*` in `z3/build.rs`), and
+/// enforces the minimum supported version.
+fn emit_version_metadata(version: Option<version::Version>) {
+    let min = version::MIN_SUPPORTED;
+    let version = match version {
+        Some(v) if v < min => panic!(
+            "Detected Z3 {v}, but z3-sys requires Z3 >= {min}. Upgrade your Z3 installation, \
+             or if this detection is wrong, override with Z3_SYS_Z3_VERSION=<version> (must \
+             still satisfy the minimum)."
+        ),
+        Some(v) => v,
+        None => {
+            println!(
+                "cargo:warning=z3-sys: could not detect linked Z3 version; assuming minimum \
+                 supported {min}. Newer version-gated APIs will be unavailable. Set \
+                 Z3_SYS_Z3_VERSION to override."
+            );
+            min
+        }
+    };
+
+    println!("cargo:version_major={}", version.major);
+    println!("cargo:version_minor={}", version.minor);
+    println!("cargo:version_patch={}", version.patch);
+    println!("cargo:min_supported_major={}", min.major);
+    println!("cargo:min_supported_minor={}", min.minor);
+    println!("cargo:min_supported_patch={}", min.patch);
+
+    enum_compat::warn_on_mismatches(version);
+}
+
+fn detect_pkg_config_version(lib: &pkg_config::Library) -> Option<version::Version> {
+    version::parse_dotted(&lib.version).or_else(|| {
+        lib.include_paths
+            .iter()
+            .find_map(|dir| version::parse_header(&dir.join("z3_version.h")))
+    })
+}
+
 #[cfg(feature = "vendored")]
-fn build_from_source() {
+fn build_from_source() -> Option<version::Version> {
     let artifacts = z3_src::build();
     artifacts.print_cargo_metadata();
+    version::parse_header(&artifacts.include_dir().join("z3_version.h"))
 }
 
 #[cfg(not(feature = "vendored"))]
-fn build_from_source() {
+fn build_from_source() -> Option<version::Version> {
     unreachable!()
 }
 
@@ -100,10 +155,10 @@ mod gh_release {
     use zip::ZipArchive;
     use zip::read::root_dir_common_filter;
 
-    pub(super) fn install_from_gh_release() {
+    pub(super) fn install_from_gh_release() -> Option<crate::version::Version> {
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
         let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-        let lib = retrieve_gh_release_z3(&target_os, &target_arch);
+        let (lib, version) = retrieve_gh_release_z3(&target_os, &target_arch);
         println!(
             "cargo:rustc-link-search=native={}",
             lib.parent().unwrap().display()
@@ -113,9 +168,13 @@ mod gh_release {
         } else {
             println!("cargo:rustc-link-lib=static=z3");
         }
+        version
     }
 
-    fn retrieve_gh_release_z3(target_os: &str, target_arch: &str) -> PathBuf {
+    fn retrieve_gh_release_z3(
+        target_os: &str,
+        target_arch: &str,
+    ) -> (PathBuf, Option<crate::version::Version>) {
         let arch = match target_arch {
             "aarch64" => "arm64",
             "x86_64" => "x64",
@@ -131,8 +190,8 @@ mod gh_release {
                 panic!("Unsupported OS: {}", os);
             }
         };
-        println!("cargo:rerun-if-env-changed=Z3_SYS_Z3_VERSION");
         let z3_version = env::var("Z3_SYS_Z3_VERSION").unwrap_or("5.0.0".to_string());
+        let version = crate::version::parse_dotted(&z3_version);
         let z3_dir = PathBuf::from(env::var("OUT_DIR").unwrap()).join(format!("z3-{z3_version}"));
 
         if !z3_dir.exists() {
@@ -162,7 +221,7 @@ mod gh_release {
             z3_dir.display()
         );
 
-        lib
+        (lib, version)
     }
 
     pub fn download_unzip(client: &Client, url: String, dir: &Path) -> reqwest::Result<()> {
@@ -234,20 +293,23 @@ mod gh_release {
 use gh_release::install_from_gh_release;
 
 #[cfg(not(feature = "gh-release"))]
-fn install_from_gh_release() {
+fn install_from_gh_release() -> Option<version::Version> {
     unreachable!()
 }
 
 #[cfg(feature = "vcpkg")]
-fn find_library_by_vcpkg() {
-    vcpkg::Config::new()
+fn find_library_by_vcpkg() -> Option<version::Version> {
+    let lib = vcpkg::Config::new()
         .emit_includes(true)
         .find_package("z3")
         .expect("vcpkg could not find z3");
+    lib.include_paths
+        .iter()
+        .find_map(|dir| version::parse_header(&dir.join("z3_version.h")))
 }
 
 #[cfg(not(feature = "vcpkg"))]
-fn find_library_by_vcpkg() {
+fn find_library_by_vcpkg() -> Option<version::Version> {
     unreachable!()
 }
 

--- a/z3-sys/enum_compat.rs
+++ b/z3-sys/enum_compat.rs
@@ -57,8 +57,8 @@ pub(crate) fn warn_on_mismatches(detected: Version) {
         return;
     }
     println!(
-        "cargo:warning=z3-sys: some enum numbering (e.g. Z3_decl_kind) may differ for Z3 \
-         {detected}; bindings were generated for Z3 >= {current}. Consider regenerating with the \
-         `bindgen` feature if you observe unexpected enum values.",
+        "cargo:warning=z3-sys: attempting to link against Z3 {detected} with `z3-sys` bindings for Z3 >= {current}; \
+         enum numbering (e.g. Z3_decl_kind) may differ across these versions. \
+         Consider updating Z3 or else enabling the `bindgen` feature to ensure compatibility.",
     );
 }

--- a/z3-sys/enum_compat.rs
+++ b/z3-sys/enum_compat.rs
@@ -1,0 +1,64 @@
+use crate::version::Version;
+
+/// A Z3 version range over which an enum's committed numbering
+/// (`src/generated/enums.rs`) is believed to be valid.
+///
+/// Z3 sometimes inserts new variants into the middle of a C enum instead of
+/// appending them, which reassigns the numeric value of every later variant.
+/// Bindgen only ever sees a single header snapshot, so this can't be
+/// detected automatically — entries here are added by hand whenever such a
+/// break is discovered (via Z3's changelog, a GitHub issue, or by diffing
+/// `enums.rs` generated against two different Z3 versions).
+pub(crate) struct EnumVersionRange {
+    pub enum_name: &'static str,
+    pub safe_min: Version,
+    pub safe_max: Option<Version>,
+}
+
+macro_rules! version {
+    ($major:expr, $minor:expr, $patch:expr) => {
+        Version {
+            major: $major,
+            minor: $minor,
+            patch: $patch,
+        }
+    };
+}
+
+pub(crate) const KNOWN_ENUM_VERSION_RANGES: &[EnumVersionRange] = &[
+    EnumVersionRange {
+        // Z3_OP_RECURSIVE was inserted in the middle of Z3_decl_kind (rather
+        // than appended) by commit c9fa00a, shifting the numeric value of
+        // every later Z3_OP_* variant. Released in Z3 4.8.16.
+        // See https://github.com/Z3Prover/z3/issues/6030.
+        enum_name: "Z3_decl_kind",
+        safe_min: version!(4, 8, 16),
+        safe_max: None,
+    },
+    EnumVersionRange {
+        // Z3 4.8.17 inserted SeqMap/SeqMapi/SeqFoldl/SeqFoldli into the
+        // sequence range of Z3_decl_kind (values 1569-1572), shifting every
+        // later string-operation variant (e.g. StrToInt) up by four.
+        enum_name: "Z3_decl_kind",
+        safe_min: version!(4, 8, 17),
+        safe_max: None,
+    },
+];
+
+/// Warns (via `cargo:warning`) about any known enum whose safe version range
+/// doesn't cover `detected`. This is advisory only — it can't prove
+/// compatibility, only flag known-risky combinations.
+pub(crate) fn warn_on_mismatches(detected: Version) {
+    for range in KNOWN_ENUM_VERSION_RANGES {
+        let below_min = detected < range.safe_min;
+        let above_max = range.safe_max.is_some_and(|max| detected > max);
+        if below_min || above_max {
+            println!(
+                "cargo:warning=z3-sys: enum {} numbering may differ for Z3 {detected} \
+                 (bindings assume Z3 >= {}); consider regenerating with the `bindgen` \
+                 feature if you observe unexpected enum values.",
+                range.enum_name, range.safe_min
+            );
+        }
+    }
+}

--- a/z3-sys/enum_compat.rs
+++ b/z3-sys/enum_compat.rs
@@ -1,16 +1,22 @@
 use crate::version::Version;
 
-/// A Z3 version range over which an enum's committed numbering
-/// (`src/generated/enums.rs`) is believed to be valid.
+/// A Z3 version range over which the committed enum numbering
+/// (`src/generated/enums.rs`) is believed to be stable.
 ///
 /// Z3 sometimes inserts new variants into the middle of a C enum instead of
 /// appending them, which reassigns the numeric value of every later variant.
 /// Bindgen only ever sees a single header snapshot, so this can't be
-/// detected automatically — entries here are added by hand whenever such a
+/// detected automatically — ranges here are added by hand whenever such a
 /// break is discovered (via Z3's changelog, a GitHub issue, or by diffing
 /// `enums.rs` generated against two different Z3 versions).
+///
+/// `KNOWN_ENUM_VERSION_RANGES` must be sorted ascending by `safe_min` and
+/// cover every released Z3 version with no gaps or overlaps: each range's
+/// `safe_max` is the last version known to share that numbering, and the
+/// next range's `safe_min` is the version that broke it. The final range has
+/// `safe_max: None` and its `safe_min` is the version `enums.rs` was
+/// actually generated from — i.e. the current bin.
 pub(crate) struct EnumVersionRange {
-    pub enum_name: &'static str,
     pub safe_min: Version,
     pub safe_max: Option<Version>,
 }
@@ -31,34 +37,54 @@ pub(crate) const KNOWN_ENUM_VERSION_RANGES: &[EnumVersionRange] = &[
         // than appended) by commit c9fa00a, shifting the numeric value of
         // every later Z3_OP_* variant. Released in Z3 4.8.16.
         // See https://github.com/Z3Prover/z3/issues/6030.
-        enum_name: "Z3_decl_kind",
+        // Stable through 4.13.0 (the last release before the next break).
         safe_min: version!(4, 8, 16),
-        safe_max: None,
+        safe_max: Some(version!(4, 13, 0)),
     },
     EnumVersionRange {
-        // Z3 4.8.17 inserted SeqMap/SeqMapi/SeqFoldl/SeqFoldli into the
-        // sequence range of Z3_decl_kind (values 1569-1572), shifting every
-        // later string-operation variant (e.g. StrToInt) up by four.
-        enum_name: "Z3_decl_kind",
-        safe_min: version!(4, 8, 17),
+        // Z3 4.13.2 inserted Z3_OP_ABS and SeqMap/SeqMapi/SeqFoldl/SeqFoldli
+        // into the sequence range of Z3_decl_kind (values 1569-1572),
+        // shifting every later string-operation variant (e.g. StrToInt) up
+        // by four. Introduced by commit fc6c4c98e ("initial warppers for
+        // seq-map/seq-fold"). Stable through 4.14.0.
+        safe_min: version!(4, 13, 2),
+        safe_max: Some(version!(4, 14, 0)),
+    },
+    EnumVersionRange {
+        // Z3 4.14.1 inserted Z3_OP_SBV2INT into the bitvector range of
+        // Z3_decl_kind, shifting Z3_OP_CARRY, Z3_OP_XOR3, and 8 other later
+        // variants up by one. Stable through 4.16.0.
+        safe_min: version!(4, 14, 1),
+        safe_max: Some(version!(4, 16, 0)),
+    },
+    EnumVersionRange {
+        // Z3 5.0.0 inserted 13 Z3_OP_FINITE_SET_* variants into
+        // Z3_decl_kind before Z3_OP_INTERNAL, shifting Z3_OP_INTERNAL,
+        // Z3_OP_RECURSIVE, and Z3_OP_UNINTERPRETED from 45100-45102 to
+        // 49165-49167. This is the numbering currently committed in
+        // src/generated/enums.rs.
+        safe_min: version!(5, 0, 0),
         safe_max: None,
     },
 ];
 
-/// Warns (via `cargo:warning`) about any known enum whose safe version range
-/// doesn't cover `detected`. This is advisory only — it can't prove
-/// compatibility, only flag known-risky combinations.
+/// Warns (via `cargo:warning`) if `detected` falls outside the version era
+/// the committed enum numbering was generated from. This is advisory only —
+/// it can't prove compatibility, only flag a known-risky combination.
 pub(crate) fn warn_on_mismatches(detected: Version) {
-    for range in KNOWN_ENUM_VERSION_RANGES {
-        let below_min = detected < range.safe_min;
-        let above_max = range.safe_max.is_some_and(|max| detected > max);
-        if below_min || above_max {
-            println!(
-                "cargo:warning=z3-sys: enum {} numbering may differ for Z3 {detected} \
-                 (bindings assume Z3 >= {}); consider regenerating with the `bindgen` \
-                 feature if you observe unexpected enum values.",
-                range.enum_name, range.safe_min
-            );
-        }
+    let Some(current) = KNOWN_ENUM_VERSION_RANGES
+        .iter()
+        .find(|r| r.safe_max.is_none())
+    else {
+        return;
+    };
+    if detected >= current.safe_min {
+        return;
     }
+    println!(
+        "cargo:warning=z3-sys: some enum numbering (e.g. Z3_decl_kind) may differ for Z3 \
+         {detected}; bindings were generated for Z3 >= {}. Consider regenerating with the \
+         `bindgen` feature if you observe unexpected enum values.",
+        current.safe_min
+    );
 }

--- a/z3-sys/enum_compat.rs
+++ b/z3-sys/enum_compat.rs
@@ -1,26 +1,17 @@
 use crate::version::Version;
 
-/// A Z3 version range over which the committed enum numbering
-/// (`src/generated/enums.rs`) is believed to be stable.
+/// A Z3 version at which the committed enum numbering
+/// (`src/generated/enums.rs`) is known to have changed.
 ///
 /// Z3 sometimes inserts new variants into the middle of a C enum instead of
 /// appending them, which reassigns the numeric value of every later variant.
 /// Bindgen only ever sees a single header snapshot, so this can't be
-/// detected automatically — ranges here are added by hand whenever such a
+/// detected automatically — entries here are added by hand whenever such a
 /// break is discovered (via Z3's changelog, a GitHub issue, or by diffing
 /// `enums.rs` generated against two different Z3 versions).
 ///
-/// `KNOWN_ENUM_VERSION_RANGES` must be sorted ascending by `safe_min` and
-/// cover every released Z3 version with no gaps or overlaps: each range's
-/// `safe_max` is the last version known to share that numbering, and the
-/// next range's `safe_min` is the version that broke it. The final range has
-/// `safe_max: None` and its `safe_min` is the version `enums.rs` was
-/// actually generated from — i.e. the current bin.
-pub(crate) struct EnumVersionRange {
-    pub safe_min: Version,
-    pub safe_max: Option<Version>,
-}
-
+/// `KNOWN_ENUM_BREAKS` must be sorted ascending. The last entry is the
+/// version `enums.rs` was actually generated from — i.e. the current bin.
 macro_rules! version {
     ($major:expr, $minor:expr, $patch:expr) => {
         Version {
@@ -31,60 +22,43 @@ macro_rules! version {
     };
 }
 
-pub(crate) const KNOWN_ENUM_VERSION_RANGES: &[EnumVersionRange] = &[
-    EnumVersionRange {
-        // Z3_OP_RECURSIVE was inserted in the middle of Z3_decl_kind (rather
-        // than appended) by commit c9fa00a, shifting the numeric value of
-        // every later Z3_OP_* variant. Released in Z3 4.8.16.
-        // See https://github.com/Z3Prover/z3/issues/6030.
-        // Stable through 4.13.0 (the last release before the next break).
-        safe_min: version!(4, 8, 16),
-        safe_max: Some(version!(4, 13, 0)),
-    },
-    EnumVersionRange {
-        // Z3 4.13.2 inserted Z3_OP_ABS and SeqMap/SeqMapi/SeqFoldl/SeqFoldli
-        // into the sequence range of Z3_decl_kind (values 1569-1572),
-        // shifting every later string-operation variant (e.g. StrToInt) up
-        // by four. Introduced by commit fc6c4c98e ("initial warppers for
-        // seq-map/seq-fold"). Stable through 4.14.0.
-        safe_min: version!(4, 13, 2),
-        safe_max: Some(version!(4, 14, 0)),
-    },
-    EnumVersionRange {
-        // Z3 4.14.1 inserted Z3_OP_SBV2INT into the bitvector range of
-        // Z3_decl_kind, shifting Z3_OP_CARRY, Z3_OP_XOR3, and 8 other later
-        // variants up by one. Stable through 4.16.0.
-        safe_min: version!(4, 14, 1),
-        safe_max: Some(version!(4, 16, 0)),
-    },
-    EnumVersionRange {
-        // Z3 5.0.0 inserted 13 Z3_OP_FINITE_SET_* variants into
-        // Z3_decl_kind before Z3_OP_INTERNAL, shifting Z3_OP_INTERNAL,
-        // Z3_OP_RECURSIVE, and Z3_OP_UNINTERPRETED from 45100-45102 to
-        // 49165-49167. This is the numbering currently committed in
-        // src/generated/enums.rs.
-        safe_min: version!(5, 0, 0),
-        safe_max: None,
-    },
+pub(crate) const KNOWN_ENUM_BREAKS: &[Version] = &[
+    // Z3_OP_RECURSIVE was inserted in the middle of Z3_decl_kind (rather
+    // than appended) by commit c9fa00a, shifting the numeric value of
+    // every later Z3_OP_* variant. Released in Z3 4.8.16.
+    // See https://github.com/Z3Prover/z3/issues/6030.
+    version!(4, 8, 16),
+    // Z3 4.13.2 inserted Z3_OP_ABS and SeqMap/SeqMapi/SeqFoldl/SeqFoldli
+    // into the sequence range of Z3_decl_kind (values 1569-1572),
+    // shifting every later string-operation variant (e.g. StrToInt) up
+    // by four. Introduced by commit fc6c4c98e ("initial warppers for
+    // seq-map/seq-fold").
+    version!(4, 13, 2),
+    // Z3 4.14.1 inserted Z3_OP_SBV2INT into the bitvector range of
+    // Z3_decl_kind, shifting Z3_OP_CARRY, Z3_OP_XOR3, and 8 other later
+    // variants up by one.
+    version!(4, 14, 1),
+    // Z3 5.0.0 inserted 13 Z3_OP_FINITE_SET_* variants into
+    // Z3_decl_kind before Z3_OP_INTERNAL, shifting Z3_OP_INTERNAL,
+    // Z3_OP_RECURSIVE, and Z3_OP_UNINTERPRETED from 45100-45102 to
+    // 49165-49167. This is the numbering currently committed in
+    // src/generated/enums.rs.
+    version!(5, 0, 0),
 ];
 
 /// Warns (via `cargo:warning`) if `detected` falls outside the version era
 /// the committed enum numbering was generated from. This is advisory only —
 /// it can't prove compatibility, only flag a known-risky combination.
 pub(crate) fn warn_on_mismatches(detected: Version) {
-    let Some(current) = KNOWN_ENUM_VERSION_RANGES
-        .iter()
-        .find(|r| r.safe_max.is_none())
-    else {
+    let Some(&current) = KNOWN_ENUM_BREAKS.last() else {
         return;
     };
-    if detected >= current.safe_min {
+    if detected >= current {
         return;
     }
     println!(
         "cargo:warning=z3-sys: some enum numbering (e.g. Z3_decl_kind) may differ for Z3 \
-         {detected}; bindings were generated for Z3 >= {}. Consider regenerating with the \
+         {detected}; bindings were generated for Z3 >= {current}. Consider regenerating with the \
          `bindgen` feature if you observe unexpected enum values.",
-        current.safe_min
     );
 }

--- a/z3-sys/version.rs
+++ b/z3-sys/version.rs
@@ -65,3 +65,59 @@ fn find_macro_value(contents: &str, name: &str) -> Option<u32> {
     }
     None
 }
+
+/// Parses a version out of `z3 --version` output, e.g. `"Z3 version 4.13.3 -
+/// 64 bit"`. Used as a fallback when no pkg-config metadata is available
+/// (e.g. Z3 installed from a prebuilt release archive with no `.pc` file).
+pub(crate) fn parse_cli_output(s: &str) -> Option<Version> {
+    let after = s.split("version").nth(1)?;
+    let token = after.split_whitespace().next()?;
+    parse_dotted(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_dotted_versions() {
+        assert_eq!(
+            parse_dotted("4.13.3"),
+            Some(Version {
+                major: 4,
+                minor: 13,
+                patch: 3
+            })
+        );
+        assert_eq!(
+            parse_dotted("5.0"),
+            Some(Version {
+                major: 5,
+                minor: 0,
+                patch: 0
+            })
+        );
+        assert_eq!(parse_dotted("not-a-version"), None);
+    }
+
+    #[test]
+    fn parses_cli_output() {
+        assert_eq!(
+            parse_cli_output("Z3 version 4.13.3 - 64 bit"),
+            Some(Version {
+                major: 4,
+                minor: 13,
+                patch: 3
+            })
+        );
+        assert_eq!(
+            parse_cli_output("Z3 version 5.0.0"),
+            Some(Version {
+                major: 5,
+                minor: 0,
+                patch: 0
+            })
+        );
+        assert_eq!(parse_cli_output("not z3 output"), None);
+    }
+}

--- a/z3-sys/version.rs
+++ b/z3-sys/version.rs
@@ -1,0 +1,67 @@
+use std::fs;
+use std::path::Path;
+
+/// A parsed Z3 version (major.minor.patch).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub(crate) struct Version {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// The minimum Z3 version z3-sys supports (Ubuntu 26.04's shipped Z3).
+pub(crate) const MIN_SUPPORTED: Version = Version {
+    major: 4,
+    minor: 13,
+    patch: 3,
+};
+
+/// Parses a dotted version string like `"4.13.3"` or `"4.13.3.0"`.
+///
+/// Extra trailing components (e.g. a build/tweak number) are ignored.
+pub(crate) fn parse_dotted(s: &str) -> Option<Version> {
+    let mut parts = s.trim().split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next().unwrap_or("0").parse().ok()?;
+    Some(Version {
+        major,
+        minor,
+        patch,
+    })
+}
+
+/// Parses a Z3 version from a `z3_version.h` header, which defines
+/// `Z3_MAJOR_VERSION`, `Z3_MINOR_VERSION`, and `Z3_BUILD_NUMBER` (the patch
+/// component — Z3 does not call it `Z3_PATCH_VERSION`).
+pub(crate) fn parse_header(path: &Path) -> Option<Version> {
+    let contents = fs::read_to_string(path).ok()?;
+    let major = find_macro_value(&contents, "Z3_MAJOR_VERSION")?;
+    let minor = find_macro_value(&contents, "Z3_MINOR_VERSION")?;
+    let patch = find_macro_value(&contents, "Z3_BUILD_NUMBER").unwrap_or(0);
+    Some(Version {
+        major,
+        minor,
+        patch,
+    })
+}
+
+fn find_macro_value(contents: &str, name: &str) -> Option<u32> {
+    for line in contents.lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix("#define") else {
+            continue;
+        };
+        let mut tokens = rest.split_whitespace();
+        if tokens.next() == Some(name) {
+            return tokens.next()?.parse().ok();
+        }
+    }
+    None
+}

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -2,6 +2,7 @@
 name = "z3"
 rust-version = "1.85.0"
 version = "0.20.2"
+build = "build.rs"
 authors = ["Graydon Hoare <graydon@pobox.com>", "Bruce Mitchener <bruce.mitchener@gmail.com>", "Nick Fitzgerald <fitzgen@gmail.com>", "Mark DenHoed <mark.denhoed@cs.ox.ac.uk>"]
 
 description = "High-level rust bindings for the Z3 SMT solver from Microsoft Research"
@@ -26,11 +27,6 @@ gh-release = ["z3-sys/gh-release"]
 bundled = ["z3-sys/bundled"]
 
 num = ["dep:num"]
-
-# Temporary feature gate for APIs requiring Z3 >= 4.16.0.
-# This flag will be removed and these APIs will become unconditional once
-# the minimum supported Z3 version is bumped to 4.16.0.
-z3_4_16 = []
 
 [dependencies]
 log = "0.4"

--- a/z3/build.rs
+++ b/z3/build.rs
@@ -1,25 +1,32 @@
 use std::env;
 
 /// Version thresholds that gate specific APIs. Add an entry here alongside
-/// the `#[cfg(z3_{major}_{minor})]` attribute(s) it controls.
-const KNOWN_THRESHOLDS: &[(u32, u32)] = &[
-    (4, 16), // Optimize::solutions(), Translate/Clone for Optimize (see src/optimize.rs)
+/// the `#[cfg(z3_{major}_{minor}_{patch})]` attribute(s) it controls.
+///
+/// Z3 doesn't treat its version number as an API-stability contract: new C
+/// API functions have landed in patch releases (e.g. `Z3_mk_abs` in 4.13.2,
+/// several `Z3_mk_seq_*` functions across 4.15.3-4.15.5), so thresholds here
+/// must be exact `(major, minor, patch)` triples, not just `(major, minor)`.
+const KNOWN_THRESHOLDS: &[(u32, u32, u32)] = &[
+    (4, 16, 0), // Optimize::solutions(), Translate/Clone for Optimize (see src/optimize.rs)
 ];
 
 fn main() {
     // Declare every cfg we might emit up front, regardless of which branch
     // below runs, so `-D warnings` never trips on `unexpected_cfgs`.
-    for (major, minor) in KNOWN_THRESHOLDS {
-        println!("cargo::rustc-check-cfg=cfg(z3_{major}_{minor})");
+    for (major, minor, patch) in KNOWN_THRESHOLDS {
+        println!("cargo::rustc-check-cfg=cfg(z3_{major}_{minor}_{patch})");
     }
     println!("cargo::rustc-check-cfg=cfg(z3_version_major, values(any()))");
     println!("cargo::rustc-check-cfg=cfg(z3_version_minor, values(any()))");
+    println!("cargo::rustc-check-cfg=cfg(z3_version_patch, values(any()))");
 
     println!("cargo:rerun-if-env-changed=DOCS_RS");
     println!("cargo:rerun-if-env-changed=DEP_Z3_VERSION_MAJOR");
     println!("cargo:rerun-if-env-changed=DEP_Z3_VERSION_MINOR");
+    println!("cargo:rerun-if-env-changed=DEP_Z3_VERSION_PATCH");
 
-    let (major, minor) = if env::var_os("DOCS_RS").is_some() {
+    let (major, minor, patch) = if env::var_os("DOCS_RS").is_some() {
         // docs.rs never links a real Z3 (z3-sys's own detection falls back to
         // its minimum-supported version in that environment), so force
         // "assume the latest known threshold" here instead, so every
@@ -34,30 +41,35 @@ fn main() {
 
     println!("cargo::rustc-cfg=z3_version_major=\"{major}\"");
     println!("cargo::rustc-cfg=z3_version_minor=\"{minor}\"");
-    for (t_major, t_minor) in KNOWN_THRESHOLDS {
-        if (major, minor) >= (*t_major, *t_minor) {
-            println!("cargo::rustc-cfg=z3_{t_major}_{t_minor}");
+    println!("cargo::rustc-cfg=z3_version_patch=\"{patch}\"");
+    for (t_major, t_minor, t_patch) in KNOWN_THRESHOLDS {
+        if (major, minor, patch) >= (*t_major, *t_minor, *t_patch) {
+            println!("cargo::rustc-cfg=z3_{t_major}_{t_minor}_{t_patch}");
         }
     }
 }
 
 /// Reads the Z3 version z3-sys detected, via the `links = "z3"` metadata
-/// passthrough (`DEP_Z3_VERSION_MAJOR`/`MINOR`, emitted by z3-sys/build.rs).
-fn read_dep_z3_version() -> (u32, u32) {
+/// passthrough (`DEP_Z3_VERSION_MAJOR`/`MINOR`/`PATCH` in `z3/build.rs`),
+/// emitted by z3-sys/build.rs.
+fn read_dep_z3_version() -> (u32, u32, u32) {
     let major = env::var("DEP_Z3_VERSION_MAJOR")
         .ok()
         .and_then(|s| s.parse().ok());
     let minor = env::var("DEP_Z3_VERSION_MINOR")
         .ok()
         .and_then(|s| s.parse().ok());
-    match (major, minor) {
-        (Some(major), Some(minor)) => (major, minor),
+    let patch = env::var("DEP_Z3_VERSION_PATCH")
+        .ok()
+        .and_then(|s| s.parse().ok());
+    match (major, minor, patch) {
+        (Some(major), Some(minor), Some(patch)) => (major, minor, patch),
         _ => {
             println!(
                 "cargo:warning=z3: could not read the Z3 version detected by z3-sys \
-                 (DEP_Z3_VERSION_MAJOR/MINOR); version-gated APIs will be unavailable."
+                 (DEP_Z3_VERSION_MAJOR/MINOR/PATCH); version-gated APIs will be unavailable."
             );
-            (0, 0)
+            (0, 0, 0)
         }
     }
 }

--- a/z3/build.rs
+++ b/z3/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 /// Version thresholds that gate specific APIs. Add an entry here alongside
-/// the `#[cfg(z3_ge_{major}_{minor})]` attribute(s) it controls.
+/// the `#[cfg(z3_{major}_{minor})]` attribute(s) it controls.
 const KNOWN_THRESHOLDS: &[(u32, u32)] = &[
     (4, 16), // Optimize::solutions(), Translate/Clone for Optimize (see src/optimize.rs)
 ];
@@ -10,7 +10,7 @@ fn main() {
     // Declare every cfg we might emit up front, regardless of which branch
     // below runs, so `-D warnings` never trips on `unexpected_cfgs`.
     for (major, minor) in KNOWN_THRESHOLDS {
-        println!("cargo::rustc-check-cfg=cfg(z3_ge_{major}_{minor})");
+        println!("cargo::rustc-check-cfg=cfg(z3_{major}_{minor})");
     }
     println!("cargo::rustc-check-cfg=cfg(z3_version_major, values(any()))");
     println!("cargo::rustc-check-cfg=cfg(z3_version_minor, values(any()))");
@@ -36,7 +36,7 @@ fn main() {
     println!("cargo::rustc-cfg=z3_version_minor=\"{minor}\"");
     for (t_major, t_minor) in KNOWN_THRESHOLDS {
         if (major, minor) >= (*t_major, *t_minor) {
-            println!("cargo::rustc-cfg=z3_ge_{t_major}_{t_minor}");
+            println!("cargo::rustc-cfg=z3_{t_major}_{t_minor}");
         }
     }
 }

--- a/z3/build.rs
+++ b/z3/build.rs
@@ -1,0 +1,63 @@
+use std::env;
+
+/// Version thresholds that gate specific APIs. Add an entry here alongside
+/// the `#[cfg(z3_ge_{major}_{minor})]` attribute(s) it controls.
+const KNOWN_THRESHOLDS: &[(u32, u32)] = &[
+    (4, 16), // Optimize::solutions(), Translate/Clone for Optimize (see src/optimize.rs)
+];
+
+fn main() {
+    // Declare every cfg we might emit up front, regardless of which branch
+    // below runs, so `-D warnings` never trips on `unexpected_cfgs`.
+    for (major, minor) in KNOWN_THRESHOLDS {
+        println!("cargo::rustc-check-cfg=cfg(z3_ge_{major}_{minor})");
+    }
+    println!("cargo::rustc-check-cfg=cfg(z3_version_major, values(any()))");
+    println!("cargo::rustc-check-cfg=cfg(z3_version_minor, values(any()))");
+
+    println!("cargo:rerun-if-env-changed=DOCS_RS");
+    println!("cargo:rerun-if-env-changed=DEP_Z3_VERSION_MAJOR");
+    println!("cargo:rerun-if-env-changed=DEP_Z3_VERSION_MINOR");
+
+    let (major, minor) = if env::var_os("DOCS_RS").is_some() {
+        // docs.rs never links a real Z3 (z3-sys's own detection falls back to
+        // its minimum-supported version in that environment), so force
+        // "assume the latest known threshold" here instead, so every
+        // version-gated API still renders in the published docs.
+        *KNOWN_THRESHOLDS
+            .iter()
+            .max()
+            .expect("KNOWN_THRESHOLDS is non-empty")
+    } else {
+        read_dep_z3_version()
+    };
+
+    println!("cargo::rustc-cfg=z3_version_major=\"{major}\"");
+    println!("cargo::rustc-cfg=z3_version_minor=\"{minor}\"");
+    for (t_major, t_minor) in KNOWN_THRESHOLDS {
+        if (major, minor) >= (*t_major, *t_minor) {
+            println!("cargo::rustc-cfg=z3_ge_{t_major}_{t_minor}");
+        }
+    }
+}
+
+/// Reads the Z3 version z3-sys detected, via the `links = "z3"` metadata
+/// passthrough (`DEP_Z3_VERSION_MAJOR`/`MINOR`, emitted by z3-sys/build.rs).
+fn read_dep_z3_version() -> (u32, u32) {
+    let major = env::var("DEP_Z3_VERSION_MAJOR")
+        .ok()
+        .and_then(|s| s.parse().ok());
+    let minor = env::var("DEP_Z3_VERSION_MINOR")
+        .ok()
+        .and_then(|s| s.parse().ok());
+    match (major, minor) {
+        (Some(major), Some(minor)) => (major, minor),
+        _ => {
+            println!(
+                "cargo:warning=z3: could not read the Z3 version detected by z3-sys \
+                 (DEP_Z3_VERSION_MAJOR/MINOR); version-gated APIs will be unavailable."
+            );
+            (0, 0)
+        }
+    }
+}

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -79,6 +79,8 @@
 #![allow(clippy::unreadable_literal)]
 #![warn(clippy::doc_markdown)]
 #![deny(missing_debug_implementations)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, doc(auto_cfg))]
 
 use std::cell::Cell;
 use std::ffi::CString;

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -7,7 +7,7 @@ use std::iter::FusedIterator;
 use std::ptr::NonNull;
 use z3_sys::*;
 
-#[cfg(z3_ge_4_16)]
+#[cfg(z3_4_16)]
 use crate::Translate;
 use crate::callbacks::FfiState;
 use crate::solver::Solvable;
@@ -327,7 +327,7 @@ impl Optimize {
     /// - [`Optimize::into_solutions`]
     /// - [`Optimize::check_and_get_model`]
     // Requires Z3 >= 4.16.0 (auto-detected; see z3/build.rs).
-    #[cfg(z3_ge_4_16)]
+    #[cfg(z3_4_16)]
     pub fn solutions<T: Solvable>(
         &self,
         t: T,
@@ -566,7 +566,7 @@ impl Drop for Optimize {
 }
 
 // [Z3_optimize_translate] was added in Z3 4.16.0 (auto-detected; see z3/build.rs).
-#[cfg(z3_ge_4_16)]
+#[cfg(z3_4_16)]
 unsafe impl Translate for Optimize {
     fn translate(&self, dest: &Context) -> Optimize {
         unsafe {
@@ -581,7 +581,7 @@ unsafe impl Translate for Optimize {
 /// Creates a new [`Optimize`] with the same assertions, objectives, and parameters
 /// as the original
 // Requires Z3 >= 4.16.0 (auto-detected; see z3/build.rs).
-#[cfg(z3_ge_4_16)]
+#[cfg(z3_4_16)]
 impl Clone for Optimize {
     fn clone(&self) -> Self {
         self.translate(&Context::thread_local())

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -298,6 +298,8 @@ impl Optimize {
 
     /// Iterate over solutions to the given [`Solvable`], cloning this [`Optimize`].
     ///
+    /// Only available when Z3 >= 4.16.0 was detected at build time.
+    ///
     /// The [`Optimize`] given to this method is [`Clone`]'d when producing the iterator: no change
     /// is made to the optimizer passed to the function.
     ///

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -7,7 +7,7 @@ use std::iter::FusedIterator;
 use std::ptr::NonNull;
 use z3_sys::*;
 
-#[cfg(z3_4_16)]
+#[cfg(z3_4_16_0)]
 use crate::Translate;
 use crate::callbacks::FfiState;
 use crate::solver::Solvable;
@@ -327,7 +327,7 @@ impl Optimize {
     /// - [`Optimize::into_solutions`]
     /// - [`Optimize::check_and_get_model`]
     // Requires Z3 >= 4.16.0 (auto-detected; see z3/build.rs).
-    #[cfg(z3_4_16)]
+    #[cfg(z3_4_16_0)]
     pub fn solutions<T: Solvable>(
         &self,
         t: T,
@@ -566,7 +566,7 @@ impl Drop for Optimize {
 }
 
 // [Z3_optimize_translate] was added in Z3 4.16.0 (auto-detected; see z3/build.rs).
-#[cfg(z3_4_16)]
+#[cfg(z3_4_16_0)]
 unsafe impl Translate for Optimize {
     fn translate(&self, dest: &Context) -> Optimize {
         unsafe {
@@ -581,7 +581,7 @@ unsafe impl Translate for Optimize {
 /// Creates a new [`Optimize`] with the same assertions, objectives, and parameters
 /// as the original
 // Requires Z3 >= 4.16.0 (auto-detected; see z3/build.rs).
-#[cfg(z3_4_16)]
+#[cfg(z3_4_16_0)]
 impl Clone for Optimize {
     fn clone(&self) -> Self {
         self.translate(&Context::thread_local())

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -7,7 +7,7 @@ use std::iter::FusedIterator;
 use std::ptr::NonNull;
 use z3_sys::*;
 
-#[cfg(feature = "z3_4_16")]
+#[cfg(z3_ge_4_16)]
 use crate::Translate;
 use crate::callbacks::FfiState;
 use crate::solver::Solvable;
@@ -324,9 +324,8 @@ impl Optimize {
     ///
     /// - [`Optimize::into_solutions`]
     /// - [`Optimize::check_and_get_model`]
-    // Requires the `z3_4_16` feature (Z3 >= 4.16.0). This gate is temporary and will
-    // be removed once the minimum supported Z3 version is bumped to 4.16.0.
-    #[cfg(feature = "z3_4_16")]
+    // Requires Z3 >= 4.16.0 (auto-detected; see z3/build.rs).
+    #[cfg(z3_ge_4_16)]
     pub fn solutions<T: Solvable>(
         &self,
         t: T,
@@ -564,9 +563,8 @@ impl Drop for Optimize {
     }
 }
 
-// [Z3_optimize_translate] was added in Z3 4.16.0. This feature gate is temporary
-// and will be removed once the minimum supported Z3 version is bumped to 4.16.0.
-#[cfg(feature = "z3_4_16")]
+// [Z3_optimize_translate] was added in Z3 4.16.0 (auto-detected; see z3/build.rs).
+#[cfg(z3_ge_4_16)]
 unsafe impl Translate for Optimize {
     fn translate(&self, dest: &Context) -> Optimize {
         unsafe {
@@ -580,9 +578,8 @@ unsafe impl Translate for Optimize {
 
 /// Creates a new [`Optimize`] with the same assertions, objectives, and parameters
 /// as the original
-// Requires the `z3_4_16` feature (Z3 >= 4.16.0). This gate is temporary and will
-// be removed once the minimum supported Z3 version is bumped to 4.16.0.
-#[cfg(feature = "z3_4_16")]
+// Requires Z3 >= 4.16.0 (auto-detected; see z3/build.rs).
+#[cfg(z3_ge_4_16)]
 impl Clone for Optimize {
     fn clone(&self) -> Self {
         self.translate(&Context::thread_local())

--- a/z3/tests/optimize_model_handler.rs
+++ b/z3/tests/optimize_model_handler.rs
@@ -1,8 +1,8 @@
 use std::cell::Cell;
 use std::rc::Rc;
-#[cfg(feature = "z3_4_16")]
+#[cfg(z3_ge_4_16)]
 use std::sync::Arc;
-#[cfg(feature = "z3_4_16")]
+#[cfg(z3_ge_4_16)]
 use std::sync::atomic::{AtomicBool, Ordering};
 use z3::ast::Int;
 use z3::*;
@@ -123,7 +123,7 @@ fn drop_with_active_handler_does_not_panic() {
 
 // ── translate interaction (requires Z3 >= 4.16.0) ───────────────────────────
 
-#[cfg(feature = "z3_4_16")]
+#[cfg(z3_ge_4_16)]
 #[test]
 fn translate_with_no_handler_gives_no_handler() {
     let x = Int::new_const("x");
@@ -150,7 +150,7 @@ fn translate_with_no_handler_gives_no_handler() {
     assert!(fired.get());
 }
 
-#[cfg(feature = "z3_4_16")]
+#[cfg(z3_ge_4_16)]
 #[test]
 fn translate_does_not_carry_handler_across_contexts() {
     // Handler on the original; translated instance should start with no handler.
@@ -190,7 +190,7 @@ fn translate_does_not_carry_handler_across_contexts() {
     );
 }
 
-#[cfg(feature = "z3_4_16")]
+#[cfg(z3_ge_4_16)]
 #[test]
 fn drop_translated_instance_with_no_handler_does_not_corrupt_original() {
     let x = Int::new_const("x");
@@ -223,7 +223,7 @@ fn drop_translated_instance_with_no_handler_does_not_corrupt_original() {
     );
 }
 
-#[cfg(feature = "z3_4_16")]
+#[cfg(z3_ge_4_16)]
 #[test]
 fn translated_check_with_no_handler_after_original_drops() {
     // Regression: dropping the original Optimize (which has a handler) must not
@@ -248,7 +248,7 @@ fn translated_check_with_no_handler_after_original_drops() {
     assert_eq!(translated.check(&[]), SatResult::Sat);
 }
 
-#[cfg(feature = "z3_4_16")]
+#[cfg(z3_ge_4_16)]
 #[test]
 fn cloned_check_with_no_handler_after_original_drops() {
     // Same as above but via Clone (same context) instead of translate.

--- a/z3/tests/optimize_model_handler.rs
+++ b/z3/tests/optimize_model_handler.rs
@@ -1,8 +1,8 @@
 use std::cell::Cell;
 use std::rc::Rc;
-#[cfg(z3_ge_4_16)]
+#[cfg(z3_4_16)]
 use std::sync::Arc;
-#[cfg(z3_ge_4_16)]
+#[cfg(z3_4_16)]
 use std::sync::atomic::{AtomicBool, Ordering};
 use z3::ast::Int;
 use z3::*;
@@ -123,7 +123,7 @@ fn drop_with_active_handler_does_not_panic() {
 
 // ── translate interaction (requires Z3 >= 4.16.0) ───────────────────────────
 
-#[cfg(z3_ge_4_16)]
+#[cfg(z3_4_16)]
 #[test]
 fn translate_with_no_handler_gives_no_handler() {
     let x = Int::new_const("x");
@@ -150,7 +150,7 @@ fn translate_with_no_handler_gives_no_handler() {
     assert!(fired.get());
 }
 
-#[cfg(z3_ge_4_16)]
+#[cfg(z3_4_16)]
 #[test]
 fn translate_does_not_carry_handler_across_contexts() {
     // Handler on the original; translated instance should start with no handler.
@@ -190,7 +190,7 @@ fn translate_does_not_carry_handler_across_contexts() {
     );
 }
 
-#[cfg(z3_ge_4_16)]
+#[cfg(z3_4_16)]
 #[test]
 fn drop_translated_instance_with_no_handler_does_not_corrupt_original() {
     let x = Int::new_const("x");
@@ -223,7 +223,7 @@ fn drop_translated_instance_with_no_handler_does_not_corrupt_original() {
     );
 }
 
-#[cfg(z3_ge_4_16)]
+#[cfg(z3_4_16)]
 #[test]
 fn translated_check_with_no_handler_after_original_drops() {
     // Regression: dropping the original Optimize (which has a handler) must not
@@ -248,7 +248,7 @@ fn translated_check_with_no_handler_after_original_drops() {
     assert_eq!(translated.check(&[]), SatResult::Sat);
 }
 
-#[cfg(z3_ge_4_16)]
+#[cfg(z3_4_16)]
 #[test]
 fn cloned_check_with_no_handler_after_original_drops() {
     // Same as above but via Clone (same context) instead of translate.

--- a/z3/tests/optimize_model_handler.rs
+++ b/z3/tests/optimize_model_handler.rs
@@ -1,8 +1,8 @@
 use std::cell::Cell;
 use std::rc::Rc;
-#[cfg(z3_4_16)]
+#[cfg(z3_4_16_0)]
 use std::sync::Arc;
-#[cfg(z3_4_16)]
+#[cfg(z3_4_16_0)]
 use std::sync::atomic::{AtomicBool, Ordering};
 use z3::ast::Int;
 use z3::*;
@@ -123,7 +123,7 @@ fn drop_with_active_handler_does_not_panic() {
 
 // ── translate interaction (requires Z3 >= 4.16.0) ───────────────────────────
 
-#[cfg(z3_4_16)]
+#[cfg(z3_4_16_0)]
 #[test]
 fn translate_with_no_handler_gives_no_handler() {
     let x = Int::new_const("x");
@@ -150,7 +150,7 @@ fn translate_with_no_handler_gives_no_handler() {
     assert!(fired.get());
 }
 
-#[cfg(z3_4_16)]
+#[cfg(z3_4_16_0)]
 #[test]
 fn translate_does_not_carry_handler_across_contexts() {
     // Handler on the original; translated instance should start with no handler.
@@ -190,7 +190,7 @@ fn translate_does_not_carry_handler_across_contexts() {
     );
 }
 
-#[cfg(z3_4_16)]
+#[cfg(z3_4_16_0)]
 #[test]
 fn drop_translated_instance_with_no_handler_does_not_corrupt_original() {
     let x = Int::new_const("x");
@@ -223,7 +223,7 @@ fn drop_translated_instance_with_no_handler_does_not_corrupt_original() {
     );
 }
 
-#[cfg(z3_4_16)]
+#[cfg(z3_4_16_0)]
 #[test]
 fn translated_check_with_no_handler_after_original_drops() {
     // Regression: dropping the original Optimize (which has a handler) must not
@@ -248,7 +248,7 @@ fn translated_check_with_no_handler_after_original_drops() {
     assert_eq!(translated.check(&[]), SatResult::Sat);
 }
 
-#[cfg(z3_4_16)]
+#[cfg(z3_4_16_0)]
 #[test]
 fn cloned_check_with_no_handler_after_original_drops() {
     // Same as above but via Clone (same context) instead of translate.

--- a/z3/tests/optimize_translate.rs
+++ b/z3/tests/optimize_translate.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "z3_4_16")]
+#[cfg(z3_ge_4_16)]
 #[test]
 fn test_optimize_translate() {
     use z3::ast::Int;
@@ -27,7 +27,7 @@ fn test_optimize_translate() {
     assert_eq!(opt.check(&[]), SatResult::Unsat);
 }
 
-#[cfg(feature = "z3_4_16")]
+#[cfg(z3_ge_4_16)]
 #[test]
 fn test_optimize_clone() {
     use z3::ast::Int;

--- a/z3/tests/optimize_translate.rs
+++ b/z3/tests/optimize_translate.rs
@@ -1,4 +1,4 @@
-#[cfg(z3_ge_4_16)]
+#[cfg(z3_4_16)]
 #[test]
 fn test_optimize_translate() {
     use z3::ast::Int;
@@ -27,7 +27,7 @@ fn test_optimize_translate() {
     assert_eq!(opt.check(&[]), SatResult::Unsat);
 }
 
-#[cfg(z3_ge_4_16)]
+#[cfg(z3_4_16)]
 #[test]
 fn test_optimize_clone() {
     use z3::ast::Int;

--- a/z3/tests/optimize_translate.rs
+++ b/z3/tests/optimize_translate.rs
@@ -1,4 +1,4 @@
-#[cfg(z3_4_16)]
+#[cfg(z3_4_16_0)]
 #[test]
 fn test_optimize_translate() {
     use z3::ast::Int;
@@ -27,7 +27,7 @@ fn test_optimize_translate() {
     assert_eq!(opt.check(&[]), SatResult::Unsat);
 }
 
-#[cfg(z3_4_16)]
+#[cfg(z3_4_16_0)]
 #[test]
 fn test_optimize_clone() {
     use z3::ast::Int;


### PR DESCRIPTION
Looking over a bunch of the to-be-added features it struck me that the versioning strategy in this library was about to get a lot more complicated.

Previous to 0.20.0, the z3 crate basically just implemented the API as it existed at 4.8.17, with no existing utilities to allow adding support for newer APIs.

The changes in 0.20.0 allowed better explicit tying of z3-rs versions to z3 versions, but committed bindgen results, so it was possible for bindgen to get out-of-sync vs the linked library on enum definitions. Additionally, the current solution for properly gating new apis (a cargo feature per-z3 version) was fine for the _one_ feature that used it, but if we add all these other missing APIs, we suddenly have many different versions to track and this gets unwieldy.

This PR is a claude-coded (and will probably be hand-tweaked once I have time to thoroughly review it) implementation of the following strategy:

* z3-sys, since it always has either `z3-version.h` available or has a pre-set z3 version given to it (via e.g. `gh-release`), emits cargo cfgs identifying the version number
* z3-sys gains metadata defining which version its generated enums were built against, prompting the user with a warning to enable the bindgen feature if they are using a different version of z3.
* z3 gains a build.rs that further sets "z3 is greater or equal to version x `cfg`s" based on the reported version number from z3-sys. These `cfg`s, which are maintained in one place and auto-set, are then used to gate APIs that need them.
* The library's minimum version is now assumed to be z3 4.13.3, the version shipping with ubuntu 26.04. Older versions will give a build.rs-sourced error (more digestible than a linker error). Newer features will be supported behind cfg guards. The library will assume the standard user is using z3 5.0 (so 4.13.3 will work but will give an error due to enum mismatch between that version and 5 unless bindgen is re-run).

I have yet to play with this, and need to try it across different platforms and make sure it is actually doing what I wanted it to, but I think this would be a much cleaner version-selection story than what's there now.