### PR TITLE
refactor: Replace internal usages of z3_ctx.0 with z3_ctx.as_ptr()

### DIFF
--- a/z3/src/ast/algebraic.rs
+++ b/z3/src/ast/algebraic.rs
@@ -16,27 +16,27 @@ pub struct Algebraic {
 impl Algebraic {
     /// Check if the given AST is a value in the Z3 real algebraic number package.
     pub fn is_value(ast: &impl Ast) -> bool {
-        unsafe { Z3_algebraic_is_value(ast.get_ctx().z3_ctx.0, ast.get_z3_ast()) }
+        unsafe { Z3_algebraic_is_value(ast.get_ctx().z3_ctx.as_ptr(), ast.get_z3_ast()) }
     }
 
     /// Check if the algebraic number is positive.
     pub fn is_positive(&self) -> bool {
-        unsafe { Z3_algebraic_is_pos(self.ctx.z3_ctx.0, self.z3_ast) }
+        unsafe { Z3_algebraic_is_pos(self.ctx.z3_ctx.as_ptr(), self.z3_ast) }
     }
 
     /// Check if the algebraic number is negative.
     pub fn is_negative(&self) -> bool {
-        unsafe { Z3_algebraic_is_neg(self.ctx.z3_ctx.0, self.z3_ast) }
+        unsafe { Z3_algebraic_is_neg(self.ctx.z3_ctx.as_ptr(), self.z3_ast) }
     }
 
     /// Check if the algebraic number is zero.
     pub fn is_zero(&self) -> bool {
-        unsafe { Z3_algebraic_is_zero(self.ctx.z3_ctx.0, self.z3_ast) }
+        unsafe { Z3_algebraic_is_zero(self.ctx.z3_ctx.as_ptr(), self.z3_ast) }
     }
 
     /// Return the sign of the algebraic number: -1 if negative, 0 if zero, 1 if positive.
     pub fn sign(&self) -> i32 {
-        unsafe { Z3_algebraic_sign(self.ctx.z3_ctx.0, self.z3_ast) }
+        unsafe { Z3_algebraic_sign(self.ctx.z3_ctx.as_ptr(), self.z3_ast) }
     }
 
     /// Add two algebraic numbers.
@@ -45,7 +45,7 @@ impl Algebraic {
         unsafe {
             Algebraic::wrap(
                 &a.ctx,
-                Z3_algebraic_add(a.ctx.z3_ctx.0, a.z3_ast, b.z3_ast).unwrap(),
+                Z3_algebraic_add(a.ctx.z3_ctx.as_ptr(), a.z3_ast, b.z3_ast).unwrap(),
             )
         }
     }
@@ -56,7 +56,7 @@ impl Algebraic {
         unsafe {
             Algebraic::wrap(
                 &a.ctx,
-                Z3_algebraic_sub(a.ctx.z3_ctx.0, a.z3_ast, b.z3_ast).unwrap(),
+                Z3_algebraic_sub(a.ctx.z3_ctx.as_ptr(), a.z3_ast, b.z3_ast).unwrap(),
             )
         }
     }
@@ -67,7 +67,7 @@ impl Algebraic {
         unsafe {
             Algebraic::wrap(
                 &a.ctx,
-                Z3_algebraic_mul(a.ctx.z3_ctx.0, a.z3_ast, b.z3_ast).unwrap(),
+                Z3_algebraic_mul(a.ctx.z3_ctx.as_ptr(), a.z3_ast, b.z3_ast).unwrap(),
             )
         }
     }
@@ -78,7 +78,7 @@ impl Algebraic {
         unsafe {
             Algebraic::wrap(
                 &a.ctx,
-                Z3_algebraic_div(a.ctx.z3_ctx.0, a.z3_ast, b.z3_ast).unwrap(),
+                Z3_algebraic_div(a.ctx.z3_ctx.as_ptr(), a.z3_ast, b.z3_ast).unwrap(),
             )
         }
     }
@@ -88,7 +88,7 @@ impl Algebraic {
         unsafe {
             Algebraic::wrap(
                 &self.ctx,
-                Z3_algebraic_root(self.ctx.z3_ctx.0, self.z3_ast, k).unwrap(),
+                Z3_algebraic_root(self.ctx.z3_ctx.as_ptr(), self.z3_ast, k).unwrap(),
             )
         }
     }
@@ -98,7 +98,7 @@ impl Algebraic {
         unsafe {
             Algebraic::wrap(
                 &self.ctx,
-                Z3_algebraic_power(self.ctx.z3_ctx.0, self.z3_ast, k).unwrap(),
+                Z3_algebraic_power(self.ctx.z3_ctx.as_ptr(), self.z3_ast, k).unwrap(),
             )
         }
     }
@@ -106,19 +106,19 @@ impl Algebraic {
     /// Return true if `a < b`.
     pub fn lt(a: &Algebraic, b: &Algebraic) -> bool {
         assert_eq!(a.ctx.z3_ctx, b.ctx.z3_ctx);
-        unsafe { Z3_algebraic_lt(a.ctx.z3_ctx.0, a.z3_ast, b.z3_ast) }
+        unsafe { Z3_algebraic_lt(a.ctx.z3_ctx.as_ptr(), a.z3_ast, b.z3_ast) }
     }
 
     /// Return true if `a > b`.
     pub fn gt(a: &Algebraic, b: &Algebraic) -> bool {
         assert_eq!(a.ctx.z3_ctx, b.ctx.z3_ctx);
-        unsafe { Z3_algebraic_gt(a.ctx.z3_ctx.0, a.z3_ast, b.z3_ast) }
+        unsafe { Z3_algebraic_gt(a.ctx.z3_ctx.as_ptr(), a.z3_ast, b.z3_ast) }
     }
 
     /// Return true if `a == b` (algebraic equality).
     pub fn eq_algebraic(a: &Algebraic, b: &Algebraic) -> bool {
         assert_eq!(a.ctx.z3_ctx, b.ctx.z3_ctx);
-        unsafe { Z3_algebraic_eq(a.ctx.z3_ctx.0, a.z3_ast, b.z3_ast) }
+        unsafe { Z3_algebraic_eq(a.ctx.z3_ctx.as_ptr(), a.z3_ast, b.z3_ast) }
     }
 }
 

--- a/z3/src/ast/array.rs
+++ b/z3/src/ast/array.rs
@@ -20,7 +20,12 @@ impl Array {
         let sort = Sort::array(domain, range);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap()
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap()
             })
         }
     }
@@ -32,7 +37,7 @@ impl Array {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), p, sort.z3_sort).unwrap()
             })
         }
     }
@@ -46,7 +51,7 @@ impl Array {
         let ctx = &Context::thread_local();
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const_array(ctx.z3_ctx.0, domain.z3_sort, val.get_z3_ast()).unwrap()
+                Z3_mk_const_array(ctx.z3_ctx.as_ptr(), domain.z3_sort, val.get_z3_ast()).unwrap()
             })
         }
     }
@@ -71,7 +76,7 @@ impl Array {
         // This way we also avoid the redundant check every time this method is called.
         unsafe {
             Dynamic::wrap(&self.ctx, {
-                Z3_mk_select(self.ctx.z3_ctx.0, self.z3_ast, index.get_z3_ast()).unwrap()
+                Z3_mk_select(self.ctx.z3_ctx.as_ptr(), self.z3_ast, index.get_z3_ast()).unwrap()
             })
         }
     }
@@ -84,7 +89,7 @@ impl Array {
         unsafe {
             Dynamic::wrap(&self.ctx, {
                 Z3_mk_select_n(
-                    self.ctx.z3_ctx.0,
+                    self.ctx.z3_ctx.as_ptr(),
                     self.z3_ast,
                     idxs.len().try_into().unwrap(),
                     idxs.as_ptr() as *const Z3_ast,
@@ -108,7 +113,7 @@ impl Array {
         unsafe {
             Self::wrap(&self.ctx, {
                 Z3_mk_store(
-                    self.ctx.z3_ctx.0,
+                    self.ctx.z3_ctx.as_ptr(),
                     self.z3_ast,
                     index.get_z3_ast(),
                     value.get_z3_ast(),

--- a/z3/src/ast/bool.rs
+++ b/z3/src/ast/bool.rs
@@ -14,7 +14,12 @@ impl Bool {
         let sort = Sort::bool();
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap()
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap()
             })
         }
     }
@@ -27,7 +32,7 @@ impl Bool {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), p, sort.z3_sort).unwrap()
             })
         }
     }
@@ -38,9 +43,9 @@ impl Bool {
         unsafe {
             Self::wrap(ctx, {
                 if b {
-                    Z3_mk_true(ctx.z3_ctx.0).unwrap()
+                    Z3_mk_true(ctx.z3_ctx.as_ptr()).unwrap()
                 } else {
-                    Z3_mk_false(ctx.z3_ctx.0).unwrap()
+                    Z3_mk_false(ctx.z3_ctx.as_ptr()).unwrap()
                 }
             })
         }
@@ -49,7 +54,7 @@ impl Bool {
     /// If `self` is the Boolean value `true` or `false`, return its value. Otherwise, return [None].
     pub fn as_bool(&self) -> Option<bool> {
         unsafe {
-            match Z3_get_bool_value(self.ctx.z3_ctx.0, self.z3_ast) {
+            match Z3_get_bool_value(self.ctx.z3_ctx.as_ptr(), self.z3_ast) {
                 Z3_L_TRUE => Some(true),
                 Z3_L_FALSE => Some(false),
                 _ => None,
@@ -65,7 +70,7 @@ impl Bool {
         unsafe {
             T::wrap(&self.ctx, {
                 Z3_mk_ite(
-                    self.ctx.z3_ctx.0,
+                    self.ctx.z3_ctx.as_ptr(),
                     self.z3_ast,
                     then_expr.get_z3_ast(),
                     else_expr.get_z3_ast(),
@@ -110,7 +115,7 @@ impl Bool {
                     .map(|(boolean, coefficient)| (boolean.z3_ast, coefficient))
                     .unzip();
                 Z3_mk_pble(
-                    ctx.z3_ctx.0,
+                    ctx.z3_ctx.as_ptr(),
                     values.len() as u32,
                     values.as_ptr(),
                     coefficients.as_ptr(),
@@ -137,7 +142,7 @@ impl Bool {
                     .map(|(boolean, coefficient)| (boolean.z3_ast, coefficient))
                     .unzip();
                 Z3_mk_pbge(
-                    ctx.z3_ctx.0,
+                    ctx.z3_ctx.as_ptr(),
                     values.len() as u32,
                     values.as_ptr(),
                     coefficients.as_ptr(),
@@ -160,7 +165,7 @@ impl Bool {
                     .map(|(boolean, coefficient)| (boolean.z3_ast, coefficient))
                     .unzip();
                 Z3_mk_pbeq(
-                    ctx.z3_ctx.0,
+                    ctx.z3_ctx.as_ptr(),
                     values.len() as u32,
                     values.as_ptr(),
                     coefficients.as_ptr(),

--- a/z3/src/ast/bv.rs
+++ b/z3/src/ast/bv.rs
@@ -21,7 +21,7 @@ macro_rules! bv_overflow_check_signed {
             pub fn $f(&self, other: &BV, b: bool) -> Bool {
                 unsafe {
                     Ast::wrap(&self.ctx, {
-                        $z3fn(self.ctx.z3_ctx.0, self.z3_ast, other.z3_ast, b).unwrap()
+                        $z3fn(self.ctx.z3_ctx.as_ptr(), self.z3_ast, other.z3_ast, b).unwrap()
                     })
                 }
             }
@@ -35,7 +35,7 @@ impl BV {
         let sort = Sort::bitvector(sz);
         let ast = unsafe {
             let bv_cstring = CString::new(value).unwrap();
-            Z3_mk_numeral(ctx.z3_ctx.0, bv_cstring.as_ptr(), sort.z3_sort)?
+            Z3_mk_numeral(ctx.z3_ctx.as_ptr(), bv_cstring.as_ptr(), sort.z3_sort)?
         };
         Some(unsafe { Self::wrap(ctx, ast) })
     }
@@ -53,7 +53,8 @@ impl BV {
     /// ```
     pub fn from_bits(bits: &[bool]) -> Option<BV> {
         let ctx = &Context::thread_local();
-        let ast = unsafe { Z3_mk_bv_numeral(ctx.z3_ctx.0, bits.len() as u32, bits.as_ptr())? };
+        let ast =
+            unsafe { Z3_mk_bv_numeral(ctx.z3_ctx.as_ptr(), bits.len() as u32, bits.as_ptr())? };
         Some(unsafe { Self::wrap(ctx, ast) })
     }
 
@@ -62,7 +63,12 @@ impl BV {
         let sort = Sort::bitvector(sz);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap()
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap()
             })
         }
     }
@@ -74,7 +80,7 @@ impl BV {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), p, sort.z3_sort).unwrap()
             })
         }
     }
@@ -82,7 +88,12 @@ impl BV {
     pub fn from_i64(i: i64, sz: u32) -> BV {
         let ctx = &Context::thread_local();
         let sort = Sort::bitvector(sz);
-        unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx.0, i, sort.z3_sort).unwrap()) }
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_int64(ctx.z3_ctx.as_ptr(), i, sort.z3_sort).unwrap(),
+            )
+        }
     }
 
     pub fn from_u64(u: u64, sz: u32) -> BV {
@@ -91,7 +102,7 @@ impl BV {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_unsigned_int64(ctx.z3_ctx.0, u, sort.z3_sort).unwrap(),
+                Z3_mk_unsigned_int64(ctx.z3_ctx.as_ptr(), u, sort.z3_sort).unwrap(),
             )
         }
     }
@@ -99,7 +110,7 @@ impl BV {
     pub fn as_i64(&self) -> Option<i64> {
         unsafe {
             let mut tmp: ::std::os::raw::c_longlong = 0;
-            if Z3_get_numeral_int64(self.ctx.z3_ctx.0, self.z3_ast, &mut tmp) {
+            if Z3_get_numeral_int64(self.ctx.z3_ctx.as_ptr(), self.z3_ast, &mut tmp) {
                 Some(tmp)
             } else {
                 None
@@ -110,7 +121,7 @@ impl BV {
     pub fn as_u64(&self) -> Option<u64> {
         unsafe {
             let mut tmp: ::std::os::raw::c_ulonglong = 0;
-            if Z3_get_numeral_uint64(self.ctx.z3_ctx.0, self.z3_ast, &mut tmp) {
+            if Z3_get_numeral_uint64(self.ctx.z3_ctx.as_ptr(), self.z3_ast, &mut tmp) {
                 Some(tmp)
             } else {
                 None
@@ -142,7 +153,7 @@ impl BV {
         unsafe {
             Self::wrap(
                 &ast.ctx,
-                Z3_mk_int2bv(ast.ctx.z3_ctx.0, sz, ast.z3_ast).unwrap(),
+                Z3_mk_int2bv(ast.ctx.z3_ctx.as_ptr(), sz, ast.z3_ast).unwrap(),
             )
         }
     }
@@ -157,7 +168,7 @@ impl BV {
     /// Get the size of the bitvector (in bits)
     pub fn get_size(&self) -> u32 {
         let sort = self.get_sort();
-        unsafe { Z3_get_bv_sort_size(self.ctx.z3_ctx.0, sort.z3_sort) }
+        unsafe { Z3_get_bv_sort_size(self.ctx.z3_ctx.as_ptr(), sort.z3_sort) }
     }
 
     // Bitwise ops
@@ -274,7 +285,7 @@ impl BV {
     pub fn extract(&self, high: u32, low: u32) -> Self {
         unsafe {
             Self::wrap(&self.ctx, {
-                Z3_mk_extract(self.ctx.z3_ctx.0, high, low, self.z3_ast).unwrap()
+                Z3_mk_extract(self.ctx.z3_ctx.as_ptr(), high, low, self.z3_ast).unwrap()
             })
         }
     }
@@ -284,7 +295,7 @@ impl BV {
     pub fn sign_ext(&self, i: u32) -> Self {
         unsafe {
             Self::wrap(&self.ctx, {
-                Z3_mk_sign_ext(self.ctx.z3_ctx.0, i, self.z3_ast).unwrap()
+                Z3_mk_sign_ext(self.ctx.z3_ctx.as_ptr(), i, self.z3_ast).unwrap()
             })
         }
     }
@@ -294,7 +305,7 @@ impl BV {
     pub fn zero_ext(&self, i: u32) -> Self {
         unsafe {
             Self::wrap(&self.ctx, {
-                Z3_mk_zero_ext(self.ctx.z3_ctx.0, i, self.z3_ast).unwrap()
+                Z3_mk_zero_ext(self.ctx.z3_ctx.as_ptr(), i, self.z3_ast).unwrap()
             })
         }
     }

--- a/z3/src/ast/char.rs
+++ b/z3/src/ast/char.rs
@@ -17,7 +17,12 @@ impl Char {
         let sort = Sort::char();
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap()
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap()
             })
         }
     }
@@ -29,7 +34,7 @@ impl Char {
         unsafe {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, pp.as_ptr(), sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), pp.as_ptr(), sort.z3_sort).unwrap()
             })
         }
     }
@@ -37,7 +42,7 @@ impl Char {
     /// Creates a character literal from a Unicode code point.
     pub fn from_u32(ch: u32) -> Char {
         let ctx = &Context::thread_local();
-        unsafe { Self::wrap(ctx, Z3_mk_char(ctx.z3_ctx.0, ch).unwrap()) }
+        unsafe { Self::wrap(ctx, Z3_mk_char(ctx.z3_ctx.as_ptr(), ch).unwrap()) }
     }
 
     /// Creates a character from a `char` value.
@@ -50,7 +55,7 @@ impl Char {
         unsafe {
             Z3String::wrap(
                 &self.ctx,
-                Z3_mk_seq_unit(self.ctx.z3_ctx.0, self.z3_ast).unwrap(),
+                Z3_mk_seq_unit(self.ctx.z3_ctx.as_ptr(), self.z3_ast).unwrap(),
             )
         }
     }
@@ -74,7 +79,7 @@ impl Char {
         unsafe {
             Self::wrap(
                 bv.get_ctx(),
-                Z3_mk_char_from_bv(bv.get_ctx().z3_ctx.0, bv.get_z3_ast()).unwrap(),
+                Z3_mk_char_from_bv(bv.get_ctx().z3_ctx.as_ptr(), bv.get_z3_ast()).unwrap(),
             )
         }
     }

--- a/z3/src/ast/datatype.rs
+++ b/z3/src/ast/datatype.rs
@@ -17,7 +17,12 @@ impl Datatype {
 
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap()
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap()
             })
         }
     }
@@ -31,7 +36,7 @@ impl Datatype {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), p, sort.z3_sort).unwrap()
             })
         }
     }

--- a/z3/src/ast/dynamic.rs
+++ b/z3/src/ast/dynamic.rs
@@ -19,7 +19,12 @@ impl Dynamic {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap(),
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap(),
             )
         }
     }
@@ -30,7 +35,7 @@ impl Dynamic {
             Self::wrap(&ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), p, sort.z3_sort).unwrap()
             })
         }
     }
@@ -38,8 +43,8 @@ impl Dynamic {
     pub fn sort_kind(&self) -> SortKind {
         unsafe {
             Z3_get_sort_kind(
-                self.ctx.z3_ctx.0,
-                Z3_get_sort(self.ctx.z3_ctx.0, self.z3_ast).unwrap(),
+                self.ctx.z3_ctx.as_ptr(),
+                Z3_get_sort(self.ctx.z3_ctx.as_ptr(), self.z3_ast).unwrap(),
             )
         }
     }
@@ -80,8 +85,8 @@ impl Dynamic {
     pub fn as_char(&self) -> Option<Char> {
         unsafe {
             if Z3_is_char_sort(
-                self.ctx.z3_ctx.0,
-                Z3_get_sort(self.ctx.z3_ctx.0, self.z3_ast)?,
+                self.ctx.z3_ctx.as_ptr(),
+                Z3_get_sort(self.ctx.z3_ctx.as_ptr(), self.z3_ast)?,
             ) {
                 Some(Char::wrap(&self.ctx, self.z3_ast))
             } else {
@@ -94,8 +99,8 @@ impl Dynamic {
     pub fn as_string(&self) -> Option<ast::String> {
         unsafe {
             if Z3_is_string_sort(
-                self.ctx.z3_ctx.0,
-                Z3_get_sort(self.ctx.z3_ctx.0, self.z3_ast)?,
+                self.ctx.z3_ctx.as_ptr(),
+                Z3_get_sort(self.ctx.z3_ctx.as_ptr(), self.z3_ast)?,
             ) {
                 Some(ast::String::wrap(&self.ctx, self.z3_ast))
             } else {
@@ -126,10 +131,10 @@ impl Dynamic {
             match self.sort_kind() {
                 SortKind::Array => {
                     match Z3_get_sort_kind(
-                        self.ctx.z3_ctx.0,
+                        self.ctx.z3_ctx.as_ptr(),
                         Z3_get_array_sort_range(
-                            self.ctx.z3_ctx.0,
-                            Z3_get_sort(self.ctx.z3_ctx.0, self.z3_ast)?,
+                            self.ctx.z3_ctx.as_ptr(),
+                            Z3_get_sort(self.ctx.z3_ctx.as_ptr(), self.z3_ast)?,
                         )?,
                     ) {
                         SortKind::Bool => Some(Set::wrap(&self.ctx, self.z3_ast)),

--- a/z3/src/ast/float.rs
+++ b/z3/src/ast/float.rs
@@ -18,7 +18,7 @@ impl Float {
         let sort = Sort::float32();
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_fpa_numeral_float(ctx.z3_ctx.0, value, sort.z3_sort).unwrap()
+                Z3_mk_fpa_numeral_float(ctx.z3_ctx.as_ptr(), value, sort.z3_sort).unwrap()
             })
         }
     }
@@ -30,20 +30,25 @@ impl Float {
         let sort = Sort::double();
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_fpa_numeral_double(ctx.z3_ctx.0, value, sort.z3_sort).unwrap()
+                Z3_mk_fpa_numeral_double(ctx.z3_ctx.as_ptr(), value, sort.z3_sort).unwrap()
             })
         }
     }
 
     pub fn as_f64(&self) -> f64 {
-        unsafe { Z3_get_numeral_double(self.ctx.z3_ctx.0, self.z3_ast) }
+        unsafe { Z3_get_numeral_double(self.ctx.z3_ctx.as_ptr(), self.z3_ast) }
     }
 
     /// A NaN (Not a Number) value of the given ([`Float`]) [`Sort`].
     pub fn nan(sort: &Sort) -> Float {
         let ctx = &Context::thread_local();
         assert!(matches!(sort.kind(), SortKind::FloatingPoint));
-        unsafe { Self::wrap(ctx, Z3_mk_fpa_nan(ctx.z3_ctx.0, sort.z3_sort).unwrap()) }
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_fpa_nan(ctx.z3_ctx.as_ptr(), sort.z3_sort).unwrap(),
+            )
+        }
     }
 
     /// A single-precision [`Float`] NaN value.
@@ -98,7 +103,12 @@ impl Float {
         let sort = Sort::float(ebits, sbits);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap()
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap()
             })
         }
     }
@@ -109,7 +119,12 @@ impl Float {
         let sort = Sort::float32();
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap()
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap()
             })
         }
     }
@@ -120,7 +135,12 @@ impl Float {
         let sort = Sort::double();
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap()
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap()
             })
         }
     }
@@ -133,7 +153,7 @@ impl Float {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), p, sort.z3_sort).unwrap()
             })
         }
     }
@@ -145,7 +165,7 @@ impl Float {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), p, sort.z3_sort).unwrap()
             })
         }
     }
@@ -157,7 +177,7 @@ impl Float {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), p, sort.z3_sort).unwrap()
             })
         }
     }
@@ -211,7 +231,7 @@ impl Float {
         unsafe {
             BV::wrap(
                 &self.ctx,
-                Z3_mk_fpa_to_ieee_bv(self.ctx.z3_ctx.0, self.z3_ast).unwrap(),
+                Z3_mk_fpa_to_ieee_bv(self.ctx.z3_ctx.as_ptr(), self.z3_ast).unwrap(),
             )
         }
     }
@@ -248,7 +268,7 @@ impl Float {
         unsafe {
             Float::wrap(
                 &self.ctx,
-                Z3_mk_fpa_sqrt(self.ctx.z3_ctx.0, rm.z3_ast, self.z3_ast).unwrap(),
+                Z3_mk_fpa_sqrt(self.ctx.z3_ctx.as_ptr(), rm.z3_ast, self.z3_ast).unwrap(),
             )
         }
     }
@@ -263,7 +283,8 @@ impl Float {
         unsafe {
             Float::wrap(
                 &self.ctx,
-                Z3_mk_fpa_round_to_integral(self.ctx.z3_ctx.0, rm.z3_ast, self.z3_ast).unwrap(),
+                Z3_mk_fpa_round_to_integral(self.ctx.z3_ctx.as_ptr(), rm.z3_ast, self.z3_ast)
+                    .unwrap(),
             )
         }
     }
@@ -281,7 +302,7 @@ impl Float {
             Float::wrap(
                 &self.ctx,
                 Z3_mk_fpa_fma(
-                    self.ctx.z3_ctx.0,
+                    self.ctx.z3_ctx.as_ptr(),
                     rm.z3_ast,
                     self.z3_ast,
                     y.z3_ast,
@@ -302,7 +323,7 @@ impl Float {
         unsafe {
             BV::wrap(
                 &self.ctx,
-                Z3_mk_fpa_to_sbv(self.ctx.z3_ctx.0, rm.z3_ast, self.z3_ast, size).unwrap(),
+                Z3_mk_fpa_to_sbv(self.ctx.z3_ctx.as_ptr(), rm.z3_ast, self.z3_ast, size).unwrap(),
             )
         }
     }
@@ -312,7 +333,7 @@ impl Float {
         unsafe {
             BV::wrap(
                 &self.ctx,
-                Z3_mk_fpa_to_ubv(self.ctx.z3_ctx.0, rm.z3_ast, self.z3_ast, size).unwrap(),
+                Z3_mk_fpa_to_ubv(self.ctx.z3_ctx.as_ptr(), rm.z3_ast, self.z3_ast, size).unwrap(),
             )
         }
     }
@@ -322,7 +343,7 @@ impl Float {
         unsafe {
             crate::ast::Real::wrap(
                 &self.ctx,
-                Z3_mk_fpa_to_real(self.ctx.z3_ctx.0, self.z3_ast).unwrap(),
+                Z3_mk_fpa_to_real(self.ctx.z3_ctx.as_ptr(), self.z3_ast).unwrap(),
             )
         }
     }
@@ -334,7 +355,7 @@ impl Float {
             Float::wrap(
                 &self.ctx,
                 Z3_mk_fpa_to_fp_float(
-                    self.ctx.z3_ctx.0,
+                    self.ctx.z3_ctx.as_ptr(),
                     rm.z3_ast,
                     self.z3_ast,
                     target_sort.z3_sort,
@@ -354,7 +375,7 @@ macro_rules! impl_into_ast {
                 let ctx = a.get_ctx();
                 unsafe {
                     Float::wrap(ctx, {
-                        Z3_mk_fpa_numeral_double(ctx.z3_ctx.0, value, sort.z3_sort).unwrap()
+                        Z3_mk_fpa_numeral_double(ctx.z3_ctx.as_ptr(), value, sort.z3_sort).unwrap()
                     })
                 }
             }

--- a/z3/src/ast/int.rs
+++ b/z3/src/ast/int.rs
@@ -25,7 +25,12 @@ impl Int {
         let sort = Sort::int();
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap()
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap()
             })
         }
     }
@@ -38,7 +43,7 @@ impl Int {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), p, sort.z3_sort).unwrap()
             })
         }
     }
@@ -47,7 +52,12 @@ impl Int {
     pub fn from_i64(i: i64) -> Int {
         let ctx = &Context::thread_local();
         let sort = Sort::int();
-        unsafe { Self::wrap(ctx, Z3_mk_int64(ctx.z3_ctx.0, i, sort.z3_sort).unwrap()) }
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_int64(ctx.z3_ctx.as_ptr(), i, sort.z3_sort).unwrap(),
+            )
+        }
     }
 
     /// Create an AST node representing the integer value `u`.
@@ -57,7 +67,7 @@ impl Int {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_unsigned_int64(ctx.z3_ctx.0, u, sort.z3_sort).unwrap(),
+                Z3_mk_unsigned_int64(ctx.z3_ctx.as_ptr(), u, sort.z3_sort).unwrap(),
             )
         }
     }
@@ -65,7 +75,7 @@ impl Int {
     pub fn as_i64(&self) -> Option<i64> {
         unsafe {
             let mut tmp: ::std::os::raw::c_longlong = 0;
-            if Z3_get_numeral_int64(self.ctx.z3_ctx.0, self.z3_ast, &mut tmp) {
+            if Z3_get_numeral_int64(self.ctx.z3_ctx.as_ptr(), self.z3_ast, &mut tmp) {
                 Some(tmp)
             } else {
                 None
@@ -76,7 +86,7 @@ impl Int {
     pub fn as_u64(&self) -> Option<u64> {
         unsafe {
             let mut tmp: ::std::os::raw::c_ulonglong = 0;
-            if Z3_get_numeral_uint64(self.ctx.z3_ctx.0, self.z3_ast, &mut tmp) {
+            if Z3_get_numeral_uint64(self.ctx.z3_ctx.as_ptr(), self.z3_ast, &mut tmp) {
                 Some(tmp)
             } else {
                 None
@@ -88,7 +98,7 @@ impl Int {
         unsafe {
             Self::wrap(
                 &ast.ctx,
-                Z3_mk_real2int(ast.ctx.z3_ctx.0, ast.z3_ast).unwrap(),
+                Z3_mk_real2int(ast.ctx.z3_ctx.as_ptr(), ast.z3_ast).unwrap(),
             )
         }
     }
@@ -122,7 +132,7 @@ impl Int {
     pub fn from_bv(ast: &BV, signed: bool) -> Int {
         unsafe {
             Self::wrap(&ast.ctx, {
-                Z3_mk_bv2int(ast.ctx.z3_ctx.0, ast.z3_ast, signed).unwrap()
+                Z3_mk_bv2int(ast.ctx.z3_ctx.as_ptr(), ast.z3_ast, signed).unwrap()
             })
         }
     }
@@ -212,7 +222,7 @@ impl FromStr for Int {
         let sort = Sort::int();
         let ast = unsafe {
             let int_cstring = CString::new(value).unwrap();
-            Z3_mk_numeral(ctx.z3_ctx.0, int_cstring.as_ptr(), sort.z3_sort)
+            Z3_mk_numeral(ctx.z3_ctx.as_ptr(), int_cstring.as_ptr(), sort.z3_sort)
         }
         .ok_or(())?;
         Ok(unsafe { Int::wrap(ctx, ast) })

--- a/z3/src/ast/mod.rs
+++ b/z3/src/ast/mod.rs
@@ -61,7 +61,7 @@ macro_rules! unop {
             pub fn $f(&self) -> $retty {
                 unsafe {
                     <$retty>::wrap(&self.ctx, {
-                        $z3fn(self.ctx.z3_ctx.0, self.z3_ast).unwrap()
+                        $z3fn(self.ctx.z3_ctx.as_ptr(), self.z3_ast).unwrap()
                     })
                 }
             }
@@ -81,7 +81,7 @@ macro_rules! binop {
                 let ast = other.into_ast(self);
                 unsafe {
                     <$retty>::wrap(&self.ctx, {
-                        $z3fn(self.ctx.z3_ctx.0, self.z3_ast, ast.z3_ast).unwrap()
+                        $z3fn(self.ctx.z3_ctx.as_ptr(), self.z3_ast, ast.z3_ast).unwrap()
                     })
                 }
             }
@@ -102,7 +102,7 @@ macro_rules! trinop {
                 let b = b.into_ast(&a);
                 unsafe {
                     <$retty>::wrap(&self.ctx, {
-                        $z3fn(self.ctx.z3_ctx.0, self.z3_ast, a.z3_ast, b.z3_ast).unwrap()
+                        $z3fn(self.ctx.z3_ctx.as_ptr(), self.z3_ast, a.z3_ast, b.z3_ast).unwrap()
                     })
                 }
             }
@@ -125,7 +125,7 @@ macro_rules! varop {
                         let tmp: Vec<Self> = values.iter().cloned().map(|x| x.into()).collect();
                         let tmp2: Vec<_> = tmp.iter().map(|x| x.z3_ast).collect();
                         assert!(tmp.len() <= 0xffff_ffff);
-                        $z3fn(ctx.z3_ctx.0, tmp.len() as u32, tmp2.as_ptr()).unwrap()
+                        $z3fn(ctx.z3_ctx.as_ptr(), tmp.len() as u32, tmp2.as_ptr()).unwrap()
                     })
                 }
             }
@@ -150,7 +150,7 @@ pub trait Ast: fmt::Debug {
             ctx,
             z3_ast: unsafe {
                 debug!("new ast {:p}", ast);
-                Z3_inc_ref(ctx.z3_ctx.0, ast);
+                Z3_inc_ref(ctx.z3_ctx.as_ptr(), ast);
                 ast
             },
         }
@@ -184,7 +184,7 @@ pub trait Ast: fmt::Debug {
                     .iter()
                     .map(|nodes| nodes.borrow().get_z3_ast())
                     .collect();
-                Z3_mk_distinct(ctx.z3_ctx.0, values.len() as u32, values.as_ptr()).unwrap()
+                Z3_mk_distinct(ctx.z3_ctx.as_ptr(), values.len() as u32, values.as_ptr()).unwrap()
             })
         }
     }
@@ -194,7 +194,7 @@ pub trait Ast: fmt::Debug {
         unsafe {
             Sort::wrap(
                 self.get_ctx(),
-                Z3_get_sort(self.get_ctx().z3_ctx.0, self.get_z3_ast()).unwrap(),
+                Z3_get_sort(self.get_ctx().z3_ctx.as_ptr(), self.get_z3_ast()).unwrap(),
             )
         }
     }
@@ -208,7 +208,7 @@ pub trait Ast: fmt::Debug {
     {
         unsafe {
             Self::wrap(self.get_ctx(), {
-                Z3_simplify(self.get_ctx().z3_ctx.0, self.get_z3_ast()).unwrap()
+                Z3_simplify(self.get_ctx().z3_ctx.as_ptr(), self.get_z3_ast()).unwrap()
             })
         }
     }
@@ -240,7 +240,7 @@ pub trait Ast: fmt::Debug {
                 }
 
                 Z3_substitute(
-                    self.get_ctx().z3_ctx.0,
+                    self.get_ctx().z3_ctx.as_ptr(),
                     this_ast,
                     num_exprs,
                     froms.as_ptr(),
@@ -255,7 +255,7 @@ pub trait Ast: fmt::Debug {
     ///
     /// Leaf nodes (eg `Bool` consts) will return 0.
     fn num_children(&self) -> usize {
-        let this_ctx = self.get_ctx().z3_ctx.0;
+        let this_ctx = self.get_ctx().z3_ctx.as_ptr();
         unsafe {
             let this_app = Z3_to_app(this_ctx, self.get_z3_ast()).unwrap();
             Z3_get_app_num_args(this_ctx, this_app) as usize
@@ -270,7 +270,7 @@ pub trait Ast: fmt::Debug {
             None
         } else {
             let idx = u32::try_from(idx).unwrap();
-            let this_ctx = self.get_ctx().z3_ctx.0;
+            let this_ctx = self.get_ctx().z3_ctx.as_ptr();
             let child_ast = unsafe {
                 let this_app = Z3_to_app(this_ctx, self.get_z3_ast()).unwrap();
                 Z3_get_app_arg(this_ctx, this_app, idx).unwrap()
@@ -288,7 +288,7 @@ pub trait Ast: fmt::Debug {
     /// Return the `AstKind` for this `Ast`.
     fn kind(&self) -> AstKind {
         unsafe {
-            let z3_ctx = self.get_ctx().z3_ctx.0;
+            let z3_ctx = self.get_ctx().z3_ctx.as_ptr();
             Z3_get_ast_kind(z3_ctx, self.get_z3_ast())
         }
     }
@@ -322,9 +322,9 @@ pub trait Ast: fmt::Debug {
         } else {
             let ctx = self.get_ctx();
             let func_decl = unsafe {
-                let app =
-                    Z3_to_app(ctx.z3_ctx.0, self.get_z3_ast()).ok_or(IsNotApp::new(self.kind()))?;
-                Z3_get_app_decl(ctx.z3_ctx.0, app)
+                let app = Z3_to_app(ctx.z3_ctx.as_ptr(), self.get_z3_ast())
+                    .ok_or(IsNotApp::new(self.kind()))?;
+                Z3_get_app_decl(ctx.z3_ctx.as_ptr(), app)
             }
             .unwrap();
             Ok(unsafe { FuncDecl::wrap(ctx, func_decl) })
@@ -371,11 +371,11 @@ macro_rules! impl_ast {
                     z3_ast: {
                         debug!(
                             "new ast: id = {}, pointer = {:p}",
-                            unsafe { Z3_get_ast_id(ctx.z3_ctx.0, ast) },
+                            unsafe { Z3_get_ast_id(ctx.z3_ctx.as_ptr(), ast) },
                             ast
                         );
                         unsafe {
-                            Z3_inc_ref(ctx.z3_ctx.0, ast);
+                            Z3_inc_ref(ctx.z3_ctx.as_ptr(), ast);
                         }
                         ast
                     },
@@ -414,7 +414,7 @@ macro_rules! impl_ast {
                 assert_eq!(self.get_ctx(), other.get_ctx());
                 unsafe {
                     Z3_is_eq_ast(
-                        self.get_ctx().z3_ctx.0,
+                        self.get_ctx().z3_ctx.as_ptr(),
                         self.get_z3_ast(),
                         other.get_z3_ast(),
                     )
@@ -472,7 +472,7 @@ macro_rules! impl_ast {
                     true => Ok(unsafe {
                         Bool::wrap(self.get_ctx(), {
                             Z3_mk_eq(
-                                self.get_ctx().z3_ctx.0,
+                                self.get_ctx().z3_ctx.as_ptr(),
                                 self.get_z3_ast(),
                                 other.get_z3_ast(),
                             )
@@ -487,7 +487,7 @@ macro_rules! impl_ast {
         impl<T: IntoAst<$ast> + Clone> PartialEq<T> for $ast {
             fn eq(&self, other: &T) -> bool {
                 let other = other.clone().into_ast(self);
-                unsafe { Z3_is_eq_ast(self.ctx.z3_ctx.0, self.z3_ast, other.z3_ast) }
+                unsafe { Z3_is_eq_ast(self.ctx.z3_ctx.as_ptr(), self.z3_ast, other.z3_ast) }
             }
         }
 
@@ -503,7 +503,7 @@ macro_rules! impl_ast {
             fn clone(&self) -> Self {
                 debug!(
                     "clone ast: id = {}, pointer = {:p}",
-                    unsafe { Z3_get_ast_id(self.ctx.z3_ctx.0, self.z3_ast) },
+                    unsafe { Z3_get_ast_id(self.ctx.z3_ctx.as_ptr(), self.z3_ast) },
                     self.z3_ast
                 );
                 unsafe { Self::wrap(&self.ctx, self.z3_ast) }
@@ -514,11 +514,11 @@ macro_rules! impl_ast {
             fn drop(&mut self) {
                 debug!(
                     "drop ast: id = {}, pointer = {:p}",
-                    unsafe { Z3_get_ast_id(self.ctx.z3_ctx.0, self.z3_ast) },
+                    unsafe { Z3_get_ast_id(self.ctx.z3_ctx.as_ptr(), self.z3_ast) },
                     self.z3_ast
                 );
                 unsafe {
-                    Z3_dec_ref(self.ctx.z3_ctx.0, self.z3_ast);
+                    Z3_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_ast);
                 }
             }
         }
@@ -526,7 +526,7 @@ macro_rules! impl_ast {
         impl Hash for $ast {
             fn hash<H: Hasher>(&self, state: &mut H) {
                 unsafe {
-                    let u = Z3_get_ast_hash(self.ctx.z3_ctx.0, self.z3_ast);
+                    let u = Z3_get_ast_hash(self.ctx.z3_ctx.as_ptr(), self.z3_ast);
                     u.hash(state);
                 }
             }
@@ -534,7 +534,7 @@ macro_rules! impl_ast {
 
         impl fmt::Debug for $ast {
             fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-                let p = unsafe { Z3_ast_to_string(self.ctx.z3_ctx.0, self.z3_ast) };
+                let p = unsafe { Z3_ast_to_string(self.ctx.z3_ctx.as_ptr(), self.z3_ast) };
                 if p.is_null() {
                     return Result::Err(fmt::Error);
                 }
@@ -639,7 +639,7 @@ fn _atmost(args: &[Z3_ast], k: u32) -> Bool {
         Bool::wrap(
             ctx,
             Z3_mk_atmost(
-                ctx.z3_ctx.0,
+                ctx.z3_ctx.as_ptr(),
                 args.len().try_into().unwrap(),
                 args.as_ptr(),
                 k,
@@ -661,7 +661,7 @@ fn _atleast(args: &[Z3_ast], k: u32) -> Bool {
         Bool::wrap(
             ctx,
             Z3_mk_atleast(
-                ctx.z3_ctx.0,
+                ctx.z3_ctx.as_ptr(),
                 args.len().try_into().unwrap(),
                 args.as_ptr(),
                 k,
@@ -713,7 +713,7 @@ pub fn forall_const(bounds: &[&dyn Ast], patterns: &[&Pattern], body: &Bool) -> 
     unsafe {
         Ast::wrap(ctx, {
             Z3_mk_forall_const(
-                ctx.z3_ctx.0,
+                ctx.z3_ctx.as_ptr(),
                 0,
                 bounds.len().try_into().unwrap(),
                 bounds.as_ptr() as *const Z3_app,
@@ -769,7 +769,7 @@ pub fn exists_const(bounds: &[&dyn Ast], patterns: &[&Pattern], body: &Bool) -> 
     unsafe {
         Ast::wrap(ctx, {
             Z3_mk_exists_const(
-                ctx.z3_ctx.0,
+                ctx.z3_ctx.as_ptr(),
                 0,
                 bounds.len().try_into().unwrap(),
                 bounds.as_ptr() as *const Z3_app,
@@ -851,7 +851,7 @@ pub fn quantifier_const(
     unsafe {
         Ast::wrap(ctx, {
             Z3_mk_quantifier_const_ex(
-                ctx.z3_ctx.0,
+                ctx.z3_ctx.as_ptr(),
                 is_forall,
                 weight,
                 quantifier_id.into().as_z3_symbol(),
@@ -913,7 +913,7 @@ pub fn lambda_const(bounds: &[&dyn Ast], body: &Dynamic) -> Array {
         Ast::wrap(
             ctx,
             Z3_mk_lambda_const(
-                ctx.z3_ctx.0,
+                ctx.z3_ctx.as_ptr(),
                 bounds.len().try_into().unwrap(),
                 bounds.as_ptr() as *const Z3_app,
                 body.get_z3_ast(),

--- a/z3/src/ast/polynomial.rs
+++ b/z3/src/ast/polynomial.rs
@@ -34,7 +34,7 @@ impl Polynomial {
             AstVector::wrap(
                 ctx,
                 Z3_polynomial_subresultants(
-                    ctx.z3_ctx.0,
+                    ctx.z3_ctx.as_ptr(),
                     p.get_z3_ast(),
                     q.get_z3_ast(),
                     x.get_z3_ast(),

--- a/z3/src/ast/real.rs
+++ b/z3/src/ast/real.rs
@@ -29,7 +29,7 @@ impl Real {
         let sort = Sort::real();
         let ast = unsafe {
             let fraction_cstring = CString::new(format!("{num:} / {den:}")).unwrap();
-            Z3_mk_numeral(ctx.z3_ctx.0, fraction_cstring.as_ptr(), sort.z3_sort)?
+            Z3_mk_numeral(ctx.z3_ctx.as_ptr(), fraction_cstring.as_ptr(), sort.z3_sort)?
         };
         Some(unsafe { Real::wrap(ctx, ast) })
     }
@@ -40,7 +40,12 @@ impl Real {
         let sort = Sort::real();
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap()
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap()
             })
         }
     }
@@ -52,7 +57,7 @@ impl Real {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), p, sort.z3_sort).unwrap()
             })
         }
     }
@@ -69,7 +74,7 @@ impl Real {
                 // Use the int64 fraction API, not Z3_mk_real (which takes C `int`):
                 // casting the i64 args to c_int silently truncates any value outside
                 // the i32 range (e.g. 634909090909091/100000000000 wrapped to garbage).
-                Z3_mk_real_int64(ctx.z3_ctx.0, num, den).unwrap()
+                Z3_mk_real_int64(ctx.z3_ctx.as_ptr(), num, den).unwrap()
             })
         }
     }
@@ -83,7 +88,7 @@ impl Real {
         unsafe {
             let mut num: i64 = 0;
             let mut den: i64 = 0;
-            if Z3_get_numeral_small(self.ctx.z3_ctx.0, self.z3_ast, &mut num, &mut den) {
+            if Z3_get_numeral_small(self.ctx.z3_ctx.as_ptr(), self.z3_ast, &mut num, &mut den) {
                 Some((num, den))
             } else {
                 None
@@ -94,7 +99,7 @@ impl Real {
     pub fn approx(&self, precision: usize) -> ::std::string::String {
         let s = unsafe {
             CStr::from_ptr(Z3_get_numeral_decimal_string(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_ast,
                 precision as _,
             ))
@@ -111,7 +116,7 @@ impl Real {
         unsafe {
             Self::wrap(
                 &ast.ctx,
-                Z3_mk_int2real(ast.ctx.z3_ctx.0, ast.z3_ast).unwrap(),
+                Z3_mk_int2real(ast.ctx.z3_ctx.as_ptr(), ast.z3_ast).unwrap(),
             )
         }
     }

--- a/z3/src/ast/regexp.rs
+++ b/z3/src/ast/regexp.rs
@@ -36,8 +36,8 @@ impl Regexp {
             Self::wrap(ctx, {
                 let c_str = CString::new(s).unwrap();
                 Z3_mk_seq_to_re(
-                    ctx.z3_ctx.0,
-                    Z3_mk_string(ctx.z3_ctx.0, c_str.as_ptr()).unwrap(),
+                    ctx.z3_ctx.as_ptr(),
+                    Z3_mk_string(ctx.z3_ctx.as_ptr(), c_str.as_ptr()).unwrap(),
                 )
                 .unwrap()
             })
@@ -52,14 +52,14 @@ impl Regexp {
             Self::wrap(ctx, {
                 let lo_cs = CString::new(lo.to_string()).unwrap();
                 let hi_cs = CString::new(hi.to_string()).unwrap();
-                let lo_z3s = Z3_mk_string(ctx.z3_ctx.0, lo_cs.as_ptr()).unwrap();
-                Z3_inc_ref(ctx.z3_ctx.0, lo_z3s);
-                let hi_z3s = Z3_mk_string(ctx.z3_ctx.0, hi_cs.as_ptr()).unwrap();
-                Z3_inc_ref(ctx.z3_ctx.0, hi_z3s);
+                let lo_z3s = Z3_mk_string(ctx.z3_ctx.as_ptr(), lo_cs.as_ptr()).unwrap();
+                Z3_inc_ref(ctx.z3_ctx.as_ptr(), lo_z3s);
+                let hi_z3s = Z3_mk_string(ctx.z3_ctx.as_ptr(), hi_cs.as_ptr()).unwrap();
+                Z3_inc_ref(ctx.z3_ctx.as_ptr(), hi_z3s);
 
-                let ret = Z3_mk_re_range(ctx.z3_ctx.0, lo_z3s, hi_z3s);
-                Z3_dec_ref(ctx.z3_ctx.0, lo_z3s);
-                Z3_dec_ref(ctx.z3_ctx.0, hi_z3s);
+                let ret = Z3_mk_re_range(ctx.z3_ctx.as_ptr(), lo_z3s, hi_z3s);
+                Z3_dec_ref(ctx.z3_ctx.as_ptr(), lo_z3s);
+                Z3_dec_ref(ctx.z3_ctx.as_ptr(), hi_z3s);
                 ret.unwrap()
             })
         }
@@ -69,7 +69,7 @@ impl Regexp {
     pub fn r#loop(&self, lo: u32, hi: u32) -> Self {
         unsafe {
             Self::wrap(&self.ctx, {
-                Z3_mk_re_loop(self.ctx.z3_ctx.0, self.z3_ast, lo, hi).unwrap()
+                Z3_mk_re_loop(self.ctx.z3_ctx.as_ptr(), self.z3_ast, lo, hi).unwrap()
             })
         }
     }
@@ -79,7 +79,7 @@ impl Regexp {
     pub fn power(&self, n: u32) -> Self {
         unsafe {
             Self::wrap(&self.ctx, {
-                Z3_mk_re_power(self.ctx.z3_ctx.0, self.z3_ast, n).unwrap()
+                Z3_mk_re_power(self.ctx.z3_ctx.as_ptr(), self.z3_ast, n).unwrap()
             })
         }
     }
@@ -90,8 +90,12 @@ impl Regexp {
         unsafe {
             Self::wrap(ctx, {
                 Z3_mk_re_full(
-                    ctx.z3_ctx.0,
-                    Z3_mk_re_sort(ctx.z3_ctx.0, Z3_mk_string_sort(ctx.z3_ctx.0).unwrap()).unwrap(),
+                    ctx.z3_ctx.as_ptr(),
+                    Z3_mk_re_sort(
+                        ctx.z3_ctx.as_ptr(),
+                        Z3_mk_string_sort(ctx.z3_ctx.as_ptr()).unwrap(),
+                    )
+                    .unwrap(),
                 )
                 .unwrap()
             })
@@ -104,8 +108,12 @@ impl Regexp {
         unsafe {
             Self::wrap(ctx, {
                 Z3_mk_re_allchar(
-                    ctx.z3_ctx.0,
-                    Z3_mk_re_sort(ctx.z3_ctx.0, Z3_mk_string_sort(ctx.z3_ctx.0).unwrap()).unwrap(),
+                    ctx.z3_ctx.as_ptr(),
+                    Z3_mk_re_sort(
+                        ctx.z3_ctx.as_ptr(),
+                        Z3_mk_string_sort(ctx.z3_ctx.as_ptr()).unwrap(),
+                    )
+                    .unwrap(),
                 )
                 .unwrap()
             })
@@ -118,8 +126,12 @@ impl Regexp {
         unsafe {
             Self::wrap(ctx, {
                 Z3_mk_re_empty(
-                    ctx.z3_ctx.0,
-                    Z3_mk_re_sort(ctx.z3_ctx.0, Z3_mk_string_sort(ctx.z3_ctx.0).unwrap()).unwrap(),
+                    ctx.z3_ctx.as_ptr(),
+                    Z3_mk_re_sort(
+                        ctx.z3_ctx.as_ptr(),
+                        Z3_mk_string_sort(ctx.z3_ctx.as_ptr()).unwrap(),
+                    )
+                    .unwrap(),
                 )
                 .unwrap()
             })

--- a/z3/src/ast/rounding_mode.rs
+++ b/z3/src/ast/rounding_mode.rs
@@ -11,19 +11,34 @@ impl RoundingMode {
     /// Create a numeral of [`RoundingMode`] sort which represents the `TowardZero` rounding mode.
     pub fn round_towards_zero() -> RoundingMode {
         let ctx = &Context::thread_local();
-        unsafe { Self::wrap(ctx, Z3_mk_fpa_round_toward_zero(ctx.z3_ctx.0).unwrap()) }
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_fpa_round_toward_zero(ctx.z3_ctx.as_ptr()).unwrap(),
+            )
+        }
     }
 
     /// Create a numeral of [`RoundingMode`] sort which represents the `TowardNegative` rounding mode.
     pub fn round_towards_negative() -> RoundingMode {
         let ctx = &Context::thread_local();
-        unsafe { Self::wrap(ctx, Z3_mk_fpa_round_toward_negative(ctx.z3_ctx.0).unwrap()) }
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_fpa_round_toward_negative(ctx.z3_ctx.as_ptr()).unwrap(),
+            )
+        }
     }
 
     /// Create a numeral of [`RoundingMode`] sort which represents the `TowardPositive` rounding mode.
     pub fn round_towards_positive() -> RoundingMode {
         let ctx = &Context::thread_local();
-        unsafe { Self::wrap(ctx, Z3_mk_fpa_round_toward_positive(ctx.z3_ctx.0).unwrap()) }
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_fpa_round_toward_positive(ctx.z3_ctx.as_ptr()).unwrap(),
+            )
+        }
     }
 
     /// Create a numeral of [`RoundingMode`] sort which represents the `NearestTiesToAway` rounding mode.
@@ -32,7 +47,7 @@ impl RoundingMode {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_fpa_round_nearest_ties_to_away(ctx.z3_ctx.0).unwrap(),
+                Z3_mk_fpa_round_nearest_ties_to_away(ctx.z3_ctx.as_ptr()).unwrap(),
             )
         }
     }
@@ -43,7 +58,7 @@ impl RoundingMode {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_fpa_round_nearest_ties_to_even(ctx.z3_ctx.0).unwrap(),
+                Z3_mk_fpa_round_nearest_ties_to_even(ctx.z3_ctx.as_ptr()).unwrap(),
             )
         }
     }

--- a/z3/src/ast/seq.rs
+++ b/z3/src/ast/seq.rs
@@ -15,7 +15,12 @@ impl Seq {
         let sort = Sort::seq(eltype);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap()
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap()
             })
         }
     }
@@ -27,7 +32,7 @@ impl Seq {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), p, sort.z3_sort).unwrap()
             })
         }
     }
@@ -48,13 +53,23 @@ impl Seq {
     pub fn empty(eltype: &Sort) -> Self {
         let ctx = &Context::thread_local();
         let sort = Sort::seq(eltype);
-        unsafe { Self::wrap(ctx, Z3_mk_seq_empty(ctx.z3_ctx.0, sort.z3_sort).unwrap()) }
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_seq_empty(ctx.z3_ctx.as_ptr(), sort.z3_sort).unwrap(),
+            )
+        }
     }
 
     /// Create a unit sequence of `a`.
     pub fn unit<A: Ast>(a: &A) -> Self {
         let ctx = &Context::thread_local();
-        unsafe { Self::wrap(ctx, Z3_mk_seq_unit(ctx.z3_ctx.0, a.get_z3_ast()).unwrap()) }
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_seq_unit(ctx.z3_ctx.as_ptr(), a.get_z3_ast()).unwrap(),
+            )
+        }
     }
 
     /// Retrieve the unit sequence positioned at position `index`.
@@ -63,7 +78,7 @@ impl Seq {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_mk_seq_at(self.ctx.z3_ctx.0, self.z3_ast, index.z3_ast).unwrap(),
+                Z3_mk_seq_at(self.ctx.z3_ctx.as_ptr(), self.z3_ast, index.z3_ast).unwrap(),
             )
         }
     }
@@ -89,7 +104,7 @@ impl Seq {
         unsafe {
             Dynamic::wrap(
                 &self.ctx,
-                Z3_mk_seq_nth(self.ctx.z3_ctx.0, self.z3_ast, index.z3_ast).unwrap(),
+                Z3_mk_seq_nth(self.ctx.z3_ctx.as_ptr(), self.z3_ast, index.z3_ast).unwrap(),
             )
         }
     }
@@ -98,7 +113,7 @@ impl Seq {
         unsafe {
             Int::wrap(
                 &self.ctx,
-                Z3_mk_seq_length(self.ctx.z3_ctx.0, self.z3_ast).unwrap(),
+                Z3_mk_seq_length(self.ctx.z3_ctx.as_ptr(), self.z3_ast).unwrap(),
             )
         }
     }
@@ -121,7 +136,8 @@ impl Seq {
         unsafe {
             Bool::wrap(
                 &self.ctx,
-                Z3_mk_seq_contains(self.ctx.z3_ctx.0, self.z3_ast, containee.z3_ast).unwrap(),
+                Z3_mk_seq_contains(self.ctx.z3_ctx.as_ptr(), self.z3_ast, containee.z3_ast)
+                    .unwrap(),
             )
         }
     }

--- a/z3/src/ast/set.rs
+++ b/z3/src/ast/set.rs
@@ -15,7 +15,12 @@ impl Set {
         let sort = Sort::set(eltype);
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap()
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap()
             })
         }
     }
@@ -27,7 +32,7 @@ impl Set {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), p, sort.z3_sort).unwrap()
             })
         }
     }
@@ -35,7 +40,12 @@ impl Set {
     /// Creates a set that maps the domain to false by default
     pub fn empty(domain: &Sort) -> Set {
         let ctx = &Context::thread_local();
-        unsafe { Self::wrap(ctx, Z3_mk_empty_set(ctx.z3_ctx.0, domain.z3_sort).unwrap()) }
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_empty_set(ctx.z3_ctx.as_ptr(), domain.z3_sort).unwrap(),
+            )
+        }
     }
 
     /// Add an element to the set.
@@ -49,7 +59,7 @@ impl Set {
     {
         unsafe {
             Self::wrap(&self.ctx, {
-                Z3_mk_set_add(self.ctx.z3_ctx.0, self.z3_ast, element.get_z3_ast()).unwrap()
+                Z3_mk_set_add(self.ctx.z3_ctx.as_ptr(), self.z3_ast, element.get_z3_ast()).unwrap()
             })
         }
     }
@@ -65,7 +75,7 @@ impl Set {
     {
         unsafe {
             Self::wrap(&self.ctx, {
-                Z3_mk_set_del(self.ctx.z3_ctx.0, self.z3_ast, element.get_z3_ast()).unwrap()
+                Z3_mk_set_del(self.ctx.z3_ctx.as_ptr(), self.z3_ast, element.get_z3_ast()).unwrap()
             })
         }
     }
@@ -81,7 +91,8 @@ impl Set {
     {
         unsafe {
             Bool::wrap(&self.ctx, {
-                Z3_mk_set_member(self.ctx.z3_ctx.0, element.get_z3_ast(), self.z3_ast).unwrap()
+                Z3_mk_set_member(self.ctx.z3_ctx.as_ptr(), element.get_z3_ast(), self.z3_ast)
+                    .unwrap()
             })
         }
     }

--- a/z3/src/ast/string.rs
+++ b/z3/src/ast/string.rs
@@ -18,7 +18,12 @@ impl String {
         let sort = Sort::string();
         unsafe {
             Self::wrap(ctx, {
-                Z3_mk_const(ctx.z3_ctx.0, name.into().as_z3_symbol(), sort.z3_sort).unwrap()
+                Z3_mk_const(
+                    ctx.z3_ctx.as_ptr(),
+                    name.into().as_z3_symbol(),
+                    sort.z3_sort,
+                )
+                .unwrap()
             })
         }
     }
@@ -31,7 +36,7 @@ impl String {
             Self::wrap(ctx, {
                 let pp = CString::new(prefix).unwrap();
                 let p = pp.as_ptr();
-                Z3_mk_fresh_const(ctx.z3_ctx.0, p, sort.z3_sort).unwrap()
+                Z3_mk_fresh_const(ctx.z3_ctx.as_ptr(), p, sort.z3_sort).unwrap()
             })
         }
     }
@@ -45,7 +50,7 @@ impl String {
     /// `z3::ast::String::from_str(s).unwrap().as_string()` returns a
     /// `String` equal to the original value.
     pub fn as_string(&self) -> Option<std::string::String> {
-        let z3_ctx = self.get_ctx().z3_ctx.0;
+        let z3_ctx = self.get_ctx().z3_ctx.as_ptr();
         unsafe {
             let bytes = Z3_get_string(z3_ctx, self.get_z3_ast());
             if bytes.is_null() {
@@ -77,7 +82,7 @@ impl String {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_mk_seq_at(self.ctx.z3_ctx.0, self.z3_ast, index.z3_ast).unwrap(),
+                Z3_mk_seq_at(self.ctx.z3_ctx.as_ptr(), self.z3_ast, index.z3_ast).unwrap(),
             )
         }
     }
@@ -120,8 +125,13 @@ impl String {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_mk_seq_extract(self.ctx.z3_ctx.0, self.z3_ast, offset.z3_ast, length.z3_ast)
-                    .unwrap(),
+                Z3_mk_seq_extract(
+                    self.ctx.z3_ctx.as_ptr(),
+                    self.z3_ast,
+                    offset.z3_ast,
+                    length.z3_ast,
+                )
+                .unwrap(),
             )
         }
     }
@@ -132,7 +142,12 @@ impl String {
         unsafe {
             Bool::wrap(
                 &self.ctx,
-                Z3_mk_seq_in_re(self.ctx.z3_ctx.0, self.get_z3_ast(), regex.get_z3_ast()).unwrap(),
+                Z3_mk_seq_in_re(
+                    self.ctx.z3_ctx.as_ptr(),
+                    self.get_z3_ast(),
+                    regex.get_z3_ast(),
+                )
+                .unwrap(),
             )
         }
     }
@@ -214,7 +229,7 @@ impl FromStr for String {
         let string = CString::new(string)?;
         Ok(unsafe {
             Self::wrap(ctx, {
-                Z3_mk_string(ctx.z3_ctx.0, string.as_c_str().as_ptr()).unwrap()
+                Z3_mk_string(ctx.z3_ctx.as_ptr(), string.as_c_str().as_ptr()).unwrap()
             })
         })
     }

--- a/z3/src/ast_vector.rs
+++ b/z3/src/ast_vector.rs
@@ -26,7 +26,7 @@ pub struct AstVector {
 impl Drop for AstVector {
     fn drop(&mut self) {
         unsafe {
-            Z3_ast_vector_dec_ref(self.ctx.z3_ctx.0, self.z3_ast_vector);
+            Z3_ast_vector_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_ast_vector);
         }
     }
 }
@@ -36,8 +36,8 @@ impl AstVector {
     pub fn new() -> AstVector {
         let ctx = Context::thread_local();
         unsafe {
-            let av = Z3_mk_ast_vector(ctx.z3_ctx.0).unwrap();
-            Z3_ast_vector_inc_ref(ctx.z3_ctx.0, av);
+            let av = Z3_mk_ast_vector(ctx.z3_ctx.as_ptr()).unwrap();
+            Z3_ast_vector_inc_ref(ctx.z3_ctx.as_ptr(), av);
             AstVector {
                 ctx: ctx.clone(),
                 z3_ast_vector: av,
@@ -48,7 +48,7 @@ impl AstVector {
     /// Wrap an existing Z3 AST vector.
     pub(crate) unsafe fn wrap(ctx: &Context, z3_ast_vector: Z3_ast_vector) -> AstVector {
         unsafe {
-            Z3_ast_vector_inc_ref(ctx.z3_ctx.0, z3_ast_vector);
+            Z3_ast_vector_inc_ref(ctx.z3_ctx.as_ptr(), z3_ast_vector);
         }
         AstVector {
             ctx: ctx.clone(),
@@ -58,7 +58,7 @@ impl AstVector {
 
     /// Get the number of elements in the vector.
     pub fn len(&self) -> usize {
-        unsafe { Z3_ast_vector_size(self.ctx.z3_ctx.0, self.z3_ast_vector) as usize }
+        unsafe { Z3_ast_vector_size(self.ctx.z3_ctx.as_ptr(), self.z3_ast_vector) as usize }
     }
 
     /// Check if the vector is empty.
@@ -76,7 +76,8 @@ impl AstVector {
         unsafe {
             Dynamic::wrap(
                 &self.ctx,
-                Z3_ast_vector_get(self.ctx.z3_ctx.0, self.z3_ast_vector, index as u32).unwrap(),
+                Z3_ast_vector_get(self.ctx.z3_ctx.as_ptr(), self.z3_ast_vector, index as u32)
+                    .unwrap(),
             )
         }
     }
@@ -90,7 +91,7 @@ impl AstVector {
         assert!(index < self.len(), "Index {index} out of bounds");
         unsafe {
             Z3_ast_vector_set(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_ast_vector,
                 index as u32,
                 ast.get_z3_ast(),
@@ -101,7 +102,11 @@ impl AstVector {
     /// Push an element to the end of the vector.
     pub fn push(&self, ast: &impl Ast) {
         unsafe {
-            Z3_ast_vector_push(self.ctx.z3_ctx.0, self.z3_ast_vector, ast.get_z3_ast());
+            Z3_ast_vector_push(
+                self.ctx.z3_ctx.as_ptr(),
+                self.z3_ast_vector,
+                ast.get_z3_ast(),
+            );
         }
     }
 
@@ -110,7 +115,11 @@ impl AstVector {
     /// New elements (if any) are uninitialized.
     pub fn resize(&self, new_size: usize) {
         unsafe {
-            Z3_ast_vector_resize(self.ctx.z3_ctx.0, self.z3_ast_vector, new_size as u32);
+            Z3_ast_vector_resize(
+                self.ctx.z3_ctx.as_ptr(),
+                self.z3_ast_vector,
+                new_size as u32,
+            );
         }
     }
 
@@ -124,8 +133,12 @@ impl AstVector {
         unsafe {
             AstVector::wrap(
                 target_ctx,
-                Z3_ast_vector_translate(self.ctx.z3_ctx.0, self.z3_ast_vector, target_ctx.z3_ctx.0)
-                    .unwrap(),
+                Z3_ast_vector_translate(
+                    self.ctx.z3_ctx.as_ptr(),
+                    self.z3_ast_vector,
+                    target_ctx.z3_ctx.as_ptr(),
+                )
+                .unwrap(),
             )
         }
     }
@@ -160,7 +173,7 @@ impl Default for AstVector {
 impl fmt::Display for AstVector {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let s = unsafe {
-            let raw = Z3_ast_vector_to_string(self.ctx.z3_ctx.0, self.z3_ast_vector);
+            let raw = Z3_ast_vector_to_string(self.ctx.z3_ctx.as_ptr(), self.z3_ast_vector);
             std::ffi::CStr::from_ptr(raw).to_string_lossy().into_owned()
         };
         write!(f, "{s}")

--- a/z3/src/context.rs
+++ b/z3/src/context.rs
@@ -12,6 +12,12 @@ use crate::{Config, ContextHandle};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ContextInternal(pub(crate) Z3_context);
 
+impl ContextInternal {
+    pub(crate) fn as_ptr(&self) -> Z3_context {
+        self.0
+    }
+}
+
 impl Drop for ContextInternal {
     fn drop(&mut self) {
         unsafe { Z3_del_context(self.0) };
@@ -122,7 +128,7 @@ impl Context {
     }
 
     pub fn get_z3_context(&self) -> Z3_context {
-        self.z3_ctx.0
+        self.z3_ctx.as_ptr()
     }
 
     /// Interrupt a solver performing a satisfiability test, a tactic processing a goal, or simplify functions.
@@ -148,7 +154,7 @@ impl Context {
     pub fn update_param_value(&mut self, k: &str, v: &str) {
         let ks = CString::new(k).unwrap();
         let vs = CString::new(v).unwrap();
-        unsafe { Z3_update_param_value(self.z3_ctx.0, ks.as_ptr(), vs.as_ptr()) };
+        unsafe { Z3_update_param_value(self.z3_ctx.as_ptr(), ks.as_ptr(), vs.as_ptr()) };
     }
 
     /// Update a global parameter.
@@ -167,7 +173,7 @@ impl ContextHandle<'_> {
     /// Interrupt a solver performing a satisfiability test, a tactic processing a goal, or simplify functions.
     pub fn interrupt(&self) {
         unsafe {
-            Z3_interrupt(self.ctx.z3_ctx.0);
+            Z3_interrupt(self.ctx.z3_ctx.as_ptr());
         }
     }
 }

--- a/z3/src/datatype_builder/constructor.rs
+++ b/z3/src/datatype_builder/constructor.rs
@@ -74,7 +74,7 @@ impl Constructor {
 
         let z3_constructor = unsafe {
             Z3_mk_constructor(
-                ctx.z3_ctx.0,
+                ctx.z3_ctx.as_ptr(),
                 cname.as_z3_symbol(),
                 rname.as_z3_symbol(),
                 num_fs.try_into().unwrap(),
@@ -97,7 +97,7 @@ impl Constructor {
 impl Drop for Constructor {
     fn drop(&mut self) {
         unsafe {
-            Z3_del_constructor(self.ctx.z3_ctx.0, self.z3_constructor);
+            Z3_del_constructor(self.ctx.z3_ctx.as_ptr(), self.z3_constructor);
         }
     }
 }
@@ -128,7 +128,7 @@ impl ConstructorList {
 
         let z3_constructor_list = unsafe {
             Z3_mk_constructor_list(
-                ctx.z3_ctx.0,
+                ctx.z3_ctx.as_ptr(),
                 num_cs.try_into().unwrap(),
                 cs_handles.as_mut_ptr(),
             )
@@ -147,7 +147,7 @@ impl ConstructorList {
 impl Drop for ConstructorList {
     fn drop(&mut self) {
         unsafe {
-            Z3_del_constructor_list(self.ctx.z3_ctx.0, self.z3_constructor_list);
+            Z3_del_constructor_list(self.ctx.z3_ctx.as_ptr(), self.z3_constructor_list);
         }
     }
 }

--- a/z3/src/datatype_builder/mod.rs
+++ b/z3/src/datatype_builder/mod.rs
@@ -82,7 +82,7 @@ fn build_datatype_sort(
 
         let raw_constructor = unsafe {
             Z3_get_datatype_sort_constructor(
-                ctx.z3_ctx.0,
+                ctx.z3_ctx.as_ptr(),
                 sort.get_z3_sort(),
                 j.try_into().unwrap(),
             )
@@ -91,8 +91,12 @@ fn build_datatype_sort(
         let constructor: FuncDecl = unsafe { FuncDecl::wrap(ctx, raw_constructor) };
 
         let tester_func = unsafe {
-            Z3_get_datatype_sort_recognizer(ctx.z3_ctx.0, sort.get_z3_sort(), j.try_into().unwrap())
-                .unwrap()
+            Z3_get_datatype_sort_recognizer(
+                ctx.z3_ctx.as_ptr(),
+                sort.get_z3_sort(),
+                j.try_into().unwrap(),
+            )
+            .unwrap()
         };
         let tester = unsafe { FuncDecl::wrap(ctx, tester_func) };
 
@@ -100,7 +104,7 @@ fn build_datatype_sort(
         for k in 0..num_fs {
             let accessor_func = unsafe {
                 Z3_get_datatype_sort_constructor_accessor(
-                    ctx.z3_ctx.0,
+                    ctx.z3_ctx.as_ptr(),
                     sort.get_z3_sort(),
                     j.try_into().unwrap(),
                     k.try_into().unwrap(),
@@ -187,7 +191,7 @@ pub fn create_datatypes(datatype_builders: Vec<DatatypeBuilder>) -> Vec<Datatype
 
     unsafe {
         Z3_mk_datatypes(
-            ctx.z3_ctx.0,
+            ctx.z3_ctx.as_ptr(),
             num.try_into().unwrap(),
             names.as_ptr(),
             raw_sorts.as_mut_ptr(),

--- a/z3/src/fixedpoint.rs
+++ b/z3/src/fixedpoint.rs
@@ -7,7 +7,7 @@ use z3_sys::*;
 impl Drop for Fixedpoint {
     fn drop(&mut self) {
         unsafe {
-            Z3_fixedpoint_dec_ref(self.ctx.z3_ctx.0, self.z3_fp);
+            Z3_fixedpoint_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_fp);
         }
     }
 }
@@ -17,8 +17,8 @@ impl Fixedpoint {
     pub fn new() -> Fixedpoint {
         let ctx = Context::thread_local();
         unsafe {
-            let fp = Z3_mk_fixedpoint(ctx.z3_ctx.0).unwrap();
-            Z3_fixedpoint_inc_ref(ctx.z3_ctx.0, fp);
+            let fp = Z3_mk_fixedpoint(ctx.z3_ctx.as_ptr()).unwrap();
+            Z3_fixedpoint_inc_ref(ctx.z3_ctx.as_ptr(), fp);
             Fixedpoint {
                 ctx: ctx.clone(),
                 z3_fp: fp,
@@ -42,10 +42,15 @@ impl Fixedpoint {
     pub fn add_rule(&self, rule: &impl Ast, name: Option<&str>) {
         let name_sym = name.map(|name| {
             let cname = CString::new(name).unwrap();
-            unsafe { Z3_mk_string_symbol(self.ctx.z3_ctx.0, cname.as_ptr()).unwrap() }
+            unsafe { Z3_mk_string_symbol(self.ctx.z3_ctx.as_ptr(), cname.as_ptr()).unwrap() }
         });
         unsafe {
-            Z3_fixedpoint_add_rule(self.ctx.z3_ctx.0, self.z3_fp, rule.get_z3_ast(), name_sym);
+            Z3_fixedpoint_add_rule(
+                self.ctx.z3_ctx.as_ptr(),
+                self.z3_fp,
+                rule.get_z3_ast(),
+                name_sym,
+            );
         }
     }
 
@@ -54,7 +59,7 @@ impl Fixedpoint {
         let mut args: Vec<u32> = args.to_vec();
         unsafe {
             Z3_fixedpoint_add_fact(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_fp,
                 pred.z3_func_decl,
                 args.len() as u32,
@@ -66,7 +71,7 @@ impl Fixedpoint {
     /// Assert a formula in the fixedpoint context.
     pub fn assert(&self, axiom: &impl Ast) {
         unsafe {
-            Z3_fixedpoint_assert(self.ctx.z3_ctx.0, self.z3_fp, axiom.get_z3_ast());
+            Z3_fixedpoint_assert(self.ctx.z3_ctx.as_ptr(), self.z3_fp, axiom.get_z3_ast());
         }
     }
 
@@ -75,7 +80,7 @@ impl Fixedpoint {
     /// Returns the result of the query (satisfiable, unsatisfiable, or unknown).
     pub fn query(&self, query: &impl Ast) -> SatResult {
         unsafe {
-            match Z3_fixedpoint_query(self.ctx.z3_ctx.0, self.z3_fp, query.get_z3_ast()) {
+            match Z3_fixedpoint_query(self.ctx.z3_ctx.as_ptr(), self.z3_fp, query.get_z3_ast()) {
                 Z3_L_TRUE => SatResult::Sat,
                 Z3_L_FALSE => SatResult::Unsat,
                 _ => SatResult::Unknown,
@@ -88,7 +93,7 @@ impl Fixedpoint {
         let decls: Vec<Z3_func_decl> = relations.iter().map(|r| r.z3_func_decl).collect();
         unsafe {
             match Z3_fixedpoint_query_relations(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_fp,
                 decls.len() as u32,
                 decls.as_ptr(),
@@ -104,7 +109,7 @@ impl Fixedpoint {
     /// This provides the concrete values that make the query satisfiable.
     pub fn get_answer(&self) -> Option<Bool> {
         unsafe {
-            let answer = Z3_fixedpoint_get_answer(self.ctx.z3_ctx.0, self.z3_fp);
+            let answer = Z3_fixedpoint_get_answer(self.ctx.z3_ctx.as_ptr(), self.z3_fp);
             answer.map(|answer| Bool::wrap(&self.ctx, answer))
         }
     }
@@ -112,7 +117,7 @@ impl Fixedpoint {
     /// Get the reason (core) for unsatisfiability after an unsuccessful query.
     pub fn get_reason_unknown(&self) -> String {
         unsafe {
-            let reason = Z3_fixedpoint_get_reason_unknown(self.ctx.z3_ctx.0, self.z3_fp);
+            let reason = Z3_fixedpoint_get_reason_unknown(self.ctx.z3_ctx.as_ptr(), self.z3_fp);
             std::ffi::CStr::from_ptr(reason)
                 .to_string_lossy()
                 .into_owned()
@@ -123,21 +128,28 @@ impl Fixedpoint {
     pub fn update_rule(&self, rule: &impl Ast, name: &str) {
         unsafe {
             let cname = CString::new(name).unwrap();
-            let name_sym = Z3_mk_string_symbol(self.ctx.z3_ctx.0, cname.as_ptr()).unwrap();
-            Z3_fixedpoint_update_rule(self.ctx.z3_ctx.0, self.z3_fp, rule.get_z3_ast(), name_sym);
+            let name_sym = Z3_mk_string_symbol(self.ctx.z3_ctx.as_ptr(), cname.as_ptr()).unwrap();
+            Z3_fixedpoint_update_rule(
+                self.ctx.z3_ctx.as_ptr(),
+                self.z3_fp,
+                rule.get_z3_ast(),
+                name_sym,
+            );
         }
     }
 
     /// Get the number of levels explored during the last query.
     pub fn get_num_levels(&self, pred: &FuncDecl) -> u32 {
-        unsafe { Z3_fixedpoint_get_num_levels(self.ctx.z3_ctx.0, self.z3_fp, pred.z3_func_decl) }
+        unsafe {
+            Z3_fixedpoint_get_num_levels(self.ctx.z3_ctx.as_ptr(), self.z3_fp, pred.z3_func_decl)
+        }
     }
 
     /// Get the cover (approximation) at a given level.
     pub fn get_cover_delta(&self, level: i32, predicate: &FuncDecl) -> Option<Bool> {
         unsafe {
             Z3_fixedpoint_get_cover_delta(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_fp,
                 level,
                 predicate.z3_func_decl,
@@ -150,7 +162,7 @@ impl Fixedpoint {
     pub fn add_cover(&self, level: i32, predicate: &FuncDecl, property: &impl Ast) {
         unsafe {
             Z3_fixedpoint_add_cover(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_fp,
                 level,
                 predicate.z3_func_decl,
@@ -164,7 +176,7 @@ impl Fixedpoint {
         unsafe {
             Statistics::wrap(
                 &self.ctx,
-                Z3_fixedpoint_get_statistics(self.ctx.z3_ctx.0, self.z3_fp).unwrap(),
+                Z3_fixedpoint_get_statistics(self.ctx.z3_ctx.as_ptr(), self.z3_fp).unwrap(),
             )
         }
     }
@@ -172,21 +184,25 @@ impl Fixedpoint {
     /// Register a relation as fixedpoint-defined (least-fixedpoint semantics).
     pub fn register_relation(&self, pred: &FuncDecl) {
         unsafe {
-            Z3_fixedpoint_register_relation(self.ctx.z3_ctx.0, self.z3_fp, pred.z3_func_decl);
+            Z3_fixedpoint_register_relation(
+                self.ctx.z3_ctx.as_ptr(),
+                self.z3_fp,
+                pred.z3_func_decl,
+            );
         }
     }
 
     /// Set parameters for the fixedpoint context.
     pub fn set_params(&self, params: &Params) {
         unsafe {
-            Z3_fixedpoint_set_params(self.ctx.z3_ctx.0, self.z3_fp, params.z3_params);
+            Z3_fixedpoint_set_params(self.ctx.z3_ctx.as_ptr(), self.z3_fp, params.z3_params);
         }
     }
 
     /// Get the help string for fixedpoint parameters.
     pub fn get_help(&self) -> String {
         unsafe {
-            let help = Z3_fixedpoint_get_help(self.ctx.z3_ctx.0, self.z3_fp);
+            let help = Z3_fixedpoint_get_help(self.ctx.z3_ctx.as_ptr(), self.z3_fp);
             std::ffi::CStr::from_ptr(help)
                 .to_string_lossy()
                 .into_owned()
@@ -197,7 +213,8 @@ impl Fixedpoint {
     pub fn from_string(&self, s: &str) -> Result<(), String> {
         let cs = CString::new(s).map_err(|_| "String contains null byte")?;
         unsafe {
-            let result = Z3_fixedpoint_from_string(self.ctx.z3_ctx.0, self.z3_fp, cs.as_ptr());
+            let result =
+                Z3_fixedpoint_from_string(self.ctx.z3_ctx.as_ptr(), self.z3_fp, cs.as_ptr());
             match result {
                 Some(_) => Ok(()),
                 None => Err("Failed to parse fixedpoint from string".to_string()),
@@ -209,7 +226,7 @@ impl Fixedpoint {
     pub fn from_file(&self, filename: &str) -> Result<(), String> {
         let cs = CString::new(filename).map_err(|_| "Filename contains null byte")?;
         unsafe {
-            let result = Z3_fixedpoint_from_file(self.ctx.z3_ctx.0, self.z3_fp, cs.as_ptr());
+            let result = Z3_fixedpoint_from_file(self.ctx.z3_ctx.as_ptr(), self.z3_fp, cs.as_ptr());
             match result {
                 Some(_) => Ok(()),
                 None => Err("Failed to parse fixedpoint from file".to_string()),
@@ -227,7 +244,12 @@ impl Default for Fixedpoint {
 impl fmt::Display for Fixedpoint {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let s = unsafe {
-            let s = Z3_fixedpoint_to_string(self.ctx.z3_ctx.0, self.z3_fp, 0, std::ptr::null_mut());
+            let s = Z3_fixedpoint_to_string(
+                self.ctx.z3_ctx.as_ptr(),
+                self.z3_fp,
+                0,
+                std::ptr::null_mut(),
+            );
             std::ffi::CStr::from_ptr(s).to_string_lossy().into_owned()
         };
         write!(f, "{s}")

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -9,8 +9,8 @@ impl FuncDecl {
     pub(crate) unsafe fn wrap(ctx: &Context, z3_func_decl: Z3_func_decl) -> Self {
         unsafe {
             Z3_inc_ref(
-                ctx.z3_ctx.0,
-                Z3_func_decl_to_ast(ctx.z3_ctx.0, z3_func_decl).unwrap(),
+                ctx.z3_ctx.as_ptr(),
+                Z3_func_decl_to_ast(ctx.z3_ctx.as_ptr(), z3_func_decl).unwrap(),
             );
         }
         Self {
@@ -29,7 +29,7 @@ impl FuncDecl {
             Self::wrap(
                 ctx,
                 Z3_mk_func_decl(
-                    ctx.z3_ctx.0,
+                    ctx.z3_ctx.as_ptr(),
                     name.into().as_z3_symbol(),
                     domain.len().try_into().unwrap(),
                     domain.as_ptr(),
@@ -105,7 +105,7 @@ impl FuncDecl {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_partial_order(ctx.z3_ctx.0, a.z3_sort, id as u32).unwrap(),
+                Z3_mk_partial_order(ctx.z3_ctx.as_ptr(), a.z3_sort, id as u32).unwrap(),
             )
         }
     }
@@ -126,7 +126,7 @@ impl FuncDecl {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_piecewise_linear_order(ctx.z3_ctx.0, a.z3_sort, id as u32).unwrap(),
+                Z3_mk_piecewise_linear_order(ctx.z3_ctx.as_ptr(), a.z3_sort, id as u32).unwrap(),
             )
         }
     }
@@ -147,7 +147,7 @@ impl FuncDecl {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_linear_order(ctx.z3_ctx.0, a.z3_sort, id as u32).unwrap(),
+                Z3_mk_linear_order(ctx.z3_ctx.as_ptr(), a.z3_sort, id as u32).unwrap(),
             )
         }
     }
@@ -168,7 +168,7 @@ impl FuncDecl {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_tree_order(ctx.z3_ctx.0, a.z3_sort, id as u32).unwrap(),
+                Z3_mk_tree_order(ctx.z3_ctx.as_ptr(), a.z3_sort, id as u32).unwrap(),
             )
         }
     }
@@ -189,7 +189,7 @@ impl FuncDecl {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_transitive_closure(ctx.z3_ctx.0, a.z3_func_decl).unwrap(),
+                Z3_mk_transitive_closure(ctx.z3_ctx.as_ptr(), a.z3_func_decl).unwrap(),
             )
         }
     }
@@ -207,7 +207,7 @@ impl FuncDecl {
     /// assert_eq!(f.arity(), 2);
     /// ```
     pub fn arity(&self) -> usize {
-        unsafe { Z3_get_arity(self.ctx.z3_ctx.0, self.z3_func_decl) as usize }
+        unsafe { Z3_get_arity(self.ctx.z3_ctx.as_ptr(), self.z3_func_decl) as usize }
     }
 
     /// Create a constant (if `args` has length 0) or function application (otherwise).
@@ -221,7 +221,7 @@ impl FuncDecl {
         unsafe {
             ast::Dynamic::wrap(&self.ctx, {
                 Z3_mk_app(
-                    self.ctx.z3_ctx.0,
+                    self.ctx.z3_ctx.as_ptr(),
                     self.z3_func_decl,
                     args.len().try_into().unwrap(),
                     args.as_ptr(),
@@ -233,7 +233,7 @@ impl FuncDecl {
 
     /// Return the `DeclKind` of this `FuncDecl`.
     pub fn kind(&self) -> DeclKind {
-        unsafe { Z3_get_decl_kind(self.ctx.z3_ctx.0, self.z3_func_decl) }
+        unsafe { Z3_get_decl_kind(self.ctx.z3_ctx.as_ptr(), self.z3_func_decl) }
     }
 
     /// Return the name of this `FuncDecl`.
@@ -242,7 +242,7 @@ impl FuncDecl {
     /// the `Symbol`.
     pub fn name(&self) -> String {
         unsafe {
-            let z3_ctx = self.ctx.z3_ctx.0;
+            let z3_ctx = self.ctx.z3_ctx.as_ptr();
             let symbol = Z3_get_decl_name(z3_ctx, self.z3_func_decl).unwrap();
             match Z3_get_symbol_kind(z3_ctx, symbol) {
                 SymbolKind::String => CStr::from_ptr(Z3_get_symbol_string(z3_ctx, symbol))
@@ -257,7 +257,7 @@ impl FuncDecl {
     ///
     /// Returns `None` if `i >= |domain|`.
     pub fn domain(&self, i: usize) -> Option<SortKind> {
-        let z3_ctx = self.ctx.z3_ctx.0;
+        let z3_ctx = self.ctx.z3_ctx.as_ptr();
         let i = c_uint::try_from(i).unwrap();
 
         let domain_size = unsafe { Z3_get_domain_size(z3_ctx, self.z3_func_decl) };
@@ -275,7 +275,7 @@ impl FuncDecl {
 
     /// Returns the kind of range (output) of this `FuncDecl`.
     pub fn range(&self) -> SortKind {
-        let z3_ctx = self.ctx.z3_ctx.0;
+        let z3_ctx = self.ctx.z3_ctx.as_ptr();
         unsafe {
             Z3_get_sort_kind(
                 z3_ctx,
@@ -287,7 +287,7 @@ impl FuncDecl {
 
 impl fmt::Display for FuncDecl {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_func_decl_to_string(self.ctx.z3_ctx.0, self.z3_func_decl) };
+        let p = unsafe { Z3_func_decl_to_string(self.ctx.z3_ctx.as_ptr(), self.z3_func_decl) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -308,8 +308,8 @@ impl Drop for FuncDecl {
     fn drop(&mut self) {
         unsafe {
             Z3_dec_ref(
-                self.ctx.z3_ctx.0,
-                Z3_func_decl_to_ast(self.ctx.z3_ctx.0, self.z3_func_decl).unwrap(),
+                self.ctx.z3_ctx.as_ptr(),
+                Z3_func_decl_to_ast(self.ctx.z3_ctx.as_ptr(), self.z3_func_decl).unwrap(),
             );
         }
     }
@@ -318,9 +318,15 @@ impl Drop for FuncDecl {
 unsafe impl Translate for FuncDecl {
     fn translate(&self, dest: &Context) -> Self {
         unsafe {
-            let func_decl_ast = Z3_func_decl_to_ast(self.ctx.z3_ctx.0, self.z3_func_decl).unwrap();
-            let translated = Z3_translate(self.ctx.z3_ctx.0, func_decl_ast, dest.z3_ctx.0).unwrap();
-            let func_decl = Z3_to_func_decl(self.ctx.z3_ctx.0, translated).unwrap();
+            let func_decl_ast =
+                Z3_func_decl_to_ast(self.ctx.z3_ctx.as_ptr(), self.z3_func_decl).unwrap();
+            let translated = Z3_translate(
+                self.ctx.z3_ctx.as_ptr(),
+                func_decl_ast,
+                dest.z3_ctx.as_ptr(),
+            )
+            .unwrap();
+            let func_decl = Z3_to_func_decl(self.ctx.z3_ctx.as_ptr(), translated).unwrap();
             Self::wrap(dest, func_decl)
         }
     }

--- a/z3/src/func_entry.rs
+++ b/z3/src/func_entry.rs
@@ -9,7 +9,7 @@ use crate::{
 impl FuncEntry {
     pub(crate) unsafe fn wrap(ctx: &Context, z3_func_entry: Z3_func_entry) -> Self {
         unsafe {
-            Z3_func_entry_inc_ref(ctx.z3_ctx.0, z3_func_entry);
+            Z3_func_entry_inc_ref(ctx.z3_ctx.as_ptr(), z3_func_entry);
         }
         Self {
             ctx: ctx.clone(),
@@ -22,14 +22,14 @@ impl FuncEntry {
         unsafe {
             Dynamic::wrap(
                 &self.ctx,
-                Z3_func_entry_get_value(self.ctx.z3_ctx.0, self.z3_func_entry).unwrap(),
+                Z3_func_entry_get_value(self.ctx.z3_ctx.as_ptr(), self.z3_func_entry).unwrap(),
             )
         }
     }
 
     /// Returns the number of arguments in the function entry.
     pub fn get_num_args(&self) -> u32 {
-        unsafe { Z3_func_entry_get_num_args(self.ctx.z3_ctx.0, self.z3_func_entry) }
+        unsafe { Z3_func_entry_get_num_args(self.ctx.z3_ctx.as_ptr(), self.z3_func_entry) }
     }
 
     /// Returns the arguments of the function entry.
@@ -38,7 +38,7 @@ impl FuncEntry {
             .map(|i| unsafe {
                 Dynamic::wrap(
                     &self.ctx,
-                    Z3_func_entry_get_arg(self.ctx.z3_ctx.0, self.z3_func_entry, i).unwrap(),
+                    Z3_func_entry_get_arg(self.ctx.z3_ctx.as_ptr(), self.z3_func_entry, i).unwrap(),
                 )
             })
             .collect()
@@ -65,7 +65,7 @@ impl fmt::Debug for FuncEntry {
 impl Drop for FuncEntry {
     fn drop(&mut self) {
         unsafe {
-            Z3_func_entry_dec_ref(self.ctx.z3_ctx.0, self.z3_func_entry);
+            Z3_func_entry_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_func_entry);
         }
     }
 }

--- a/z3/src/func_interp.rs
+++ b/z3/src/func_interp.rs
@@ -9,7 +9,7 @@ use crate::{
 impl FuncInterp {
     pub(crate) unsafe fn wrap(ctx: &Context, z3_func_interp: Z3_func_interp) -> Self {
         unsafe {
-            Z3_func_interp_inc_ref(ctx.z3_ctx.0, z3_func_interp);
+            Z3_func_interp_inc_ref(ctx.z3_ctx.as_ptr(), z3_func_interp);
         }
 
         Self {
@@ -20,12 +20,12 @@ impl FuncInterp {
 
     /// Returns the number of arguments in the function interpretation.
     pub fn get_arity(&self) -> usize {
-        unsafe { Z3_func_interp_get_arity(self.ctx.z3_ctx.0, self.z3_func_interp) as usize }
+        unsafe { Z3_func_interp_get_arity(self.ctx.z3_ctx.as_ptr(), self.z3_func_interp) as usize }
     }
 
     /// Returns the number of entries in the function interpretation.
     pub fn get_num_entries(&self) -> u32 {
-        unsafe { Z3_func_interp_get_num_entries(self.ctx.z3_ctx.0, self.z3_func_interp) }
+        unsafe { Z3_func_interp_get_num_entries(self.ctx.z3_ctx.as_ptr(), self.z3_func_interp) }
     }
 
     /// Adds an entry to the function interpretation.
@@ -33,7 +33,7 @@ impl FuncInterp {
         let v: AstVector = args.into();
         unsafe {
             Z3_func_interp_add_entry(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_func_interp,
                 v.z3_ast_vector,
                 value.z3_ast,
@@ -47,7 +47,8 @@ impl FuncInterp {
             .map(|i| unsafe {
                 FuncEntry::wrap(
                     &self.ctx,
-                    Z3_func_interp_get_entry(self.ctx.z3_ctx.0, self.z3_func_interp, i).unwrap(),
+                    Z3_func_interp_get_entry(self.ctx.z3_ctx.as_ptr(), self.z3_func_interp, i)
+                        .unwrap(),
                 )
             })
             .collect()
@@ -59,14 +60,16 @@ impl FuncInterp {
         unsafe {
             Dynamic::wrap(
                 &self.ctx,
-                Z3_func_interp_get_else(self.ctx.z3_ctx.0, self.z3_func_interp).unwrap(),
+                Z3_func_interp_get_else(self.ctx.z3_ctx.as_ptr(), self.z3_func_interp).unwrap(),
             )
         }
     }
 
     /// Sets the else value of the function interpretation.
     pub fn set_else(&self, ast: &Dynamic) {
-        unsafe { Z3_func_interp_set_else(self.ctx.z3_ctx.0, self.z3_func_interp, ast.z3_ast) }
+        unsafe {
+            Z3_func_interp_set_else(self.ctx.z3_ctx.as_ptr(), self.z3_func_interp, ast.z3_ast)
+        }
     }
 }
 
@@ -106,7 +109,7 @@ impl fmt::Debug for FuncInterp {
 impl Drop for FuncInterp {
     fn drop(&mut self) {
         unsafe {
-            Z3_func_interp_dec_ref(self.ctx.z3_ctx.0, self.z3_func_interp);
+            Z3_func_interp_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_func_interp);
         }
     }
 }

--- a/z3/src/goal.rs
+++ b/z3/src/goal.rs
@@ -18,7 +18,7 @@ impl Clone for Goal {
 impl Goal {
     pub(crate) unsafe fn wrap(ctx: &Context, z3_goal: Z3_goal) -> Goal {
         unsafe {
-            Z3_goal_inc_ref(ctx.z3_ctx.0, z3_goal);
+            Z3_goal_inc_ref(ctx.z3_ctx.as_ptr(), z3_goal);
         }
         Goal {
             ctx: ctx.clone(),
@@ -32,53 +32,53 @@ impl Goal {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_goal(ctx.z3_ctx.0, models, unsat_cores, proofs).unwrap(),
+                Z3_mk_goal(ctx.z3_ctx.as_ptr(), models, unsat_cores, proofs).unwrap(),
             )
         }
     }
 
     /// Add a new formula `a` to the given goal.
     pub fn assert(&self, ast: &impl ast::Ast) {
-        unsafe { Z3_goal_assert(self.ctx.z3_ctx.0, self.z3_goal, ast.get_z3_ast()) }
+        unsafe { Z3_goal_assert(self.ctx.z3_ctx.as_ptr(), self.z3_goal, ast.get_z3_ast()) }
     }
 
     /// Return true if the given goal contains the formula `false`.
     pub fn is_inconsistent(&self) -> bool {
-        unsafe { Z3_goal_inconsistent(self.ctx.z3_ctx.0, self.z3_goal) }
+        unsafe { Z3_goal_inconsistent(self.ctx.z3_ctx.as_ptr(), self.z3_goal) }
     }
 
     /// Return the depth of the given goal. It tracks how many transformations were applied to it.
     pub fn get_depth(&self) -> u32 {
-        unsafe { Z3_goal_depth(self.ctx.z3_ctx.0, self.z3_goal) }
+        unsafe { Z3_goal_depth(self.ctx.z3_ctx.as_ptr(), self.z3_goal) }
     }
 
     /// Return the number of formulas in the given goal.
     pub fn get_size(&self) -> u32 {
-        unsafe { Z3_goal_size(self.ctx.z3_ctx.0, self.z3_goal) }
+        unsafe { Z3_goal_size(self.ctx.z3_ctx.as_ptr(), self.z3_goal) }
     }
 
     /// Return the number of formulas, subformulas and terms in the given goal.
     pub fn get_num_expr(&self) -> u32 {
-        unsafe { Z3_goal_num_exprs(self.ctx.z3_ctx.0, self.z3_goal) }
+        unsafe { Z3_goal_num_exprs(self.ctx.z3_ctx.as_ptr(), self.z3_goal) }
     }
 
     /// Return true if the goal is empty, and it is precise or the product of a under approximation.
     pub fn is_decided_sat(&self) -> bool {
-        unsafe { Z3_goal_is_decided_sat(self.ctx.z3_ctx.0, self.z3_goal) }
+        unsafe { Z3_goal_is_decided_sat(self.ctx.z3_ctx.as_ptr(), self.z3_goal) }
     }
     /// Return true if the goal contains false, and it is precise or the product of an over approximation.
     pub fn is_decided_unsat(&self) -> bool {
-        unsafe { Z3_goal_is_decided_unsat(self.ctx.z3_ctx.0, self.z3_goal) }
+        unsafe { Z3_goal_is_decided_unsat(self.ctx.z3_ctx.as_ptr(), self.z3_goal) }
     }
 
     /// Erase all formulas from the given goal.
     pub fn reset(&self) {
-        unsafe { Z3_goal_reset(self.ctx.z3_ctx.0, self.z3_goal) };
+        unsafe { Z3_goal_reset(self.ctx.z3_ctx.as_ptr(), self.z3_goal) };
     }
 
     /// Return the "precision" of the given goal. Goals can be transformed using over and under approximations.
     pub fn get_precision(&self) -> GoalPrec {
-        unsafe { Z3_goal_precision(self.ctx.z3_ctx.0, self.z3_goal) }
+        unsafe { Z3_goal_precision(self.ctx.z3_ctx.as_ptr(), self.z3_goal) }
     }
 
     pub fn iter_formulas<'a, T>(&'a self) -> impl Iterator<Item = T> + 'a
@@ -86,7 +86,7 @@ impl Goal {
         T: Ast,
     {
         let goal_size = self.get_size() as usize;
-        let z3_ctx = self.ctx.z3_ctx.0;
+        let z3_ctx = self.ctx.z3_ctx.as_ptr();
         let z3_goal = self.z3_goal;
         (0..goal_size).map(move |i| {
             let formula = unsafe { Z3_goal_formula(z3_ctx, z3_goal, i as u32).unwrap() };
@@ -103,8 +103,9 @@ impl Goal {
         let mut formulas: Vec<Bool> = Vec::with_capacity(goal_size);
 
         for i in 0..goal_size {
-            let formula =
-                unsafe { Z3_goal_formula(self.ctx.z3_ctx.0, self.z3_goal, i as u32).unwrap() };
+            let formula = unsafe {
+                Z3_goal_formula(self.ctx.z3_ctx.as_ptr(), self.z3_goal, i as u32).unwrap()
+            };
             formulas.push(unsafe { Bool::wrap(&self.ctx, formula) });
         }
         formulas
@@ -113,7 +114,7 @@ impl Goal {
 
 impl fmt::Display for Goal {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_goal_to_string(self.ctx.z3_ctx.0, self.z3_goal) };
+        let p = unsafe { Z3_goal_to_string(self.ctx.z3_ctx.as_ptr(), self.z3_goal) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -133,7 +134,7 @@ impl fmt::Debug for Goal {
 impl Drop for Goal {
     fn drop(&mut self) {
         unsafe {
-            Z3_goal_dec_ref(self.ctx.z3_ctx.0, self.z3_goal);
+            Z3_goal_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_goal);
         };
     }
 }
@@ -143,7 +144,8 @@ unsafe impl Translate for Goal {
         unsafe {
             Goal::wrap(
                 ctx,
-                Z3_goal_translate(self.ctx.z3_ctx.0, self.z3_goal, ctx.z3_ctx.0).unwrap(),
+                Z3_goal_translate(self.ctx.z3_ctx.as_ptr(), self.z3_goal, ctx.z3_ctx.as_ptr())
+                    .unwrap(),
             )
         }
     }

--- a/z3/src/model.rs
+++ b/z3/src/model.rs
@@ -15,14 +15,14 @@ impl Model {
     /// has found any model at all.
     pub(crate) fn new_empty(ctx: &Context) -> Model {
         unsafe {
-            let m = Z3_mk_model(ctx.z3_ctx.0).expect("Cannot allocate new Z3_model.");
+            let m = Z3_mk_model(ctx.z3_ctx.as_ptr()).expect("Cannot allocate new Z3_model.");
             Self::wrap(ctx, m)
         }
     }
 
     unsafe fn wrap(ctx: &Context, z3_mdl: Z3_model) -> Model {
         unsafe {
-            Z3_model_inc_ref(ctx.z3_ctx.0, z3_mdl);
+            Z3_model_inc_ref(ctx.z3_ctx.as_ptr(), z3_mdl);
         }
         Model {
             ctx: ctx.clone(),
@@ -32,14 +32,14 @@ impl Model {
 
     pub fn of_solver(slv: &Solver) -> Option<Model> {
         unsafe {
-            let m = Z3_solver_get_model(slv.ctx.z3_ctx.0, slv.z3_slv);
+            let m = Z3_solver_get_model(slv.ctx.z3_ctx.as_ptr(), slv.z3_slv);
             Some(Self::wrap(&slv.ctx, m?))
         }
     }
 
     pub fn of_optimize(opt: &Optimize) -> Option<Model> {
         unsafe {
-            let m = Z3_optimize_get_model(opt.ctx.z3_ctx.0, opt.z3_opt);
+            let m = Z3_optimize_get_model(opt.ctx.z3_ctx.as_ptr(), opt.z3_opt);
             Some(Self::wrap(&opt.ctx, m?))
         }
     }
@@ -49,8 +49,9 @@ impl Model {
     pub fn get_const_interp<T: Ast>(&self, ast: &T) -> Option<T> {
         let func = ast.safe_decl().ok()?;
 
-        let ret =
-            unsafe { Z3_model_get_const_interp(self.ctx.z3_ctx.0, self.z3_mdl, func.z3_func_decl) };
+        let ret = unsafe {
+            Z3_model_get_const_interp(self.ctx.z3_ctx.as_ptr(), self.z3_mdl, func.z3_func_decl)
+        };
         Some(unsafe { T::wrap(&self.ctx, ret?) })
     }
 
@@ -59,21 +60,21 @@ impl Model {
     pub fn get_func_interp(&self, f: &FuncDecl) -> Option<FuncInterp> {
         if f.arity() == 0 {
             let ret = unsafe {
-                Z3_model_get_const_interp(self.ctx.z3_ctx.0, self.z3_mdl, f.z3_func_decl)
+                Z3_model_get_const_interp(self.ctx.z3_ctx.as_ptr(), self.z3_mdl, f.z3_func_decl)
             }?;
             let sort_kind = unsafe {
                 Z3_get_sort_kind(
-                    self.ctx.z3_ctx.0,
-                    Z3_get_range(self.ctx.z3_ctx.0, f.z3_func_decl).unwrap(),
+                    self.ctx.z3_ctx.as_ptr(),
+                    Z3_get_range(self.ctx.z3_ctx.as_ptr(), f.z3_func_decl).unwrap(),
                 )
             };
             match sort_kind {
                 SortKind::Array => {
-                    if unsafe { Z3_is_as_array(self.ctx.z3_ctx.0, ret) } {
+                    if unsafe { Z3_is_as_array(self.ctx.z3_ctx.as_ptr(), ret) } {
                         let fd = unsafe {
                             FuncDecl::wrap(
                                 &self.ctx,
-                                Z3_get_as_array_func_decl(self.ctx.z3_ctx.0, ret).unwrap(),
+                                Z3_get_as_array_func_decl(self.ctx.z3_ctx.as_ptr(), ret).unwrap(),
                             )
                         };
                         self.get_func_interp(&fd)
@@ -84,8 +85,9 @@ impl Model {
                 _ => None,
             }
         } else {
-            let ret =
-                unsafe { Z3_model_get_func_interp(self.ctx.z3_ctx.0, self.z3_mdl, f.z3_func_decl) };
+            let ret = unsafe {
+                Z3_model_get_func_interp(self.ctx.z3_ctx.as_ptr(), self.z3_mdl, f.z3_func_decl)
+            };
             Some(unsafe { FuncInterp::wrap(&self.ctx, ret?) })
         }
     }
@@ -101,7 +103,7 @@ impl Model {
         let res = {
             unsafe {
                 Z3_model_eval(
-                    self.ctx.z3_ctx.0,
+                    self.ctx.z3_ctx.as_ptr(),
                     self.z3_mdl,
                     ast.get_z3_ast(),
                     model_completion,
@@ -118,8 +120,8 @@ impl Model {
 
     fn len(&self) -> u32 {
         unsafe {
-            Z3_model_get_num_consts(self.ctx.z3_ctx.0, self.z3_mdl)
-                + Z3_model_get_num_funcs(self.ctx.z3_ctx.0, self.z3_mdl)
+            Z3_model_get_num_consts(self.ctx.z3_ctx.as_ptr(), self.z3_mdl)
+                + Z3_model_get_num_funcs(self.ctx.z3_ctx.as_ptr(), self.z3_mdl)
         }
     }
 
@@ -129,21 +131,22 @@ impl Model {
 
     /// Returns the number of uninterpreted sorts that the model assigns an interpretation to.
     pub fn num_sorts(&self) -> u32 {
-        unsafe { Z3_model_get_num_sorts(self.ctx.z3_ctx.0, self.z3_mdl) }
+        unsafe { Z3_model_get_num_sorts(self.ctx.z3_ctx.as_ptr(), self.z3_mdl) }
     }
 
     /// Returns the i-th uninterpreted sort that the model assigns an interpretation to,
     /// or `None` if `i >= self.num_sorts()`.
     pub fn get_sort(&self, i: u32) -> Option<Sort> {
-        let z3_sort = unsafe { Z3_model_get_sort(self.ctx.z3_ctx.0, self.z3_mdl, i) }?;
+        let z3_sort = unsafe { Z3_model_get_sort(self.ctx.z3_ctx.as_ptr(), self.z3_mdl, i) }?;
         Some(unsafe { Sort::wrap(&self.ctx, z3_sort) })
     }
 
     /// Returns the universe of the given sort (the finite set of values Z3 assigned to it),
     /// or `None` if the sort has no interpretation in the model.
     pub fn get_sort_universe(&self, sort: &Sort) -> Option<AstVector> {
-        let z3_av =
-            unsafe { Z3_model_get_sort_universe(self.ctx.z3_ctx.0, self.z3_mdl, sort.z3_sort) }?;
+        let z3_av = unsafe {
+            Z3_model_get_sort_universe(self.ctx.z3_ctx.as_ptr(), self.z3_mdl, sort.z3_sort)
+        }?;
         Some(unsafe { AstVector::wrap(&self.ctx, z3_av) })
     }
 
@@ -167,7 +170,7 @@ impl Model {
 
 impl fmt::Display for Model {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_model_to_string(self.ctx.z3_ctx.0, self.z3_mdl) };
+        let p = unsafe { Z3_model_to_string(self.ctx.z3_ctx.as_ptr(), self.z3_mdl) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -186,7 +189,7 @@ impl fmt::Debug for Model {
 
 impl Drop for Model {
     fn drop(&mut self) {
-        unsafe { Z3_model_dec_ref(self.ctx.z3_ctx.0, self.z3_mdl) };
+        unsafe { Z3_model_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_mdl) };
     }
 }
 
@@ -218,19 +221,24 @@ impl Iterator for ModelIter<'_> {
         if self.idx >= self.len {
             None
         } else {
-            let num_consts =
-                unsafe { Z3_model_get_num_consts(self.model.ctx.z3_ctx.0, self.model.z3_mdl) };
+            let num_consts = unsafe {
+                Z3_model_get_num_consts(self.model.ctx.z3_ctx.as_ptr(), self.model.z3_mdl)
+            };
             if self.idx < num_consts {
                 let const_decl = unsafe {
-                    Z3_model_get_const_decl(self.model.ctx.z3_ctx.0, self.model.z3_mdl, self.idx)
-                        .unwrap()
+                    Z3_model_get_const_decl(
+                        self.model.ctx.z3_ctx.as_ptr(),
+                        self.model.z3_mdl,
+                        self.idx,
+                    )
+                    .unwrap()
                 };
                 self.idx += 1;
                 Some(unsafe { FuncDecl::wrap(&self.model.ctx, const_decl) })
             } else {
                 let func_decl = unsafe {
                     Z3_model_get_func_decl(
-                        self.model.ctx.z3_ctx.0,
+                        self.model.ctx.z3_ctx.as_ptr(),
                         self.model.z3_mdl,
                         self.idx - num_consts,
                     )
@@ -281,7 +289,8 @@ unsafe impl Translate for Model {
         unsafe {
             Model::wrap(
                 dest,
-                Z3_model_translate(self.ctx.z3_ctx.0, self.z3_mdl, dest.z3_ctx.0).unwrap(),
+                Z3_model_translate(self.ctx.z3_ctx.as_ptr(), self.z3_mdl, dest.z3_ctx.as_ptr())
+                    .unwrap(),
             )
         }
     }

--- a/z3/src/optimize.rs
+++ b/z3/src/optimize.rs
@@ -55,7 +55,7 @@ impl Optimize {
     /// handler context pointer.
     unsafe fn wrap(ctx: &Context, z3_opt: Z3_optimize) -> Optimize {
         unsafe {
-            Z3_optimize_inc_ref(ctx.z3_ctx.0, z3_opt);
+            Z3_optimize_inc_ref(ctx.z3_ctx.as_ptr(), z3_opt);
         }
         Optimize {
             ctx: ctx.clone(),
@@ -67,7 +67,7 @@ impl Optimize {
     /// Create a new optimize context.
     pub fn new() -> Optimize {
         let ctx = &Context::thread_local();
-        unsafe { Self::wrap(ctx, Z3_mk_optimize(ctx.z3_ctx.0).unwrap()) }
+        unsafe { Self::wrap(ctx, Z3_mk_optimize(ctx.z3_ctx.as_ptr()).unwrap()) }
     }
 
     /// Parse an SMT-LIB2 string with assertions, soft constraints and optimization objectives.
@@ -75,7 +75,11 @@ impl Optimize {
     pub fn from_string<T: Into<Vec<u8>>>(&self, source_string: T) {
         let source_cstring = CString::new(source_string).unwrap();
         unsafe {
-            Z3_optimize_from_string(self.ctx.z3_ctx.0, self.z3_opt, source_cstring.as_ptr());
+            Z3_optimize_from_string(
+                self.ctx.z3_ctx.as_ptr(),
+                self.z3_opt,
+                source_cstring.as_ptr(),
+            );
         }
     }
 
@@ -93,7 +97,7 @@ impl Optimize {
     /// - [`Optimize::minimize()`]
     pub fn assert<T: Borrow<Bool>>(&self, ast: T) {
         let ast = ast.borrow();
-        unsafe { Z3_optimize_assert(self.ctx.z3_ctx.0, self.z3_opt, ast.get_z3_ast()) };
+        unsafe { Z3_optimize_assert(self.ctx.z3_ctx.as_ptr(), self.z3_opt, ast.get_z3_ast()) };
     }
 
     /// Assert a constraint `a` into the solver, and track it (in the
@@ -114,7 +118,12 @@ impl Optimize {
     pub fn assert_and_track(&self, ast: &Bool, p: &Bool) {
         debug!("assert_and_track: {ast:?}");
         unsafe {
-            Z3_optimize_assert_and_track(self.ctx.z3_ctx.0, self.z3_opt, ast.z3_ast, p.z3_ast)
+            Z3_optimize_assert_and_track(
+                self.ctx.z3_ctx.as_ptr(),
+                self.z3_opt,
+                ast.z3_ast,
+                p.z3_ast,
+            )
         };
     }
 
@@ -134,7 +143,7 @@ impl Optimize {
 
         unsafe {
             Z3_optimize_assert_soft(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_opt,
                 ast.get_z3_ast(),
                 weight_cstring.as_ptr(),
@@ -155,7 +164,7 @@ impl Optimize {
             ast.get_sort().kind(),
             SortKind::Int | SortKind::Real | SortKind::Bv
         ));
-        unsafe { Z3_optimize_maximize(self.ctx.z3_ctx.0, self.z3_opt, ast.get_z3_ast()) };
+        unsafe { Z3_optimize_maximize(self.ctx.z3_ctx.as_ptr(), self.z3_opt, ast.get_z3_ast()) };
     }
 
     /// Add a minimization constraint.
@@ -169,7 +178,7 @@ impl Optimize {
             ast.get_sort().kind(),
             SortKind::Int | SortKind::Real | SortKind::Bv
         ));
-        unsafe { Z3_optimize_minimize(self.ctx.z3_ctx.0, self.z3_opt, ast.get_z3_ast()) };
+        unsafe { Z3_optimize_minimize(self.ctx.z3_ctx.as_ptr(), self.z3_opt, ast.get_z3_ast()) };
     }
 
     /// Return a subset of the assumptions provided to either the last
@@ -193,7 +202,8 @@ impl Optimize {
     ///
     /// - [`Optimize::check`]
     pub fn get_unsat_core(&self) -> Vec<Bool> {
-        let Some(raw) = (unsafe { Z3_optimize_get_unsat_core(self.ctx.z3_ctx.0, self.z3_opt) })
+        let Some(raw) =
+            (unsafe { Z3_optimize_get_unsat_core(self.ctx.z3_ctx.as_ptr(), self.z3_opt) })
         else {
             return vec![];
         };
@@ -211,7 +221,7 @@ impl Optimize {
     ///
     /// - [`Optimize::pop()`]
     pub fn push(&self) {
-        unsafe { Z3_optimize_push(self.ctx.z3_ctx.0, self.z3_opt) };
+        unsafe { Z3_optimize_push(self.ctx.z3_ctx.as_ptr(), self.z3_opt) };
     }
 
     /// Backtrack one level.
@@ -225,7 +235,7 @@ impl Optimize {
     ///
     /// - [`Optimize::push()`]
     pub fn pop(&self) {
-        unsafe { Z3_optimize_pop(self.ctx.z3_ctx.0, self.z3_opt) };
+        unsafe { Z3_optimize_pop(self.ctx.z3_ctx.as_ptr(), self.z3_opt) };
     }
 
     /// Check consistency and produce optimal values.
@@ -237,7 +247,7 @@ impl Optimize {
         let assumptions: Vec<Z3_ast> = assumptions.iter().map(|a| a.z3_ast).collect();
         match unsafe {
             Z3_optimize_check(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_opt,
                 assumptions.len().try_into().unwrap(),
                 assumptions.as_ptr(),
@@ -263,7 +273,8 @@ impl Optimize {
     ///
     /// This contains maximize/minimize objectives and grouped soft constraints.
     pub fn get_objectives(&self) -> Vec<Dynamic> {
-        let raw = unsafe { Z3_optimize_get_objectives(self.ctx.z3_ctx.0, self.z3_opt).unwrap() };
+        let raw =
+            unsafe { Z3_optimize_get_objectives(self.ctx.z3_ctx.as_ptr(), self.z3_opt).unwrap() };
         unsafe { AstVector::wrap(&self.ctx, raw) }.to_vec()
     }
 
@@ -271,7 +282,7 @@ impl Optimize {
     ///
     /// Use this method when [`Optimize::check()`] returns [`SatResult::Unknown`].
     pub fn get_reason_unknown(&self) -> Option<String> {
-        let p = unsafe { Z3_optimize_get_reason_unknown(self.ctx.z3_ctx.0, self.z3_opt) };
+        let p = unsafe { Z3_optimize_get_reason_unknown(self.ctx.z3_ctx.as_ptr(), self.z3_opt) };
         if p.is_null() {
             return None;
         }
@@ -283,7 +294,7 @@ impl Optimize {
 
     /// Configure the parameters for this Optimize.
     pub fn set_params(&self, params: &Params) {
-        unsafe { Z3_optimize_set_params(self.ctx.z3_ctx.0, self.z3_opt, params.z3_params) };
+        unsafe { Z3_optimize_set_params(self.ctx.z3_ctx.as_ptr(), self.z3_opt, params.z3_params) };
     }
 
     /// Retrieve the statistics for the last [`Optimize::check()`].
@@ -291,7 +302,7 @@ impl Optimize {
         unsafe {
             Statistics::wrap(
                 &self.ctx,
-                Z3_optimize_get_statistics(self.ctx.z3_ctx.0, self.z3_opt).unwrap(),
+                Z3_optimize_get_statistics(self.ctx.z3_ctx.as_ptr(), self.z3_opt).unwrap(),
             )
         }
     }
@@ -391,7 +402,7 @@ impl Optimize {
         let av = unsafe {
             AstVector::wrap(
                 &self.ctx,
-                Z3_optimize_get_assertions(self.ctx.z3_ctx.0, self.z3_opt).unwrap(),
+                Z3_optimize_get_assertions(self.ctx.z3_ctx.as_ptr(), self.z3_opt).unwrap(),
             )
         };
         av.try_into().expect("solver assertions are always Bool")
@@ -400,7 +411,7 @@ impl Optimize {
     /// Retrieve the lower bound value or approximation for the i-th optimization objective.
     pub fn get_lower(&self, objective_id: u32) -> Option<Dynamic> {
         unsafe {
-            Z3_optimize_get_lower(self.ctx.z3_ctx.0, self.z3_opt, objective_id)
+            Z3_optimize_get_lower(self.ctx.z3_ctx.as_ptr(), self.z3_opt, objective_id)
                 .map(|ast| Dynamic::wrap(&self.ctx, ast))
         }
     }
@@ -408,7 +419,7 @@ impl Optimize {
     /// Retrieve the upper bound value or approximation for the i-th optimization objective.
     pub fn get_upper(&self, objective_id: u32) -> Option<Dynamic> {
         unsafe {
-            Z3_optimize_get_upper(self.ctx.z3_ctx.0, self.z3_opt, objective_id)
+            Z3_optimize_get_upper(self.ctx.z3_ctx.as_ptr(), self.z3_opt, objective_id)
                 .map(|ast| Dynamic::wrap(&self.ctx, ast))
         }
     }
@@ -476,7 +487,7 @@ impl Optimize {
             // Register with Z3 before freeing the old state so Z3 never holds a dangling
             // pointer in the window between the two operations.
             Z3_optimize_register_model_eh(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_opt,
                 z3_model,
                 new_nn.as_ptr().cast::<c_void>(),
@@ -535,7 +546,7 @@ impl Default for Optimize {
 
 impl fmt::Display for Optimize {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_optimize_to_string(self.ctx.z3_ctx.0, self.z3_opt) };
+        let p = unsafe { Z3_optimize_to_string(self.ctx.z3_ctx.as_ptr(), self.z3_opt) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -561,7 +572,7 @@ impl Drop for Optimize {
         // will continue to exist, but retain a pointer to free'd memory, causing UB
         self.replace_model_handler(None);
 
-        unsafe { Z3_optimize_dec_ref(self.ctx.z3_ctx.0, self.z3_opt) };
+        unsafe { Z3_optimize_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_opt) };
     }
 }
 
@@ -572,7 +583,8 @@ unsafe impl Translate for Optimize {
         unsafe {
             Optimize::wrap(
                 dest,
-                Z3_optimize_translate(self.ctx.z3_ctx.0, self.z3_opt, dest.z3_ctx.0).unwrap(),
+                Z3_optimize_translate(self.ctx.z3_ctx.as_ptr(), self.z3_opt, dest.z3_ctx.as_ptr())
+                    .unwrap(),
             )
         }
     }

--- a/z3/src/params.rs
+++ b/z3/src/params.rs
@@ -7,7 +7,7 @@ use crate::{Context, Params, Symbol};
 impl Params {
     unsafe fn wrap(ctx: &Context, z3_params: Z3_params) -> Params {
         unsafe {
-            Z3_params_inc_ref(ctx.z3_ctx.0, z3_params);
+            Z3_params_inc_ref(ctx.z3_ctx.as_ptr(), z3_params);
         }
         Params {
             ctx: ctx.clone(),
@@ -17,13 +17,13 @@ impl Params {
 
     pub fn new() -> Params {
         let ctx = &Context::thread_local();
-        unsafe { Self::wrap(ctx, Z3_mk_params(ctx.z3_ctx.0).unwrap()) }
+        unsafe { Self::wrap(ctx, Z3_mk_params(ctx.z3_ctx.as_ptr()).unwrap()) }
     }
 
     pub fn set_symbol<K: Into<Symbol>, V: Into<Symbol>>(&mut self, k: K, v: V) {
         unsafe {
             Z3_params_set_symbol(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_params,
                 k.into().as_z3_symbol(),
                 v.into().as_z3_symbol(),
@@ -34,7 +34,7 @@ impl Params {
     pub fn set_bool<K: Into<Symbol>>(&mut self, k: K, v: bool) {
         unsafe {
             Z3_params_set_bool(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_params,
                 k.into().as_z3_symbol(),
                 v,
@@ -45,7 +45,7 @@ impl Params {
     pub fn set_f64<K: Into<Symbol>>(&mut self, k: K, v: f64) {
         unsafe {
             Z3_params_set_double(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_params,
                 k.into().as_z3_symbol(),
                 v,
@@ -56,7 +56,7 @@ impl Params {
     pub fn set_u32<K: Into<Symbol>>(&mut self, k: K, v: u32) {
         unsafe {
             Z3_params_set_uint(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_params,
                 k.into().as_z3_symbol(),
                 v,
@@ -112,7 +112,7 @@ pub fn reset_all_global_params() {
 
 impl fmt::Display for Params {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_params_to_string(self.ctx.z3_ctx.0, self.z3_params) };
+        let p = unsafe { Z3_params_to_string(self.ctx.z3_ctx.as_ptr(), self.z3_params) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -131,6 +131,6 @@ impl fmt::Debug for Params {
 
 impl Drop for Params {
     fn drop(&mut self) {
-        unsafe { Z3_params_dec_ref(self.ctx.z3_ctx.0, self.z3_params) };
+        unsafe { Z3_params_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_params) };
     }
 }

--- a/z3/src/pattern.rs
+++ b/z3/src/pattern.rs
@@ -35,12 +35,15 @@ impl Pattern {
             ctx: ctx.clone(),
             z3_pattern: unsafe {
                 let p = Z3_mk_pattern(
-                    ctx.z3_ctx.0,
+                    ctx.z3_ctx.as_ptr(),
                     terms.len().try_into().unwrap(),
                     terms.as_ptr() as *const Z3_ast,
                 )
                 .unwrap();
-                Z3_inc_ref(ctx.z3_ctx.0, Z3_pattern_to_ast(ctx.z3_ctx.0, p).unwrap());
+                Z3_inc_ref(
+                    ctx.z3_ctx.as_ptr(),
+                    Z3_pattern_to_ast(ctx.z3_ctx.as_ptr(), p).unwrap(),
+                );
                 p
             },
         }
@@ -49,7 +52,7 @@ impl Pattern {
 
 impl fmt::Debug for Pattern {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_pattern_to_string(self.ctx.z3_ctx.0, self.z3_pattern) };
+        let p = unsafe { Z3_pattern_to_string(self.ctx.z3_ctx.as_ptr(), self.z3_pattern) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -68,9 +71,9 @@ impl fmt::Display for Pattern {
 
 impl Drop for Pattern {
     fn drop(&mut self) {
-        let ast = unsafe { Z3_pattern_to_ast(self.ctx.z3_ctx.0, self.z3_pattern) }.unwrap();
+        let ast = unsafe { Z3_pattern_to_ast(self.ctx.z3_ctx.as_ptr(), self.z3_pattern) }.unwrap();
         unsafe {
-            Z3_dec_ref(self.ctx.z3_ctx.0, ast);
+            Z3_dec_ref(self.ctx.z3_ctx.as_ptr(), ast);
         }
     }
 }

--- a/z3/src/probe.rs
+++ b/z3/src/probe.rs
@@ -8,7 +8,7 @@ use crate::{Context, Goal, Probe};
 impl Probe {
     unsafe fn wrap(ctx: &Context, z3_probe: Z3_probe) -> Probe {
         unsafe {
-            Z3_probe_inc_ref(ctx.z3_ctx.0, z3_probe);
+            Z3_probe_inc_ref(ctx.z3_ctx.as_ptr(), z3_probe);
         }
         Probe {
             ctx: ctx.clone(),
@@ -27,10 +27,10 @@ impl Probe {
     /// ```
     pub fn list_all() -> Vec<Result<String, Utf8Error>> {
         let ctx = &Context::thread_local();
-        let p = unsafe { Z3_get_num_probes(ctx.z3_ctx.0) };
+        let p = unsafe { Z3_get_num_probes(ctx.z3_ctx.as_ptr()) };
         (0..p)
             .map(move |n| {
-                let t = unsafe { Z3_get_probe_name(ctx.z3_ctx.0, n) };
+                let t = unsafe { Z3_get_probe_name(ctx.z3_ctx.as_ptr(), n) };
                 unsafe { CStr::from_ptr(t).to_str().map(String::from) }
             })
             .collect()
@@ -42,7 +42,7 @@ impl Probe {
         let ctx = &Context::thread_local();
         let probe_name = CString::new(name).unwrap();
         unsafe {
-            CStr::from_ptr(Z3_probe_get_descr(ctx.z3_ctx.0, probe_name.as_ptr()))
+            CStr::from_ptr(Z3_probe_get_descr(ctx.z3_ctx.as_ptr(), probe_name.as_ptr()))
                 .to_str()
                 .map(|s| s.to_string())
         }
@@ -60,7 +60,12 @@ impl Probe {
     pub fn new(name: &str) -> Probe {
         let ctx = &Context::thread_local();
         let probe_name = CString::new(name).unwrap();
-        unsafe { Self::wrap(ctx, Z3_mk_probe(ctx.z3_ctx.0, probe_name.as_ptr()).unwrap()) }
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_probe(ctx.z3_ctx.as_ptr(), probe_name.as_ptr()).unwrap(),
+            )
+        }
     }
 
     /// Execute the probe over the goal.
@@ -68,7 +73,7 @@ impl Probe {
     /// The probe always produce a double value. "Boolean" probes return
     /// `0.0` for `false`, and a value different from `0.0` for `true`.
     pub fn apply(&self, goal: &Goal) -> f64 {
-        unsafe { Z3_probe_apply(self.ctx.z3_ctx.0, self.z3_probe, goal.z3_goal) }
+        unsafe { Z3_probe_apply(self.ctx.z3_ctx.as_ptr(), self.z3_probe, goal.z3_goal) }
     }
 
     /// Return a probe that always evaluates to val.
@@ -78,7 +83,7 @@ impl Probe {
     /// ```
     pub fn constant(val: f64) -> Probe {
         let ctx = &Context::thread_local();
-        unsafe { Self::wrap(ctx, Z3_probe_const(ctx.z3_ctx.0, val).unwrap()) }
+        unsafe { Self::wrap(ctx, Z3_probe_const(ctx.z3_ctx.as_ptr(), val).unwrap()) }
     }
 
     /// Return a probe that evaluates to "true" when the value returned
@@ -89,7 +94,7 @@ impl Probe {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_probe_lt(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe).unwrap(),
+                Z3_probe_lt(self.ctx.z3_ctx.as_ptr(), self.z3_probe, p.z3_probe).unwrap(),
             )
         }
     }
@@ -100,7 +105,7 @@ impl Probe {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_probe_gt(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe).unwrap(),
+                Z3_probe_gt(self.ctx.z3_ctx.as_ptr(), self.z3_probe, p.z3_probe).unwrap(),
             )
         }
     }
@@ -111,7 +116,7 @@ impl Probe {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_probe_le(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe).unwrap(),
+                Z3_probe_le(self.ctx.z3_ctx.as_ptr(), self.z3_probe, p.z3_probe).unwrap(),
             )
         }
     }
@@ -122,7 +127,7 @@ impl Probe {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_probe_ge(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe).unwrap(),
+                Z3_probe_ge(self.ctx.z3_ctx.as_ptr(), self.z3_probe, p.z3_probe).unwrap(),
             )
         }
     }
@@ -133,7 +138,7 @@ impl Probe {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_probe_eq(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe).unwrap(),
+                Z3_probe_eq(self.ctx.z3_ctx.as_ptr(), self.z3_probe, p.z3_probe).unwrap(),
             )
         }
     }
@@ -143,7 +148,7 @@ impl Probe {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_probe_and(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe).unwrap(),
+                Z3_probe_and(self.ctx.z3_ctx.as_ptr(), self.z3_probe, p.z3_probe).unwrap(),
             )
         }
     }
@@ -153,7 +158,7 @@ impl Probe {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_probe_or(self.ctx.z3_ctx.0, self.z3_probe, p.z3_probe).unwrap(),
+                Z3_probe_or(self.ctx.z3_ctx.as_ptr(), self.z3_probe, p.z3_probe).unwrap(),
             )
         }
     }
@@ -163,7 +168,7 @@ impl Probe {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_probe_not(self.ctx.z3_ctx.0, self.z3_probe).unwrap(),
+                Z3_probe_not(self.ctx.z3_ctx.as_ptr(), self.z3_probe).unwrap(),
             )
         }
     }
@@ -196,7 +201,7 @@ impl fmt::Debug for Probe {
 impl Drop for Probe {
     fn drop(&mut self) {
         unsafe {
-            Z3_probe_dec_ref(self.ctx.z3_ctx.0, self.z3_probe);
+            Z3_probe_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_probe);
         }
     }
 }

--- a/z3/src/quantifier_elimination.rs
+++ b/z3/src/quantifier_elimination.rs
@@ -16,7 +16,12 @@ impl QuantifierElimination {
         unsafe {
             Bool::wrap(
                 ctx,
-                Z3_qe_lite(ctx.z3_ctx.0, vars.z3_ast_vector, formula.get_z3_ast()).unwrap(),
+                Z3_qe_lite(
+                    ctx.z3_ctx.as_ptr(),
+                    vars.z3_ast_vector,
+                    formula.get_z3_ast(),
+                )
+                .unwrap(),
             )
         }
     }
@@ -30,12 +35,12 @@ impl QuantifierElimination {
         unsafe {
             let z3_vars: Vec<Z3_app> = vars
                 .iter()
-                .map(|v| Z3_to_app(ctx.z3_ctx.0, v.get_z3_ast()).unwrap())
+                .map(|v| Z3_to_app(ctx.z3_ctx.as_ptr(), v.get_z3_ast()).unwrap())
                 .collect();
             Bool::wrap(
                 ctx,
                 Z3_qe_model_project(
-                    ctx.z3_ctx.0,
+                    ctx.z3_ctx.as_ptr(),
                     model.z3_mdl,
                     z3_vars.len() as u32,
                     z3_vars.as_ptr(),

--- a/z3/src/rec_func_decl.rs
+++ b/z3/src/rec_func_decl.rs
@@ -10,8 +10,8 @@ impl RecFuncDecl {
     pub(crate) unsafe fn wrap(ctx: &Context, z3_func_decl: Z3_func_decl) -> Self {
         unsafe {
             Z3_inc_ref(
-                ctx.z3_ctx.0,
-                Z3_func_decl_to_ast(ctx.z3_ctx.0, z3_func_decl).unwrap(),
+                ctx.z3_ctx.as_ptr(),
+                Z3_func_decl_to_ast(ctx.z3_ctx.as_ptr(), z3_func_decl).unwrap(),
             );
         }
         Self {
@@ -23,7 +23,7 @@ impl RecFuncDecl {
     pub fn new<S: Into<Symbol>>(name: S, domain: &[&Sort], range: &Sort) -> Self {
         let ctx = &Context::thread_local();
         assert!(domain.iter().all(|s| s.ctx.z3_ctx == ctx.z3_ctx));
-        assert_eq!(ctx.z3_ctx.0, range.ctx.z3_ctx.0);
+        assert_eq!(ctx.z3_ctx.as_ptr(), range.ctx.z3_ctx.as_ptr());
 
         let domain: Vec<_> = domain.iter().map(|s| s.z3_sort).collect();
 
@@ -31,7 +31,7 @@ impl RecFuncDecl {
             Self::wrap(
                 ctx,
                 Z3_mk_rec_func_decl(
-                    ctx.z3_ctx.0,
+                    ctx.z3_ctx.as_ptr(),
                     name.into().as_z3_symbol(),
                     domain.len().try_into().unwrap(),
                     domain.as_ptr(),
@@ -80,11 +80,11 @@ impl RecFuncDecl {
         unsafe {
             assert_eq!(
                 body.get_sort().z3_sort,
-                Z3_get_range(self.ctx.z3_ctx.0, self.z3_func_decl).unwrap()
+                Z3_get_range(self.ctx.z3_ctx.as_ptr(), self.z3_func_decl).unwrap()
             );
 
             Z3_add_rec_def(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_func_decl,
                 self.arity() as u32,
                 args.as_mut_ptr(),
@@ -96,7 +96,7 @@ impl RecFuncDecl {
 
 impl fmt::Display for RecFuncDecl {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_func_decl_to_string(self.ctx.z3_ctx.0, self.z3_func_decl) };
+        let p = unsafe { Z3_func_decl_to_string(self.ctx.z3_ctx.as_ptr(), self.z3_func_decl) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -117,8 +117,8 @@ impl Drop for RecFuncDecl {
     fn drop(&mut self) {
         unsafe {
             Z3_dec_ref(
-                self.ctx.z3_ctx.0,
-                Z3_func_decl_to_ast(self.ctx.z3_ctx.0, self.z3_func_decl).unwrap(),
+                self.ctx.z3_ctx.as_ptr(),
+                Z3_func_decl_to_ast(self.ctx.z3_ctx.as_ptr(), self.z3_func_decl).unwrap(),
             );
         }
     }

--- a/z3/src/solver.rs
+++ b/z3/src/solver.rs
@@ -15,7 +15,7 @@ use std::ops::AddAssign;
 impl Solver {
     pub(crate) unsafe fn wrap(ctx: &Context, z3_slv: Z3_solver) -> Solver {
         unsafe {
-            Z3_solver_inc_ref(ctx.z3_ctx.0, z3_slv);
+            Z3_solver_inc_ref(ctx.z3_ctx.as_ptr(), z3_slv);
         }
         Solver {
             ctx: ctx.clone(),
@@ -47,7 +47,7 @@ impl Solver {
     /// solver to change its behaviour.
     pub fn new() -> Solver {
         let ctx = &Context::thread_local();
-        unsafe { Self::wrap(ctx, Z3_mk_solver(ctx.z3_ctx.0).unwrap()) }
+        unsafe { Self::wrap(ctx, Z3_mk_solver(ctx.z3_ctx.as_ptr()).unwrap()) }
     }
 
     /// Parse an SMT-LIB2 string with assertions, soft constraints and optimization objectives.
@@ -55,7 +55,11 @@ impl Solver {
     pub fn from_string<T: Into<Vec<u8>>>(&self, source_string: T) {
         let source_cstring = CString::new(source_string).unwrap();
         unsafe {
-            Z3_solver_from_string(self.ctx.z3_ctx.0, self.z3_slv, source_cstring.as_ptr());
+            Z3_solver_from_string(
+                self.ctx.z3_ctx.as_ptr(),
+                self.z3_slv,
+                source_cstring.as_ptr(),
+            );
         }
     }
 
@@ -64,7 +68,7 @@ impl Solver {
     pub fn new_for_logic<S: Into<Symbol>>(logic: S) -> Option<Solver> {
         let ctx = &Context::thread_local();
         unsafe {
-            let s = Z3_mk_solver_for_logic(ctx.z3_ctx.0, logic.into().as_z3_symbol())?;
+            let s = Z3_mk_solver_for_logic(ctx.z3_ctx.as_ptr(), logic.into().as_z3_symbol())?;
             Some(Self::wrap(ctx, s))
         }
     }
@@ -97,7 +101,7 @@ impl Solver {
     pub fn assert<T: Borrow<Bool>>(&self, ast: T) {
         let ast = ast.borrow();
         debug!("assert: {ast:?}");
-        unsafe { Z3_solver_assert(self.ctx.z3_ctx.0, self.z3_slv, ast.z3_ast) };
+        unsafe { Z3_solver_assert(self.ctx.z3_ctx.as_ptr(), self.z3_slv, ast.z3_ast) };
     }
 
     /// Assert a constraint `a` into the solver, and track it (in the
@@ -117,12 +121,14 @@ impl Solver {
     pub fn assert_and_track<T: Into<Bool>>(&self, ast: T, p: &Bool) {
         let ast = ast.into();
         debug!("assert_and_track: {ast:?}");
-        unsafe { Z3_solver_assert_and_track(self.ctx.z3_ctx.0, self.z3_slv, ast.z3_ast, p.z3_ast) };
+        unsafe {
+            Z3_solver_assert_and_track(self.ctx.z3_ctx.as_ptr(), self.z3_slv, ast.z3_ast, p.z3_ast)
+        };
     }
 
     /// Remove all assertions from the solver.
     pub fn reset(&self) {
-        unsafe { Z3_solver_reset(self.ctx.z3_ctx.0, self.z3_slv) };
+        unsafe { Z3_solver_reset(self.ctx.z3_ctx.as_ptr(), self.z3_slv) };
     }
 
     /// Check whether the assertions in a given solver are consistent or not.
@@ -149,7 +155,7 @@ impl Solver {
     /// [model construction is enabled]: crate::Config::set_model_generation
     /// [proof generation was enabled]: crate::Config::set_proof_generation
     pub fn check(&self) -> SatResult {
-        match unsafe { Z3_solver_check(self.ctx.z3_ctx.0, self.z3_slv) } {
+        match unsafe { Z3_solver_check(self.ctx.z3_ctx.as_ptr(), self.z3_slv) } {
             Z3_L_FALSE => SatResult::Unsat,
             Z3_L_UNDEF => SatResult::Unknown,
             Z3_L_TRUE => SatResult::Sat,
@@ -170,7 +176,12 @@ impl Solver {
     pub fn check_assumptions(&self, assumptions: &[Bool]) -> SatResult {
         let a: Vec<Z3_ast> = assumptions.iter().map(|a| a.z3_ast).collect();
         match unsafe {
-            Z3_solver_check_assumptions(self.ctx.z3_ctx.0, self.z3_slv, a.len() as u32, a.as_ptr())
+            Z3_solver_check_assumptions(
+                self.ctx.z3_ctx.as_ptr(),
+                self.z3_slv,
+                a.len() as u32,
+                a.as_ptr(),
+            )
         } {
             Z3_L_FALSE => SatResult::Unsat,
             Z3_L_UNDEF => SatResult::Unknown,
@@ -184,7 +195,7 @@ impl Solver {
         let av = unsafe {
             AstVector::wrap(
                 &self.ctx,
-                Z3_solver_get_assertions(self.ctx.z3_ctx.0, self.z3_slv).unwrap(),
+                Z3_solver_get_assertions(self.ctx.z3_ctx.as_ptr(), self.z3_slv).unwrap(),
             )
         };
         av.try_into().expect("solver assertions are always Bool")
@@ -212,7 +223,8 @@ impl Solver {
     /// - [`Solver::check_assumptions`]
     /// - [`Solver::assert_and_track`]
     pub fn get_unsat_core(&self) -> Vec<Bool> {
-        let Some(raw) = (unsafe { Z3_solver_get_unsat_core(self.ctx.z3_ctx.0, self.z3_slv) })
+        let Some(raw) =
+            (unsafe { Z3_solver_get_unsat_core(self.ctx.z3_ctx.as_ptr(), self.z3_slv) })
         else {
             return vec![];
         };
@@ -228,7 +240,7 @@ impl Solver {
 
         unsafe {
             Z3_solver_get_consequences(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 self.z3_slv,
                 assumptions_vec.z3_ast_vector,
                 variables_vec.z3_ast_vector,
@@ -249,7 +261,7 @@ impl Solver {
     ///
     /// - [`Solver::pop()`]
     pub fn push(&self) {
-        unsafe { Z3_solver_push(self.ctx.z3_ctx.0, self.z3_slv) };
+        unsafe { Z3_solver_push(self.ctx.z3_ctx.as_ptr(), self.z3_slv) };
     }
 
     /// Backtrack `n` backtracking points.
@@ -258,7 +270,7 @@ impl Solver {
     ///
     /// - [`Solver::push()`]
     pub fn pop(&self, n: u32) {
-        unsafe { Z3_solver_pop(self.ctx.z3_ctx.0, self.z3_slv, n) };
+        unsafe { Z3_solver_pop(self.ctx.z3_ctx.as_ptr(), self.z3_slv, n) };
     }
 
     /// Retrieve the model for the last [`Solver::check()`]
@@ -295,7 +307,7 @@ impl Solver {
     // This seems to actually return an Ast with kind `SortKind::Unknown`, which we don't
     // have an Ast subtype for yet.
     pub fn get_proof(&self) -> Option<impl Ast> {
-        let m = unsafe { Z3_solver_get_proof(self.ctx.z3_ctx.0, self.z3_slv) }?;
+        let m = unsafe { Z3_solver_get_proof(self.ctx.z3_ctx.as_ptr(), self.z3_slv) }?;
         Some(unsafe { ast::Dynamic::wrap(&self.ctx, m) })
     }
 
@@ -303,7 +315,7 @@ impl Solver {
     /// [`SatResult::Unknown`]) for the commands [`Solver::check()`]
     /// and [`Solver::check_assumptions()`].
     pub fn get_reason_unknown(&self) -> Option<String> {
-        let p = unsafe { Z3_solver_get_reason_unknown(self.ctx.z3_ctx.0, self.z3_slv) };
+        let p = unsafe { Z3_solver_get_reason_unknown(self.ctx.z3_ctx.as_ptr(), self.z3_slv) };
         if p.is_null() {
             return None;
         }
@@ -315,7 +327,7 @@ impl Solver {
 
     /// Set the current solver using the given parameters.
     pub fn set_params(&self, params: &Params) {
-        unsafe { Z3_solver_set_params(self.ctx.z3_ctx.0, self.z3_slv, params.z3_params) };
+        unsafe { Z3_solver_set_params(self.ctx.z3_ctx.as_ptr(), self.z3_slv, params.z3_params) };
     }
 
     /// Retrieve the statistics for the last [`Solver::check()`].
@@ -323,7 +335,7 @@ impl Solver {
         unsafe {
             Statistics::wrap(
                 &self.ctx,
-                Z3_solver_get_statistics(self.ctx.z3_ctx.0, self.z3_slv).unwrap(),
+                Z3_solver_get_statistics(self.ctx.z3_ctx.as_ptr(), self.z3_slv).unwrap(),
             )
         }
     }
@@ -345,7 +357,7 @@ impl Solver {
 
         let p = unsafe {
             Z3_benchmark_to_smtlib_string(
-                self.ctx.z3_ctx.0,
+                self.ctx.z3_ctx.as_ptr(),
                 name.as_ptr(),
                 logic.as_ptr(),
                 status.as_ptr(),
@@ -592,7 +604,7 @@ impl<T: Solvable> Iterator for SolverIterator<T> {
 
 impl fmt::Display for Solver {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_solver_to_string(self.ctx.z3_ctx.0, self.z3_slv) };
+        let p = unsafe { Z3_solver_to_string(self.ctx.z3_ctx.as_ptr(), self.z3_slv) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -611,7 +623,7 @@ impl fmt::Debug for Solver {
 
 impl Drop for Solver {
     fn drop(&mut self) {
-        unsafe { Z3_solver_dec_ref(self.ctx.z3_ctx.0, self.z3_slv) };
+        unsafe { Z3_solver_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_slv) };
     }
 }
 
@@ -628,7 +640,8 @@ unsafe impl Translate for Solver {
         unsafe {
             Solver::wrap(
                 dest,
-                Z3_solver_translate(self.ctx.z3_ctx.0, self.z3_slv, dest.z3_ctx.0).unwrap(),
+                Z3_solver_translate(self.ctx.z3_ctx.as_ptr(), self.z3_slv, dest.z3_ctx.as_ptr())
+                    .unwrap(),
             )
         }
     }

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -9,7 +9,10 @@ use crate::{Context, FuncDecl, Sort, SortDiffers, Symbol};
 impl Sort {
     pub(crate) unsafe fn wrap(ctx: &Context, z3_sort: Z3_sort) -> Sort {
         unsafe {
-            Z3_inc_ref(ctx.z3_ctx.0, Z3_sort_to_ast(ctx.z3_ctx.0, z3_sort).unwrap());
+            Z3_inc_ref(
+                ctx.z3_ctx.as_ptr(),
+                Z3_sort_to_ast(ctx.z3_ctx.as_ptr(), z3_sort).unwrap(),
+            );
         }
         Sort {
             ctx: ctx.clone(),
@@ -27,7 +30,7 @@ impl Sort {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_uninterpreted_sort(ctx.z3_ctx.0, name.as_z3_symbol()).unwrap(),
+                Z3_mk_uninterpreted_sort(ctx.z3_ctx.as_ptr(), name.as_z3_symbol()).unwrap(),
             )
         }
     }
@@ -35,56 +38,59 @@ impl Sort {
     pub fn bool() -> Sort {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_bool_sort(ctx.z3_ctx.0).unwrap())
+            Self::wrap(ctx, Z3_mk_bool_sort(ctx.z3_ctx.as_ptr()).unwrap())
         }
     }
 
     pub fn int() -> Sort {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_int_sort(ctx.z3_ctx.0).unwrap())
+            Self::wrap(ctx, Z3_mk_int_sort(ctx.z3_ctx.as_ptr()).unwrap())
         }
     }
 
     pub fn real() -> Sort {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_real_sort(ctx.z3_ctx.0).unwrap())
+            Self::wrap(ctx, Z3_mk_real_sort(ctx.z3_ctx.as_ptr()).unwrap())
         }
     }
 
     pub fn float(ebits: u32, sbits: u32) -> Sort {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.0, ebits, sbits).unwrap())
+            Self::wrap(
+                ctx,
+                Z3_mk_fpa_sort(ctx.z3_ctx.as_ptr(), ebits, sbits).unwrap(),
+            )
         }
     }
 
     pub fn float32() -> Sort {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.0, 8, 24).unwrap())
+            Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.as_ptr(), 8, 24).unwrap())
         }
     }
 
     pub fn double() -> Sort {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.0, 11, 53).unwrap())
+            Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.as_ptr(), 11, 53).unwrap())
         }
     }
 
     pub fn string() -> Sort {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_string_sort(ctx.z3_ctx.0).unwrap())
+            Self::wrap(ctx, Z3_mk_string_sort(ctx.z3_ctx.as_ptr()).unwrap())
         }
     }
 
     pub fn char() -> Sort {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_char_sort(ctx.z3_ctx.0).unwrap())
+            Self::wrap(ctx, Z3_mk_char_sort(ctx.z3_ctx.as_ptr()).unwrap())
         }
     }
 
@@ -94,7 +100,7 @@ impl Sort {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_bv_sort(ctx.z3_ctx.0, sz as ::std::os::raw::c_uint).unwrap(),
+                Z3_mk_bv_sort(ctx.z3_ctx.as_ptr(), sz as ::std::os::raw::c_uint).unwrap(),
             )
         }
     }
@@ -105,7 +111,7 @@ impl Sort {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_array_sort(ctx.z3_ctx.0, domain.z3_sort, range.z3_sort).unwrap(),
+                Z3_mk_array_sort(ctx.z3_ctx.as_ptr(), domain.z3_sort, range.z3_sort).unwrap(),
             )
         }
     }
@@ -113,13 +119,23 @@ impl Sort {
     pub fn set(elt: &Sort) -> Sort {
         let ctx = &Context::thread_local();
 
-        unsafe { Self::wrap(ctx, Z3_mk_set_sort(ctx.z3_ctx.0, elt.z3_sort).unwrap()) }
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_set_sort(ctx.z3_ctx.as_ptr(), elt.z3_sort).unwrap(),
+            )
+        }
     }
 
     pub fn seq(elt: &Sort) -> Sort {
         let ctx = &Context::thread_local();
 
-        unsafe { Self::wrap(ctx, Z3_mk_seq_sort(ctx.z3_ctx.0, elt.z3_sort).unwrap()) }
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_seq_sort(ctx.z3_ctx.as_ptr(), elt.z3_sort).unwrap(),
+            )
+        }
     }
 
     /// Create an enumeration sort.
@@ -167,7 +183,7 @@ impl Sort {
             Self::wrap(
                 ctx,
                 Z3_mk_enumeration_sort(
-                    ctx.z3_ctx.0,
+                    ctx.z3_ctx.as_ptr(),
                     name.as_z3_symbol(),
                     enum_names.len().try_into().unwrap(),
                     enum_names.as_ptr(),
@@ -182,16 +198,16 @@ impl Sort {
         for i in &enum_consts {
             unsafe {
                 Z3_inc_ref(
-                    ctx.z3_ctx.0,
-                    Z3_func_decl_to_ast(ctx.z3_ctx.0, NonNull::new(*i).unwrap()).unwrap(),
+                    ctx.z3_ctx.as_ptr(),
+                    Z3_func_decl_to_ast(ctx.z3_ctx.as_ptr(), NonNull::new(*i).unwrap()).unwrap(),
                 );
             }
         }
         for i in &enum_testers {
             unsafe {
                 Z3_inc_ref(
-                    ctx.z3_ctx.0,
-                    Z3_func_decl_to_ast(ctx.z3_ctx.0, NonNull::new(*i).unwrap()).unwrap(),
+                    ctx.z3_ctx.as_ptr(),
+                    Z3_func_decl_to_ast(ctx.z3_ctx.as_ptr(), NonNull::new(*i).unwrap()).unwrap(),
                 );
             }
         }
@@ -210,14 +226,14 @@ impl Sort {
     }
 
     pub fn kind(&self) -> SortKind {
-        unsafe { Z3_get_sort_kind(self.ctx.z3_ctx.0, self.z3_sort) }
+        unsafe { Z3_get_sort_kind(self.ctx.z3_ctx.as_ptr(), self.z3_sort) }
     }
 
     /// Returns `Some(e)` where `e` is the number of exponent bits if the sort
     /// is a `FloatingPoint` and `None` otherwise.
     pub fn float_exponent_size(&self) -> Option<u32> {
         if self.kind() == SortKind::FloatingPoint {
-            Some(unsafe { Z3_fpa_get_ebits(self.ctx.z3_ctx.0, self.z3_sort) })
+            Some(unsafe { Z3_fpa_get_ebits(self.ctx.z3_ctx.as_ptr(), self.z3_sort) })
         } else {
             None
         }
@@ -227,7 +243,7 @@ impl Sort {
     /// is a `FloatingPoint` and `None` otherwise.
     pub fn float_significand_size(&self) -> Option<u32> {
         if self.kind() == SortKind::FloatingPoint {
-            Some(unsafe { Z3_fpa_get_sbits(self.ctx.z3_ctx.0, self.z3_sort) })
+            Some(unsafe { Z3_fpa_get_sbits(self.ctx.z3_ctx.as_ptr(), self.z3_sort) })
         } else {
             None
         }
@@ -270,7 +286,7 @@ impl Sort {
     pub fn array_domain(&self) -> Option<Sort> {
         if self.is_array() {
             unsafe {
-                let domain_sort = Z3_get_array_sort_domain(self.ctx.z3_ctx.0, self.z3_sort)?;
+                let domain_sort = Z3_get_array_sort_domain(self.ctx.z3_ctx.as_ptr(), self.z3_sort)?;
                 Some(Self::wrap(&self.ctx, domain_sort))
             }
         } else {
@@ -298,7 +314,7 @@ impl Sort {
     pub fn array_range(&self) -> Option<Sort> {
         if self.is_array() {
             unsafe {
-                let range_sort = Z3_get_array_sort_range(self.ctx.z3_ctx.0, self.z3_sort)?;
+                let range_sort = Z3_get_array_sort_range(self.ctx.z3_ctx.as_ptr(), self.z3_sort)?;
                 Some(Self::wrap(&self.ctx, range_sort))
             }
         } else {
@@ -315,7 +331,7 @@ impl Clone for Sort {
 
 impl fmt::Display for Sort {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_sort_to_string(self.ctx.z3_ctx.0, self.z3_sort) };
+        let p = unsafe { Z3_sort_to_string(self.ctx.z3_ctx.as_ptr(), self.z3_sort) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -334,7 +350,7 @@ impl fmt::Debug for Sort {
 
 impl PartialEq<Sort> for Sort {
     fn eq(&self, other: &Sort) -> bool {
-        unsafe { Z3_is_eq_sort(self.ctx.z3_ctx.0, self.z3_sort, other.z3_sort) }
+        unsafe { Z3_is_eq_sort(self.ctx.z3_ctx.as_ptr(), self.z3_sort, other.z3_sort) }
     }
 }
 
@@ -344,8 +360,8 @@ impl Drop for Sort {
     fn drop(&mut self) {
         unsafe {
             Z3_dec_ref(
-                self.ctx.z3_ctx.0,
-                Z3_sort_to_ast(self.ctx.z3_ctx.0, self.z3_sort).unwrap(),
+                self.ctx.z3_ctx.as_ptr(),
+                Z3_sort_to_ast(self.ctx.z3_ctx.as_ptr(), self.z3_sort).unwrap(),
             );
         }
     }

--- a/z3/src/statistics.rs
+++ b/z3/src/statistics.rs
@@ -32,7 +32,7 @@ impl Statistics {
     /// Wrap a raw [`Z3_stats`], managing refcounts.
     pub(crate) unsafe fn wrap(ctx: &Context, z3_stats: Z3_stats) -> Statistics {
         unsafe {
-            Z3_stats_inc_ref(ctx.z3_ctx.0, z3_stats);
+            Z3_stats_inc_ref(ctx.z3_ctx.as_ptr(), z3_stats);
         }
         Statistics {
             ctx: ctx.clone(),
@@ -47,15 +47,15 @@ impl Statistics {
     /// This assumes that `idx` is a valid index.
     unsafe fn value_at_idx(&self, idx: u32) -> StatisticsValue {
         unsafe {
-            if Z3_stats_is_uint(self.ctx.z3_ctx.0, self.z3_stats, idx) {
+            if Z3_stats_is_uint(self.ctx.z3_ctx.as_ptr(), self.z3_stats, idx) {
                 StatisticsValue::UInt(Z3_stats_get_uint_value(
-                    self.ctx.z3_ctx.0,
+                    self.ctx.z3_ctx.as_ptr(),
                     self.z3_stats,
                     idx,
                 ))
             } else {
                 StatisticsValue::Double(Z3_stats_get_double_value(
-                    self.ctx.z3_ctx.0,
+                    self.ctx.z3_ctx.as_ptr(),
                     self.z3_stats,
                     idx,
                 ))
@@ -66,9 +66,13 @@ impl Statistics {
     /// Get the statistics value for the given `key`.
     pub fn value(&self, key: &str) -> Option<StatisticsValue> {
         unsafe {
-            let size = Z3_stats_size(self.ctx.z3_ctx.0, self.z3_stats);
+            let size = Z3_stats_size(self.ctx.z3_ctx.as_ptr(), self.z3_stats);
             for idx in 0..size {
-                let k = CStr::from_ptr(Z3_stats_get_key(self.ctx.z3_ctx.0, self.z3_stats, idx));
+                let k = CStr::from_ptr(Z3_stats_get_key(
+                    self.ctx.z3_ctx.as_ptr(),
+                    self.z3_stats,
+                    idx,
+                ));
                 if k.to_str().unwrap() == key {
                     return Some(self.value_at_idx(idx));
                 }
@@ -79,9 +83,9 @@ impl Statistics {
 
     /// Iterate over all of the entries in this set of statistics.
     pub fn entries(&self) -> impl Iterator<Item = StatisticsEntry> + '_ {
-        let p = unsafe { Z3_stats_size(self.ctx.z3_ctx.0, self.z3_stats) };
+        let p = unsafe { Z3_stats_size(self.ctx.z3_ctx.as_ptr(), self.z3_stats) };
         (0..p).map(move |n| unsafe {
-            let t = Z3_stats_get_key(self.ctx.z3_ctx.0, self.z3_stats, n);
+            let t = Z3_stats_get_key(self.ctx.z3_ctx.as_ptr(), self.z3_stats, n);
             StatisticsEntry {
                 key: CStr::from_ptr(t).to_str().unwrap().to_owned(),
                 value: self.value_at_idx(n),
@@ -118,7 +122,7 @@ impl fmt::Debug for Statistics {
 impl Drop for Statistics {
     fn drop(&mut self) {
         unsafe {
-            Z3_stats_dec_ref(self.ctx.z3_ctx.0, self.z3_stats);
+            Z3_stats_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_stats);
         }
     }
 }

--- a/z3/src/symbol.rs
+++ b/z3/src/symbol.rs
@@ -8,12 +8,12 @@ impl Symbol {
         let ctx = &Context::thread_local();
         match self {
             Symbol::Int(i) => unsafe {
-                Z3_mk_int_symbol(ctx.z3_ctx.0, *i as ::std::os::raw::c_int).unwrap()
+                Z3_mk_int_symbol(ctx.z3_ctx.as_ptr(), *i as ::std::os::raw::c_int).unwrap()
             },
             Symbol::String(s) => {
                 let ss = CString::new(s.clone()).unwrap();
                 let p = ss.as_ptr();
-                unsafe { Z3_mk_string_symbol(ctx.z3_ctx.0, p).unwrap() }
+                unsafe { Z3_mk_string_symbol(ctx.z3_ctx.as_ptr(), p).unwrap() }
             }
         }
     }

--- a/z3/src/tactic.rs
+++ b/z3/src/tactic.rs
@@ -12,7 +12,7 @@ use crate::{ApplyResult, Context, Goal, Params, Probe, Solver, Tactic};
 impl ApplyResult {
     unsafe fn wrap(ctx: &Context, z3_apply_result: Z3_apply_result) -> ApplyResult {
         unsafe {
-            Z3_apply_result_inc_ref(ctx.z3_ctx.0, z3_apply_result);
+            Z3_apply_result_inc_ref(ctx.z3_ctx.as_ptr(), z3_apply_result);
         }
         ApplyResult {
             ctx: ctx.clone(),
@@ -21,12 +21,14 @@ impl ApplyResult {
     }
 
     pub fn list_subgoals(self) -> impl Iterator<Item = Goal> {
-        let num_subgoals =
-            unsafe { Z3_apply_result_get_num_subgoals(self.ctx.z3_ctx.0, self.z3_apply_result) };
+        let num_subgoals = unsafe {
+            Z3_apply_result_get_num_subgoals(self.ctx.z3_ctx.as_ptr(), self.z3_apply_result)
+        };
         (0..num_subgoals).map(move |i| unsafe {
             Goal::wrap(
                 &self.ctx,
-                Z3_apply_result_get_subgoal(self.ctx.z3_ctx.0, self.z3_apply_result, i).unwrap(),
+                Z3_apply_result_get_subgoal(self.ctx.z3_ctx.as_ptr(), self.z3_apply_result, i)
+                    .unwrap(),
             )
         })
     }
@@ -41,7 +43,7 @@ impl Clone for ApplyResult {
 impl Drop for ApplyResult {
     fn drop(&mut self) {
         unsafe {
-            Z3_apply_result_dec_ref(self.ctx.z3_ctx.0, self.z3_apply_result);
+            Z3_apply_result_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_apply_result);
         }
     }
 }
@@ -58,10 +60,10 @@ impl Tactic {
     /// ```
     pub fn list_all() -> Vec<Result<String, Utf8Error>> {
         let ctx = &Context::thread_local();
-        let p = unsafe { Z3_get_num_tactics(ctx.z3_ctx.0) };
+        let p = unsafe { Z3_get_num_tactics(ctx.z3_ctx.as_ptr()) };
         (0..p)
             .map(move |n| {
-                let t = unsafe { Z3_get_tactic_name(ctx.z3_ctx.0, n) };
+                let t = unsafe { Z3_get_tactic_name(ctx.z3_ctx.as_ptr(), n) };
                 unsafe { CStr::from_ptr(t) }.to_str().map(String::from)
             })
             .collect()
@@ -69,7 +71,7 @@ impl Tactic {
 
     unsafe fn wrap(ctx: &Context, z3_tactic: Z3_tactic) -> Tactic {
         unsafe {
-            Z3_tactic_inc_ref(ctx.z3_ctx.0, z3_tactic);
+            Z3_tactic_inc_ref(ctx.z3_ctx.as_ptr(), z3_tactic);
         }
         Tactic {
             ctx: ctx.clone(),
@@ -94,7 +96,7 @@ impl Tactic {
         let tactic_name = CString::new(name).unwrap();
 
         unsafe {
-            let tactic = Z3_mk_tactic(ctx.z3_ctx.0, tactic_name.as_ptr())
+            let tactic = Z3_mk_tactic(ctx.z3_ctx.as_ptr(), tactic_name.as_ptr())
                 .unwrap_or_else(|| panic!("{name} is an invalid tactic"));
             Self::wrap(ctx, tactic)
         }
@@ -103,13 +105,13 @@ impl Tactic {
     /// Return a tactic that just return the given goal.
     pub fn create_skip() -> Tactic {
         let ctx = &Context::thread_local();
-        unsafe { Self::wrap(ctx, Z3_tactic_skip(ctx.z3_ctx.0).unwrap()) }
+        unsafe { Self::wrap(ctx, Z3_tactic_skip(ctx.z3_ctx.as_ptr()).unwrap()) }
     }
 
     /// Return a tactic that always fails.
     pub fn create_fail() -> Tactic {
         let ctx = &Context::thread_local();
-        unsafe { Self::wrap(ctx, Z3_tactic_fail(ctx.z3_ctx.0).unwrap()) }
+        unsafe { Self::wrap(ctx, Z3_tactic_fail(ctx.z3_ctx.as_ptr()).unwrap()) }
     }
 
     /// Return a tactic that keeps applying `t` until the goal is not modified anymore or the maximum
@@ -119,7 +121,7 @@ impl Tactic {
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_tactic_repeat(ctx.z3_ctx.0, t.z3_tactic, max).unwrap(),
+                Z3_tactic_repeat(ctx.z3_ctx.as_ptr(), t.z3_tactic, max).unwrap(),
             )
         }
     }
@@ -131,7 +133,7 @@ impl Tactic {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_tactic_try_for(self.ctx.z3_ctx.0, self.z3_tactic, timeout_ms).unwrap(),
+                Z3_tactic_try_for(self.ctx.z3_ctx.as_ptr(), self.z3_tactic, timeout_ms).unwrap(),
             )
         }
     }
@@ -142,8 +144,12 @@ impl Tactic {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_tactic_and_then(self.ctx.z3_ctx.0, self.z3_tactic, then_tactic.z3_tactic)
-                    .unwrap(),
+                Z3_tactic_and_then(
+                    self.ctx.z3_ctx.as_ptr(),
+                    self.z3_tactic,
+                    then_tactic.z3_tactic,
+                )
+                .unwrap(),
             )
         }
     }
@@ -154,8 +160,12 @@ impl Tactic {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_tactic_or_else(self.ctx.z3_ctx.0, self.z3_tactic, else_tactic.z3_tactic)
-                    .unwrap(),
+                Z3_tactic_or_else(
+                    self.ctx.z3_ctx.as_ptr(),
+                    self.z3_tactic,
+                    else_tactic.z3_tactic,
+                )
+                .unwrap(),
             )
         }
     }
@@ -166,7 +176,13 @@ impl Tactic {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_tactic_cond(self.ctx.z3_ctx.0, p.z3_probe, self.z3_tactic, t.z3_tactic).unwrap(),
+                Z3_tactic_cond(
+                    self.ctx.z3_ctx.as_ptr(),
+                    p.z3_probe,
+                    self.z3_tactic,
+                    t.z3_tactic,
+                )
+                .unwrap(),
             )
         }
     }
@@ -177,7 +193,7 @@ impl Tactic {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_tactic_when(self.ctx.z3_ctx.0, p.z3_probe, self.z3_tactic).unwrap(),
+                Z3_tactic_when(self.ctx.z3_ctx.as_ptr(), p.z3_probe, self.z3_tactic).unwrap(),
             )
         }
     }
@@ -190,7 +206,13 @@ impl Tactic {
         unsafe {
             Self::wrap(
                 &p.ctx,
-                Z3_tactic_cond(p.ctx.z3_ctx.0, p.z3_probe, t1.z3_tactic, t2.z3_tactic).unwrap(),
+                Z3_tactic_cond(
+                    p.ctx.z3_ctx.as_ptr(),
+                    p.z3_probe,
+                    t1.z3_tactic,
+                    t2.z3_tactic,
+                )
+                .unwrap(),
             )
         }
     }
@@ -200,7 +222,7 @@ impl Tactic {
         unsafe {
             Self::wrap(
                 &p.ctx,
-                Z3_tactic_fail_if(p.ctx.z3_ctx.0, p.z3_probe).unwrap(),
+                Z3_tactic_fail_if(p.ctx.z3_ctx.as_ptr(), p.z3_probe).unwrap(),
             )
         }
     }
@@ -210,7 +232,7 @@ impl Tactic {
         unsafe {
             Self::wrap(
                 &self.ctx,
-                Z3_tactic_using_params(self.ctx.z3_ctx.0, self.z3_tactic, params.z3_params)
+                Z3_tactic_using_params(self.ctx.z3_ctx.as_ptr(), self.z3_tactic, params.z3_params)
                     .unwrap(),
             )
         }
@@ -222,9 +244,9 @@ impl Tactic {
     pub fn apply(&self, goal: &Goal, params: Option<&Params>) -> Result<ApplyResult, String> {
         unsafe {
             let z3_apply_result = match params {
-                None => Z3_tactic_apply(self.ctx.z3_ctx.0, self.z3_tactic, goal.z3_goal),
+                None => Z3_tactic_apply(self.ctx.z3_ctx.as_ptr(), self.z3_tactic, goal.z3_goal),
                 Some(params) => Z3_tactic_apply_ex(
-                    self.ctx.z3_ctx.0,
+                    self.ctx.z3_ctx.as_ptr(),
                     self.z3_tactic,
                     goal.z3_goal,
                     params.z3_params,
@@ -233,8 +255,8 @@ impl Tactic {
             if let Some(z3_apply_result) = z3_apply_result {
                 Ok(ApplyResult::wrap(&self.ctx, z3_apply_result))
             } else {
-                let code = Z3_get_error_code(self.ctx.z3_ctx.0);
-                let msg = Z3_get_error_msg(self.ctx.z3_ctx.0, code);
+                let code = Z3_get_error_code(self.ctx.z3_ctx.as_ptr());
+                let msg = Z3_get_error_msg(self.ctx.z3_ctx.as_ptr(), code);
                 Err(String::from(CStr::from_ptr(msg).to_str().unwrap_or(
                     "Couldn't retrieve error message from z3: got invalid UTF-8",
                 )))
@@ -263,7 +285,7 @@ impl Tactic {
         unsafe {
             Solver::wrap(
                 &self.ctx,
-                Z3_mk_solver_from_tactic(self.ctx.z3_ctx.0, self.z3_tactic).unwrap(),
+                Z3_mk_solver_from_tactic(self.ctx.z3_ctx.as_ptr(), self.z3_tactic).unwrap(),
             )
         }
     }
@@ -271,7 +293,7 @@ impl Tactic {
 
 impl fmt::Display for Tactic {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let p = unsafe { Z3_tactic_get_help(self.ctx.z3_ctx.0, self.z3_tactic) };
+        let p = unsafe { Z3_tactic_get_help(self.ctx.z3_ctx.as_ptr(), self.z3_tactic) };
         if p.is_null() {
             return Result::Err(fmt::Error);
         }
@@ -291,7 +313,7 @@ impl fmt::Debug for Tactic {
 impl Drop for Tactic {
     fn drop(&mut self) {
         unsafe {
-            Z3_tactic_dec_ref(self.ctx.z3_ctx.0, self.z3_tactic);
+            Z3_tactic_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_tactic);
         }
     }
 }

--- a/z3/src/translate/mod.rs
+++ b/z3/src/translate/mod.rs
@@ -24,7 +24,12 @@ unsafe impl<T: Ast> Translate for T {
     fn translate(&self, dest: &Context) -> Self {
         unsafe {
             Self::wrap(dest, {
-                Z3_translate(self.get_ctx().z3_ctx.0, self.get_z3_ast(), dest.z3_ctx.0).unwrap()
+                Z3_translate(
+                    self.get_ctx().z3_ctx.as_ptr(),
+                    self.get_z3_ast(),
+                    dest.z3_ctx.as_ptr(),
+                )
+                .unwrap()
             })
         }
     }


### PR DESCRIPTION
A bit of rote refactoring (worth doing in its own right) to clean up the diff for #582.