### PR TITLE
feat: Ast Parameterization

### DIFF
--- a/z3/src/ast/array.rs
+++ b/z3/src/ast/array.rs
@@ -125,9 +125,9 @@ impl Array {
     /// # use z3::{ast, Config, Context, ast::{Array, Int}, Sort};
     /// # use z3::ast::Ast;
     /// # use std::convert::TryInto;
-    /// let arr = Array::const_array(&Sort::int(), &Int::from_u64(9));
+    /// let arr = Array::const_array(&Sort::int().as_dyn(), &Int::from_u64(9));
     /// assert!(arr.is_const_array());
-    /// let arr2 = Array::fresh_const("a", &Sort::int(), &Sort::int());
+    /// let arr2 = Array::fresh_const("a", &Sort::int().as_dyn(), &Sort::int().as_dyn());
     /// assert!(!arr2.is_const_array());
     /// ```
     pub fn is_const_array(&self) -> bool {

--- a/z3/src/ast/array.rs
+++ b/z3/src/ast/array.rs
@@ -1,21 +1,23 @@
 use crate::ast::{Ast, Dynamic};
 use crate::{Context, Sort, Symbol};
 use std::ffi::CString;
+use std::marker::PhantomData;
 use z3_sys::*;
 
 /// [`Ast`] node representing an array value.
-/// An array in Z3 is a mapping from indices to values.
-pub struct Array {
+/// An array in Z3 is a mapping from indices of sort `D` to values of sort `R`.
+pub struct Array<D = Dynamic, R = Dynamic> {
     pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
+    pub(crate) phantom: PhantomData<(D, R)>,
 }
 
-impl Array {
+impl<D: Ast, R: Ast> Array<D, R> {
     /// Create an `Array` which maps from indices of the `domain` `Sort` to
     /// values of the `range` `Sort`.
     ///
     /// All values in the `Array` will be unconstrained.
-    pub fn new_const<S: Into<Symbol>>(name: S, domain: &Sort, range: &Sort) -> Array {
+    pub fn new_const<S: Into<Symbol>>(name: S, domain: &Sort<D>, range: &Sort<R>) -> Array<D, R> {
         let ctx = &Context::thread_local();
         let sort = Sort::array(domain, range);
         unsafe {
@@ -30,7 +32,7 @@ impl Array {
         }
     }
 
-    pub fn fresh_const(prefix: &str, domain: &Sort, range: &Sort) -> Array {
+    pub fn fresh_const(prefix: &str, domain: &Sort<D>, range: &Sort<R>) -> Array<D, R> {
         let ctx = &Context::thread_local();
         let sort = Sort::array(domain, range);
         unsafe {
@@ -44,10 +46,7 @@ impl Array {
 
     /// Create a "constant array", that is, an `Array` initialized so that all of the
     /// indices in the `domain` map to the given value `val`
-    pub fn const_array<A>(domain: &Sort, val: &A) -> Array
-    where
-        A: Ast,
-    {
+    pub fn const_array(domain: &Sort<D>, val: &R) -> Array<D, R> {
         let ctx = &Context::thread_local();
         unsafe {
             Self::wrap(ctx, {
@@ -57,25 +56,9 @@ impl Array {
     }
 
     /// Get the value at a given index in the array.
-    ///
-    /// Note that the `index` _must be_ of the array's `domain` sort.
-    /// The return type will be of the array's `range` sort.
-    //
-    // We avoid the binop! macro because the argument has a non-Self type
-    pub fn select<A>(&self, index: &A) -> Dynamic
-    where
-        A: Ast,
-    {
-        // TODO: We could validate here that the index is of the correct type.
-        // This would require us either to keep around the original `domain` argument
-        // from when the Array was constructed, or to do an additional Z3 query
-        // to find the domain sort first.
-        // But if we did this check ourselves, we'd just panic, so it doesn't seem
-        // like a huge advantage over just letting Z3 panic itself when it discovers the
-        // problem.
-        // This way we also avoid the redundant check every time this method is called.
+    pub fn select(&self, index: &D) -> R {
         unsafe {
-            Dynamic::wrap(&self.ctx, {
+            R::wrap(&self.ctx, {
                 Z3_mk_select(self.ctx.z3_ctx.as_ptr(), self.z3_ast, index.get_z3_ast()).unwrap()
             })
         }
@@ -83,11 +66,11 @@ impl Array {
 
     /// n-ary Array read. `idxs` are the indices of the array that gets read.
     /// This is useful for applying lambdas.
-    pub fn select_n(&self, idxs: &[&dyn Ast]) -> Dynamic {
+    pub fn select_n(&self, idxs: &[&dyn Ast]) -> R {
         let idxs: Vec<_> = idxs.iter().map(|idx| idx.get_z3_ast()).collect();
 
         unsafe {
-            Dynamic::wrap(&self.ctx, {
+            R::wrap(&self.ctx, {
                 Z3_mk_select_n(
                     self.ctx.z3_ctx.as_ptr(),
                     self.z3_ast,
@@ -100,16 +83,7 @@ impl Array {
     }
 
     /// Update the value at a given index in the array.
-    ///
-    /// Note that the `index` _must be_ of the array's `domain` sort,
-    /// and the `value` _must be_ of the array's `range` sort.
-    //
-    // We avoid the trinop! macro because the arguments have non-Self types
-    pub fn store<A1, A2>(&self, index: &A1, value: &A2) -> Self
-    where
-        A1: Ast,
-        A2: Ast,
-    {
+    pub fn store(&self, index: &D, value: &R) -> Self {
         unsafe {
             Self::wrap(&self.ctx, {
                 Z3_mk_store(
@@ -130,9 +104,9 @@ impl Array {
     /// # use z3::{ast, Config, Context, ast::{Array, Int}, Sort};
     /// # use z3::ast::Ast;
     /// # use std::convert::TryInto;
-    /// let arr = Array::const_array(&Sort::int().as_dyn(), &Int::from_u64(9));
+    /// let arr = Array::const_array(&Sort::int(), &Int::from_u64(9));
     /// assert!(arr.is_const_array());
-    /// let arr2 = Array::fresh_const("a", &Sort::int().as_dyn(), &Sort::int().as_dyn());
+    /// let arr2 = Array::fresh_const("a", &Sort::int(), &Sort::int());
     /// assert!(!arr2.is_const_array());
     /// ```
     pub fn is_const_array(&self) -> bool {

--- a/z3/src/ast/dynamic.rs
+++ b/z3/src/ast/dynamic.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Array, Ast, BV, Bool, Char, Datatype, Float, Int, Real, Seq, Set};
+use crate::ast::{Array, Ast, BV, Bool, Char, Datatype, Float, Int, Real, Seq, Set, SortMarker};
 use crate::{Context, Sort, Symbol, ast};
 use std::ffi::CString;
 use z3_sys::*;
@@ -49,116 +49,80 @@ impl Dynamic {
         }
     }
 
+    /// Attempt to narrow this `Dynamic` to a specific [`Ast`] type `T`, including a specific
+    /// parameterization of a generic type such as `Array<Int, Bool>` or `Seq<BV>`.
+    ///
+    /// Returns `None` if the runtime [`Sort`] of this value doesn't match what `T` requires.
+    /// For a parameterized `T` this recursively checks its domain/range/element marker types
+    /// too, so e.g. `narrow::<Array<Int, Bool>>()` only succeeds for arrays whose domain sort
+    /// is `Int` and whose range sort is `Bool` -- unlike [`Dynamic::as_array`], which can only
+    /// recover the fully-dynamic `Array<Dynamic, Dynamic>`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use z3::ast::{Array, Ast, Bool, Dynamic, Int};
+    /// # use z3::Sort;
+    /// let arr = Array::new_const("a", &Sort::int(), &Sort::bool());
+    /// let dyn_arr: Dynamic = arr.into();
+    /// assert!(dyn_arr.narrow::<Array<Int, Bool>>().is_some());
+    /// assert!(dyn_arr.narrow::<Array<Bool, Int>>().is_none());
+    /// ```
+    pub fn narrow<T: SortMarker>(&self) -> Option<T> {
+        T::sort_matches(&self.get_sort()).then(|| unsafe { T::wrap(&self.ctx, self.z3_ast) })
+    }
+
     /// Returns `None` if the `Dynamic` is not actually a `Bool`
     pub fn as_bool(&self) -> Option<Bool> {
-        match self.sort_kind() {
-            SortKind::Bool => Some(unsafe { Bool::wrap(&self.ctx, self.z3_ast) }),
-            _ => None,
-        }
+        self.narrow()
     }
 
     /// Returns `None` if the `Dynamic` is not actually an `Int`
     pub fn as_int(&self) -> Option<Int> {
-        match self.sort_kind() {
-            SortKind::Int => Some(unsafe { Int::wrap(&self.ctx, self.z3_ast) }),
-            _ => None,
-        }
+        self.narrow()
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `Real`
     pub fn as_real(&self) -> Option<Real> {
-        match self.sort_kind() {
-            SortKind::Real => Some(unsafe { Real::wrap(&self.ctx, self.z3_ast) }),
-            _ => None,
-        }
+        self.narrow()
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `Float`
     pub fn as_float(&self) -> Option<Float> {
-        match self.sort_kind() {
-            SortKind::FloatingPoint => Some(unsafe { Float::wrap(&self.ctx, self.z3_ast) }),
-            _ => None,
-        }
+        self.narrow()
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `Char`
     pub fn as_char(&self) -> Option<Char> {
-        unsafe {
-            if Z3_is_char_sort(
-                self.ctx.z3_ctx.as_ptr(),
-                Z3_get_sort(self.ctx.z3_ctx.as_ptr(), self.z3_ast)?,
-            ) {
-                Some(Char::wrap(&self.ctx, self.z3_ast))
-            } else {
-                None
-            }
-        }
+        self.narrow()
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `String`
     pub fn as_string(&self) -> Option<ast::String> {
-        unsafe {
-            if Z3_is_string_sort(
-                self.ctx.z3_ctx.as_ptr(),
-                Z3_get_sort(self.ctx.z3_ctx.as_ptr(), self.z3_ast)?,
-            ) {
-                Some(ast::String::wrap(&self.ctx, self.z3_ast))
-            } else {
-                None
-            }
-        }
+        self.narrow()
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `BV`
     pub fn as_bv(&self) -> Option<BV> {
-        match self.sort_kind() {
-            SortKind::Bv => Some(unsafe { BV::wrap(&self.ctx, self.z3_ast) }),
-            _ => None,
-        }
+        self.narrow()
     }
 
     /// Returns `None` if the `Dynamic` is not actually an `Array`
     pub fn as_array(&self) -> Option<Array> {
-        match self.sort_kind() {
-            SortKind::Array => Some(unsafe { Array::wrap(&self.ctx, self.z3_ast) }),
-            _ => None,
-        }
+        self.narrow()
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `Set`
     pub fn as_set(&self) -> Option<Set> {
-        unsafe {
-            match self.sort_kind() {
-                SortKind::Array => {
-                    match Z3_get_sort_kind(
-                        self.ctx.z3_ctx.as_ptr(),
-                        Z3_get_array_sort_range(
-                            self.ctx.z3_ctx.as_ptr(),
-                            Z3_get_sort(self.ctx.z3_ctx.as_ptr(), self.z3_ast)?,
-                        )?,
-                    ) {
-                        SortKind::Bool => Some(Set::wrap(&self.ctx, self.z3_ast)),
-                        _ => None,
-                    }
-                }
-                _ => None,
-            }
-        }
+        self.narrow()
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `Seq`.
     pub fn as_seq(&self) -> Option<Seq> {
-        match self.sort_kind() {
-            SortKind::Seq => Some(unsafe { Seq::wrap(&self.ctx, self.z3_ast) }),
-            _ => None,
-        }
+        self.narrow()
     }
 
     /// Returns `None` if the `Dynamic` is not actually a `Datatype`
     pub fn as_datatype(&self) -> Option<Datatype> {
-        match self.sort_kind() {
-            SortKind::Datatype => Some(unsafe { Datatype::wrap(&self.ctx, self.z3_ast) }),
-            _ => None,
-        }
+        self.narrow()
     }
 }

--- a/z3/src/ast/float.rs
+++ b/z3/src/ast/float.rs
@@ -40,7 +40,7 @@ impl Float {
     }
 
     /// A NaN (Not a Number) value of the given ([`Float`]) [`Sort`].
-    pub fn nan(sort: &Sort) -> Float {
+    pub fn nan(sort: &Sort<Float>) -> Float {
         let ctx = &Context::thread_local();
         assert!(matches!(sort.kind(), SortKind::FloatingPoint));
         unsafe { Self::wrap(ctx, Z3_mk_fpa_nan(ctx.z3_ctx.0, sort.z3_sort).unwrap()) }

--- a/z3/src/ast/mod.rs
+++ b/z3/src/ast/mod.rs
@@ -679,10 +679,10 @@ fn _atleast(args: &[Z3_ast], k: u32) -> Bool {
 /// # use z3::ast::Ast;
 /// # use std::convert::TryInto;
 /// # let solver = Solver::new();
-/// let f = FuncDecl::new("f", &[&Sort::int()], &Sort::int());
+/// let f = FuncDecl::new("f", Sort::int(), &Sort::int());
 ///
 /// let x = ast::Int::new_const("x");
-/// let f_x: ast::Int = f.apply(&[&x]).try_into().unwrap();
+/// let f_x: ast::Int = f.apply(x.clone());
 /// let f_x_pattern: Pattern = Pattern::new(&[ &f_x ]);
 /// let forall: ast::Bool = ast::forall_const(
 ///     &[&x],
@@ -694,7 +694,7 @@ fn _atleast(args: &[Z3_ast], k: u32) -> Bool {
 /// assert_eq!(solver.check(), SatResult::Sat);
 /// let model = solver.get_model().unwrap();
 ///
-/// let f_f_3: ast::Int = f.apply(&[&f.apply(&[&ast::Int::from_u64(3)])]).try_into().unwrap();
+/// let f_f_3: ast::Int = f.apply(f.apply(ast::Int::from_u64(3)));
 /// assert_eq!(3, model.eval(&f_f_3, true).unwrap().as_u64().unwrap());
 /// ```
 pub fn forall_const(bounds: &[&dyn Ast], patterns: &[&Pattern], body: &Bool) -> Bool {
@@ -735,10 +735,10 @@ pub fn forall_const(bounds: &[&dyn Ast], patterns: &[&Pattern], body: &Bool) -> 
 /// # use std::convert::TryInto;
 /// # let cfg = Config::new();
 /// # let solver = Solver::new();
-/// let f = FuncDecl::new("f", &[&Sort::int()], &Sort::int());
+/// let f = FuncDecl::new("f", Sort::int(), &Sort::int());
 ///
 /// let x = ast::Int::new_const("x");
-/// let f_x: ast::Int = f.apply(&[&x]).try_into().unwrap();
+/// let f_x: ast::Int = f.apply(x.clone());
 /// let f_x_pattern: Pattern = Pattern::new(&[ &f_x ]);
 /// let exists: ast::Bool = ast::exists_const(
 ///     &[&x],
@@ -750,7 +750,7 @@ pub fn forall_const(bounds: &[&dyn Ast], patterns: &[&Pattern], body: &Bool) -> 
 /// assert_eq!(solver.check(), SatResult::Sat);
 /// let model = solver.get_model().unwrap();
 ///
-/// let f_f_3: ast::Int = f.apply(&[&f.apply(&[&ast::Int::from_u64(3)])]).try_into().unwrap();
+/// let f_f_3: ast::Int = f.apply(f.apply(ast::Int::from_u64(3)));
 /// assert_eq!(3, model.eval(&f_f_3, true).unwrap().as_u64().unwrap());
 /// ```
 pub fn exists_const(bounds: &[&dyn Ast], patterns: &[&Pattern], body: &Bool) -> Bool {
@@ -800,10 +800,10 @@ pub fn exists_const(bounds: &[&dyn Ast], patterns: &[&Pattern], body: &Bool) -> 
 /// # use z3::ast::Ast;
 /// # use std::convert::TryInto;
 /// # let solver = Solver::new();
-/// let f = FuncDecl::new("f", &[&Sort::int()], &Sort::int());
+/// let f = FuncDecl::new("f", Sort::int(), &Sort::int());
 ///
 /// let x = ast::Int::new_const("x");
-/// let f_x: ast::Int = f.apply(&[&x]).try_into().unwrap();
+/// let f_x: ast::Int = f.apply(x.clone());
 /// let f_x_pattern: Pattern = Pattern::new(&[ &f_x ]);
 /// let forall: ast::Bool = ast::quantifier_const(
 ///     true,
@@ -820,7 +820,7 @@ pub fn exists_const(bounds: &[&dyn Ast], patterns: &[&Pattern], body: &Bool) -> 
 /// assert_eq!(solver.check(), SatResult::Sat);
 /// let model = solver.get_model().unwrap();
 ///
-/// let f_f_3: ast::Int = f.apply(&[&f.apply(&[&ast::Int::from_u64(3)])]).try_into().unwrap();
+/// let f_f_3: ast::Int = f.apply(f.apply(ast::Int::from_u64(3)));
 /// assert_eq!(3, model.eval(&f_f_3, true).unwrap().as_u64().unwrap());
 /// ```
 #[allow(clippy::too_many_arguments)]

--- a/z3/src/ast/mod.rs
+++ b/z3/src/ast/mod.rs
@@ -891,18 +891,31 @@ impl SortMarker for Dynamic {
     }
 }
 
+/// Look up the domain/range sorts of an `Array`-shaped `Sort`, or `None` if `sort` isn't
+/// actually an `Array` sort. Used by the `SortMarker` impls for `Array`/`Set` below, which
+/// can't yet assume the phantom marker is accurate -- that's exactly what they're checking.
+fn array_domain_and_range(sort: &Sort) -> Option<(Sort, Sort)> {
+    if sort.kind() != SortKind::Array {
+        return None;
+    }
+    unsafe {
+        let domain = Z3_get_array_sort_domain(sort.ctx.z3_ctx.as_ptr(), sort.z3_sort)?;
+        let range = Z3_get_array_sort_range(sort.ctx.z3_ctx.as_ptr(), sort.z3_sort)?;
+        Some((Sort::wrap(&sort.ctx, domain), Sort::wrap(&sort.ctx, range)))
+    }
+}
+
 impl<D: SortMarker, R: SortMarker> SortMarker for Array<D, R> {
     fn sort_matches(sort: &Sort) -> bool {
-        sort.array_domain().is_some_and(|d| D::sort_matches(&d))
-            && sort.array_range().is_some_and(|r| R::sort_matches(&r))
+        array_domain_and_range(sort)
+            .is_some_and(|(d, r)| D::sort_matches(&d) && R::sort_matches(&r))
     }
 }
 
 impl<Elt: SortMarker> SortMarker for Set<Elt> {
     fn sort_matches(sort: &Sort) -> bool {
-        sort.array_range()
-            .is_some_and(|r| r.kind() == SortKind::Bool)
-            && sort.array_domain().is_some_and(|d| Elt::sort_matches(&d))
+        array_domain_and_range(sort)
+            .is_some_and(|(d, r)| r.kind() == SortKind::Bool && Elt::sort_matches(&d))
     }
 }
 

--- a/z3/src/ast/mod.rs
+++ b/z3/src/ast/mod.rs
@@ -835,6 +835,91 @@ macro_rules! impl_into_dynamic_generic {
     };
 }
 
+/// A marker for [`Ast`] node types whose values always inhabit one particular, statically
+/// determinable [`Sort`] shape -- including, for generic node types like `Array<D, R>`, the
+/// shape of their domain/range/element marker types.
+///
+/// This is what lets [`Dynamic::narrow`] safely recover a specific parameterization such as
+/// `Array<Int, Bool>`, and not just the fully dynamic `Array<Dynamic, Dynamic>`: each impl
+/// below checks the actual runtime [`Sort`] against what `T` claims to represent before the
+/// underlying [`Z3_ast`] is reinterpreted as `T`.
+///
+/// [`Dynamic::narrow`]: dynamic::Dynamic::narrow
+pub trait SortMarker: Ast {
+    /// Returns `true` if `sort` is a [`Sort`] that a value of this type could have.
+    fn sort_matches(sort: &Sort) -> bool;
+}
+
+macro_rules! impl_sort_marker_by_kind {
+    ($($ast:ident => $kind:expr),+ $(,)?) => {
+        $(
+            impl SortMarker for $ast {
+                fn sort_matches(sort: &Sort) -> bool {
+                    sort.kind() == $kind
+                }
+            }
+        )+
+    };
+}
+
+impl_sort_marker_by_kind! {
+    Bool => SortKind::Bool,
+    Int => SortKind::Int,
+    Real => SortKind::Real,
+    Float => SortKind::FloatingPoint,
+    BV => SortKind::Bv,
+    Datatype => SortKind::Datatype,
+    Regexp => SortKind::Re,
+    RoundingMode => SortKind::RoundingMode,
+}
+
+impl SortMarker for Char {
+    fn sort_matches(sort: &Sort) -> bool {
+        unsafe { Z3_is_char_sort(sort.ctx.z3_ctx.as_ptr(), sort.z3_sort) }
+    }
+}
+
+impl SortMarker for String {
+    fn sort_matches(sort: &Sort) -> bool {
+        unsafe { Z3_is_string_sort(sort.ctx.z3_ctx.as_ptr(), sort.z3_sort) }
+    }
+}
+
+impl SortMarker for Dynamic {
+    fn sort_matches(_sort: &Sort) -> bool {
+        true
+    }
+}
+
+impl<D: SortMarker, R: SortMarker> SortMarker for Array<D, R> {
+    fn sort_matches(sort: &Sort) -> bool {
+        sort.array_domain().is_some_and(|d| D::sort_matches(&d))
+            && sort.array_range().is_some_and(|r| R::sort_matches(&r))
+    }
+}
+
+impl<Elt: SortMarker> SortMarker for Set<Elt> {
+    fn sort_matches(sort: &Sort) -> bool {
+        sort.array_range()
+            .is_some_and(|r| r.kind() == SortKind::Bool)
+            && sort.array_domain().is_some_and(|d| Elt::sort_matches(&d))
+    }
+}
+
+impl<Elt: SortMarker> SortMarker for Seq<Elt> {
+    fn sort_matches(sort: &Sort) -> bool {
+        if sort.kind() != SortKind::Seq {
+            return false;
+        }
+        let Some(basis) =
+            (unsafe { Z3_get_seq_sort_basis(sort.ctx.z3_ctx.as_ptr(), sort.z3_sort) })
+        else {
+            return false;
+        };
+        Elt::sort_matches(&unsafe { Sort::wrap(&sort.ctx, basis) })
+    }
+}
+
 impl_ast!(Bool);
 impl_from_try_into_dynamic!(Bool, as_bool);
 impl_ast!(Int);

--- a/z3/src/ast/mod.rs
+++ b/z3/src/ast/mod.rs
@@ -598,6 +598,243 @@ macro_rules! impl_from_try_into_dynamic {
     };
 }
 
+/// Like `impl_ast!`, but for `Ast` node types that are themselves generic over one or more
+/// marker type parameters (e.g. `Array<D, R>`, `Seq<Elt>`), which classify the sorts of the
+/// values the node carries (its index/element sorts) the same way `Sort<A>`'s own marker `A`
+/// classifies the sort itself. None of the boilerplate below actually needs to touch the
+/// marker parameters (they're phantom-only), so no bounds are required on them.
+macro_rules! impl_ast_generic {
+    ($ast:ident < $($param:ident),+ >) => {
+        impl<$($param),+> Ast for $ast<$($param),+> {
+            unsafe fn wrap(ctx: &Context, ast: Z3_ast) -> Self {
+                Self {
+                    ctx: ctx.clone(),
+                    z3_ast: {
+                        debug!(
+                            "new ast: id = {}, pointer = {:p}",
+                            unsafe { Z3_get_ast_id(ctx.z3_ctx.as_ptr(), ast) },
+                            ast
+                        );
+                        unsafe {
+                            Z3_inc_ref(ctx.z3_ctx.as_ptr(), ast);
+                        }
+                        ast
+                    },
+                    phantom: std::marker::PhantomData,
+                }
+            }
+
+            fn eq<T: IntoAst<Self>>(&self, other: T) -> Bool
+            where
+                Self: Sized,
+            {
+                self.eq(other)
+            }
+
+            fn ne<T: IntoAst<Self>>(&self, other: T) -> Bool
+            where
+                Self: Sized,
+            {
+                self.ne(other)
+            }
+
+            fn get_ctx(&self) -> &Context {
+                &self.ctx
+            }
+
+            fn get_z3_ast(&self) -> Z3_ast {
+                self.z3_ast
+            }
+        }
+
+        impl<$($param),+> $ast<$($param),+> {
+            pub fn ast_eq<T: IntoAst<Self>>(&self, other: T) -> bool
+            where
+                Self: Sized,
+            {
+                let other = other.into_ast(self);
+                assert_eq!(self.get_ctx(), other.get_ctx());
+                unsafe {
+                    Z3_is_eq_ast(
+                        self.get_ctx().z3_ctx.as_ptr(),
+                        self.get_z3_ast(),
+                        other.get_z3_ast(),
+                    )
+                }
+            }
+
+            pub fn ne<T: IntoAst<Self>>(&self, other: T) -> Bool
+            where
+                Self: Sized,
+            {
+                self.eq(other).not()
+            }
+
+            #[deprecated = "Please use eq instead"]
+            pub fn _eq<T: IntoAst<Self>>(&self, other: T) -> Bool
+            where
+                Self: Sized,
+            {
+                self.eq(other)
+            }
+
+            /// Compare this `Ast` with another `Ast`, and get a [`Bool`]
+            /// representing the result.
+            ///
+            /// This operation works with all possible `Ast`s (int, real, BV, etc), but the two
+            /// `Ast`s being compared must be the same type.
+            pub fn eq<T: IntoAst<Self>>(&self, other: T) -> Bool
+            where
+                Self: Sized,
+            {
+                self.safe_eq(other).unwrap()
+            }
+
+            #[deprecated = "Please use safe_eq instead"]
+            pub fn _safe_eq<T: IntoAst<Self>>(&self, other: T) -> Result<Bool, SortDiffers>
+            where
+                Self: Sized,
+            {
+                self.safe_eq(other)
+            }
+
+            /// Compare this `Ast` with another `Ast`, and get a Result.  Errors if the sort does not
+            /// match for the two values.
+            pub fn safe_eq<T: IntoAst<Self>>(&self, other: T) -> Result<Bool, SortDiffers>
+            where
+                Self: Sized,
+            {
+                let other = other.into_ast(self);
+
+                let left_sort = self.get_sort();
+                let right_sort = other.get_sort();
+                match left_sort == right_sort {
+                    true => Ok(unsafe {
+                        Bool::wrap(self.get_ctx(), {
+                            Z3_mk_eq(
+                                self.get_ctx().z3_ctx.as_ptr(),
+                                self.get_z3_ast(),
+                                other.get_z3_ast(),
+                            )
+                            .unwrap()
+                        })
+                    }),
+                    false => Err(SortDiffers::new(left_sort, right_sort)),
+                }
+            }
+        }
+
+        impl<T: IntoAst<$ast<$($param),+>> + Clone, $($param),+> PartialEq<T> for $ast<$($param),+> {
+            fn eq(&self, other: &T) -> bool {
+                let other = other.clone().into_ast(self);
+                unsafe { Z3_is_eq_ast(self.ctx.z3_ctx.as_ptr(), self.z3_ast, other.z3_ast) }
+            }
+        }
+
+        impl<$($param),+> Eq for $ast<$($param),+> {}
+
+        impl<$($param),+> From<$ast<$($param),+>> for Z3_ast {
+            fn from(ast: $ast<$($param),+>) -> Self {
+                ast.z3_ast
+            }
+        }
+
+        impl<$($param),+> Clone for $ast<$($param),+> {
+            fn clone(&self) -> Self {
+                debug!(
+                    "clone ast: id = {}, pointer = {:p}",
+                    unsafe { Z3_get_ast_id(self.ctx.z3_ctx.as_ptr(), self.z3_ast) },
+                    self.z3_ast
+                );
+                unsafe { Self::wrap(&self.ctx, self.z3_ast) }
+            }
+        }
+
+        impl<$($param),+> Drop for $ast<$($param),+> {
+            fn drop(&mut self) {
+                debug!(
+                    "drop ast: id = {}, pointer = {:p}",
+                    unsafe { Z3_get_ast_id(self.ctx.z3_ctx.as_ptr(), self.z3_ast) },
+                    self.z3_ast
+                );
+                unsafe {
+                    Z3_dec_ref(self.ctx.z3_ctx.as_ptr(), self.z3_ast);
+                }
+            }
+        }
+
+        impl<$($param),+> Hash for $ast<$($param),+> {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                unsafe {
+                    let u = Z3_get_ast_hash(self.ctx.z3_ctx.as_ptr(), self.z3_ast);
+                    u.hash(state);
+                }
+            }
+        }
+
+        impl<$($param),+> fmt::Debug for $ast<$($param),+> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+                let p = unsafe { Z3_ast_to_string(self.ctx.z3_ctx.as_ptr(), self.z3_ast) };
+                if p.is_null() {
+                    return Result::Err(fmt::Error);
+                }
+                match unsafe { CStr::from_ptr(p) }.to_str() {
+                    Ok(s) => write!(f, "{}", s),
+                    Err(_) => Result::Err(fmt::Error),
+                }
+            }
+        }
+
+        impl<$($param),+> fmt::Display for $ast<$($param),+> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+                <Self as fmt::Debug>::fmt(self, f)
+            }
+        }
+
+        impl<$($param),+> From<&$ast<$($param),+>> for $ast<$($param),+> {
+            fn from(value: &Self) -> Self {
+                value.clone()
+            }
+        }
+
+        impl<$($param),+> Solvable for $ast<$($param),+> {
+            type ModelInstance = Self;
+            fn read_from_model(
+                &self,
+                model: &Model,
+                model_completion: bool,
+            ) -> Option<Self::ModelInstance> {
+                model.eval(self, model_completion)
+            }
+
+            fn generate_constraint(&self, model: &Self::ModelInstance) -> Bool {
+                model.eq(self.clone()).not()
+            }
+        }
+    };
+}
+
+/// Upcast a generic `Ast` node type (see `impl_ast_generic!`) to `Dynamic`, for any
+/// instantiation of its marker type parameters. The reverse direction (`TryFrom<Dynamic>`)
+/// can only recover the fully-dynamic instantiation, since Z3 doesn't hand back static
+/// domain/range/element types from a `Dynamic` value -- see the manual `TryFrom` impls next
+/// to each `impl_ast_generic!` call below.
+macro_rules! impl_into_dynamic_generic {
+    ($ast:ident < $($param:ident),+ >) => {
+        impl<$($param),+> From<$ast<$($param),+>> for Dynamic {
+            fn from(ast: $ast<$($param),+>) -> Self {
+                unsafe { Dynamic::wrap(&ast.ctx, ast.z3_ast) }
+            }
+        }
+
+        impl<$($param),+> From<&$ast<$($param),+>> for Dynamic {
+            fn from(ast: &$ast<$($param),+>) -> Self {
+                unsafe { Dynamic::wrap(&ast.ctx, ast.z3_ast) }
+            }
+        }
+    };
+}
+
 impl_ast!(Bool);
 impl_from_try_into_dynamic!(Bool, as_bool);
 impl_ast!(Int);
@@ -612,12 +849,37 @@ impl_ast!(Char);
 impl_from_try_into_dynamic!(Char, as_char);
 impl_ast!(BV);
 impl_from_try_into_dynamic!(BV, as_bv);
-impl_ast!(Array);
-impl_from_try_into_dynamic!(Array, as_array);
-impl_ast!(Set);
-impl_from_try_into_dynamic!(Set, as_set);
-impl_ast!(Seq);
-impl_from_try_into_dynamic!(Seq, as_seq);
+
+impl_ast_generic!(Array<D, R>);
+impl_into_dynamic_generic!(Array<D, R>);
+impl TryFrom<Dynamic> for Array {
+    type Error = std::string::String;
+    fn try_from(ast: Dynamic) -> Result<Self, std::string::String> {
+        ast.as_array()
+            .ok_or_else(|| format!("Dynamic is not of requested type: {:?}", ast))
+    }
+}
+
+impl_ast_generic!(Set<Elt>);
+impl_into_dynamic_generic!(Set<Elt>);
+impl TryFrom<Dynamic> for Set {
+    type Error = std::string::String;
+    fn try_from(ast: Dynamic) -> Result<Self, std::string::String> {
+        ast.as_set()
+            .ok_or_else(|| format!("Dynamic is not of requested type: {:?}", ast))
+    }
+}
+
+impl_ast_generic!(Seq<Elt>);
+impl_into_dynamic_generic!(Seq<Elt>);
+impl TryFrom<Dynamic> for Seq {
+    type Error = std::string::String;
+    fn try_from(ast: Dynamic) -> Result<Self, std::string::String> {
+        ast.as_seq()
+            .ok_or_else(|| format!("Dynamic is not of requested type: {:?}", ast))
+    }
+}
+
 impl_ast!(Regexp);
 
 impl_ast!(Datatype);

--- a/z3/src/ast/seq.rs
+++ b/z3/src/ast/seq.rs
@@ -2,15 +2,17 @@ use crate::ast::{Ast, Dynamic, Int, varop};
 use crate::ast::{Bool, IntoAst};
 use crate::{Context, Sort, Symbol};
 use std::ffi::CString;
+use std::marker::PhantomData;
 use z3_sys::*;
 
-/// [`Ast`] node representing a sequence value.
-pub struct Seq {
+/// [`Ast`] node representing a sequence value, whose elements are all of sort `Elt`.
+pub struct Seq<Elt = Dynamic> {
     pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
+    pub(crate) phantom: PhantomData<Elt>,
 }
-impl Seq {
-    pub fn new_const<S: Into<Symbol>>(name: S, eltype: &Sort) -> Self {
+impl<Elt: Ast> Seq<Elt> {
+    pub fn new_const<S: Into<Symbol>>(name: S, eltype: &Sort<Elt>) -> Self {
         let ctx = &Context::thread_local();
         let sort = Sort::seq(eltype);
         unsafe {
@@ -25,7 +27,7 @@ impl Seq {
         }
     }
 
-    pub fn fresh_const(prefix: &str, eltype: &Sort) -> Self {
+    pub fn fresh_const(prefix: &str, eltype: &Sort<Elt>) -> Self {
         let ctx = &Context::thread_local();
         let sort = Sort::seq(eltype);
         unsafe {
@@ -43,14 +45,14 @@ impl Seq {
     /// use z3::{ast, Config, Context, Solver, Sort};
     /// use z3::ast::{Ast, Seq};
     /// let solver = Solver::new();
-    /// let empty_seq = Seq::empty(&Sort::int().as_dyn());
-    /// let any_seq = Seq::new_const("any_seq", &Sort::int().as_dyn());
+    /// let empty_seq = Seq::empty(&Sort::int());
+    /// let any_seq = Seq::new_const("any_seq", &Sort::int());
     /// let concatenated = Seq::concat(&[&empty_seq, &any_seq]);
     ///
     /// solver.assert(&concatenated._eq(&any_seq));
     /// assert_eq!(solver.check(), z3::SatResult::Sat);
     /// ```
-    pub fn empty(eltype: &Sort) -> Self {
+    pub fn empty(eltype: &Sort<Elt>) -> Self {
         let ctx = &Context::thread_local();
         let sort = Sort::seq(eltype);
         unsafe {
@@ -62,7 +64,7 @@ impl Seq {
     }
 
     /// Create a unit sequence of `a`.
-    pub fn unit<A: Ast>(a: &A) -> Self {
+    pub fn unit(a: &Elt) -> Self {
         let ctx = &Context::thread_local();
         unsafe {
             Self::wrap(
@@ -90,19 +92,17 @@ impl Seq {
     /// # use z3::{ast, Config, Context, Solver, Sort};
     /// # use z3::ast::{Ast, Bool, Int, Seq};
     /// # let solver = Solver::new();
-    /// let seq = Seq::fresh_const("", &Sort::bool().as_dyn());
+    /// let seq = Seq::fresh_const("", &Sort::bool());
     ///
     /// solver.assert(
     ///     &seq.nth(0)
     ///         .simplify()
-    ///         .as_bool()
-    ///         .unwrap()
     /// );
     /// ```
-    pub fn nth<T: Into<Int>>(&self, index: T) -> Dynamic {
+    pub fn nth<T: Into<Int>>(&self, index: T) -> Elt {
         let index = index.into();
         unsafe {
-            Dynamic::wrap(
+            Elt::wrap(
                 &self.ctx,
                 Z3_mk_seq_nth(self.ctx.z3_ctx.as_ptr(), self.z3_ast, index.z3_ast).unwrap(),
             )

--- a/z3/src/ast/seq.rs
+++ b/z3/src/ast/seq.rs
@@ -38,8 +38,8 @@ impl Seq {
     /// use z3::{ast, Config, Context, Solver, Sort};
     /// use z3::ast::{Ast, Seq};
     /// let solver = Solver::new();
-    /// let empty_seq = Seq::empty(&Sort::int());
-    /// let any_seq = Seq::new_const("any_seq", &Sort::int());
+    /// let empty_seq = Seq::empty(&Sort::int().as_dyn());
+    /// let any_seq = Seq::new_const("any_seq", &Sort::int().as_dyn());
     /// let concatenated = Seq::concat(&[&empty_seq, &any_seq]);
     ///
     /// solver.assert(&concatenated._eq(&any_seq));
@@ -75,7 +75,7 @@ impl Seq {
     /// # use z3::{ast, Config, Context, Solver, Sort};
     /// # use z3::ast::{Ast, Bool, Int, Seq};
     /// # let solver = Solver::new();
-    /// let seq = Seq::fresh_const("", &Sort::bool());
+    /// let seq = Seq::fresh_const("", &Sort::bool().as_dyn());
     ///
     /// solver.assert(
     ///     &seq.nth(0)

--- a/z3/src/ast/set.rs
+++ b/z3/src/ast/set.rs
@@ -1,16 +1,18 @@
-use crate::ast::{Ast, Bool, binop, unop, varop};
+use crate::ast::{Ast, Bool, Dynamic, binop, unop, varop};
 use crate::{Context, Sort, Symbol};
 use std::ffi::CString;
+use std::marker::PhantomData;
 use z3_sys::*;
 
-/// [`Ast`] node representing a set value.
-pub struct Set {
+/// [`Ast`] node representing a set value, whose elements are all of sort `Elt`.
+pub struct Set<Elt = Dynamic> {
     pub(crate) ctx: Context,
     pub(crate) z3_ast: Z3_ast,
+    pub(crate) phantom: PhantomData<Elt>,
 }
 
-impl Set {
-    pub fn new_const<S: Into<Symbol>>(name: S, eltype: &Sort) -> Set {
+impl<Elt: Ast> Set<Elt> {
+    pub fn new_const<S: Into<Symbol>>(name: S, eltype: &Sort<Elt>) -> Set<Elt> {
         let ctx = &Context::thread_local();
         let sort = Sort::set(eltype);
         unsafe {
@@ -25,7 +27,7 @@ impl Set {
         }
     }
 
-    pub fn fresh_const(prefix: &str, eltype: &Sort) -> Set {
+    pub fn fresh_const(prefix: &str, eltype: &Sort<Elt>) -> Set<Elt> {
         let ctx = &Context::thread_local();
         let sort = Sort::set(eltype);
         unsafe {
@@ -38,25 +40,20 @@ impl Set {
     }
 
     /// Creates a set that maps the domain to false by default
-    pub fn empty(domain: &Sort) -> Set {
+    pub fn empty(eltype: &Sort<Elt>) -> Set<Elt> {
         let ctx = &Context::thread_local();
         unsafe {
             Self::wrap(
                 ctx,
-                Z3_mk_empty_set(ctx.z3_ctx.as_ptr(), domain.z3_sort).unwrap(),
+                Z3_mk_empty_set(ctx.z3_ctx.as_ptr(), eltype.z3_sort).unwrap(),
             )
         }
     }
 
     /// Add an element to the set.
-    ///
-    /// Note that the `element` _must be_ of the `Set`'s `eltype` sort.
     //
     // We avoid the binop! macro because the argument has a non-Self type
-    pub fn add<A>(&self, element: &A) -> Set
-    where
-        A: Ast,
-    {
+    pub fn add(&self, element: &Elt) -> Set<Elt> {
         unsafe {
             Self::wrap(&self.ctx, {
                 Z3_mk_set_add(self.ctx.z3_ctx.as_ptr(), self.z3_ast, element.get_z3_ast()).unwrap()
@@ -65,14 +62,9 @@ impl Set {
     }
 
     /// Remove an element from the set.
-    ///
-    /// Note that the `element` _must be_ of the `Set`'s `eltype` sort.
     //
     // We avoid the binop! macro because the argument has a non-Self type
-    pub fn del<A>(&self, element: &A) -> Set
-    where
-        A: Ast,
-    {
+    pub fn del(&self, element: &Elt) -> Set<Elt> {
         unsafe {
             Self::wrap(&self.ctx, {
                 Z3_mk_set_del(self.ctx.z3_ctx.as_ptr(), self.z3_ast, element.get_z3_ast()).unwrap()
@@ -81,14 +73,9 @@ impl Set {
     }
 
     /// Check if an item is a member of the set.
-    ///
-    /// Note that the `element` _must be_ of the `Set`'s `eltype` sort.
     //
     // We avoid the binop! macro because the argument has a non-Self type
-    pub fn member<A>(&self, element: &A) -> Bool
-    where
-        A: Ast,
-    {
+    pub fn member(&self, element: &Elt) -> Bool {
         unsafe {
             Bool::wrap(&self.ctx, {
                 Z3_mk_set_member(self.ctx.z3_ctx.as_ptr(), element.get_z3_ast(), self.z3_ast)

--- a/z3/src/datatype_builder/mod.rs
+++ b/z3/src/datatype_builder/mod.rs
@@ -12,7 +12,7 @@
 //! ```rust
 //! use z3::{Sort, DatatypeAccessor, DatatypeBuilder, Symbol};
 //! let dt = DatatypeBuilder::new("my_datatype")
-//!     .variant("case1", vec![("field1", DatatypeAccessor::sort(Sort::int()))])
+//!     .variant("case1", vec![("field1", DatatypeAccessor::sort(Sort::int().as_dyn()))])
 //!     .variant("case2", vec![("field2", DatatypeAccessor::datatype("my_datatype"))])
 //!     .finish();
 //! ```

--- a/z3/src/func_decl.rs
+++ b/z3/src/func_decl.rs
@@ -4,8 +4,183 @@ use std::fmt;
 use std::{borrow::Borrow, ffi::c_uint};
 use z3_sys::*;
 
+use crate::ast::{Array, BV, Bool, Char, Datatype, Dynamic, Float, Int, Real, Seq, Set};
 use crate::{Context, FuncDecl, Sort, Symbol, Translate, ast, ast::Ast};
-impl FuncDecl {
+
+/// Describes the argument-list shape of a [`FuncDecl`]'s domain, and how to convert between
+/// it and the untyped [`Dynamic`] values Z3's FFI actually deals in.
+///
+/// Implemented for `()` (nullary), `Sort<A>` (a single typed argument), tuples of
+/// `FuncDeclDomain` up to arity 6 (multiple typed arguments), and `Vec<Sort<Dynamic>>`
+/// (the dynamic-arity bottom case, and the default domain for [`FuncDecl`]).
+pub trait FuncDeclDomain {
+    /// The type `apply` accepts for this domain shape.
+    type ApplicationParam;
+
+    fn application_args(a: Self::ApplicationParam) -> Vec<Dynamic>;
+
+    fn sorts(&self) -> Vec<Sort<Dynamic>>;
+}
+
+/// Describes how a [`FuncDecl`]'s range is recovered from the untyped [`Dynamic`] value
+/// `Z3_mk_app` actually produces.
+///
+/// Implemented for every concrete [`Ast`] type that has a `Dynamic::as_*` conversion, and for
+/// `Dynamic` itself (the identity/bottom case, and the default range for [`FuncDecl`]).
+pub trait FuncDeclReturn: Ast {
+    fn process(d: Dynamic) -> Self;
+}
+
+impl FuncDeclDomain for () {
+    type ApplicationParam = ();
+
+    fn application_args(_a: Self::ApplicationParam) -> Vec<Dynamic> {
+        vec![]
+    }
+
+    fn sorts(&self) -> Vec<Sort<Dynamic>> {
+        vec![]
+    }
+}
+
+impl<A: Ast + Clone> FuncDeclDomain for Sort<A> {
+    type ApplicationParam = A;
+
+    fn application_args(a: Self::ApplicationParam) -> Vec<Dynamic> {
+        vec![Dynamic::from_ast(&a)]
+    }
+
+    fn sorts(&self) -> Vec<Sort<Dynamic>> {
+        vec![self.as_dyn()]
+    }
+}
+
+impl FuncDeclDomain for Vec<Sort<Dynamic>> {
+    type ApplicationParam = Vec<Dynamic>;
+
+    fn application_args(a: Self::ApplicationParam) -> Vec<Dynamic> {
+        a
+    }
+
+    fn sorts(&self) -> Vec<Sort<Dynamic>> {
+        self.clone()
+    }
+}
+
+// Macro to implement `FuncDeclDomain` for tuples of `FuncDeclDomain`.
+macro_rules! impl_func_decl_domain_for_tuples {
+    ($(($($T:ident),+)),+ $(,)?) => {
+        $(
+            impl<$($T: FuncDeclDomain),+> FuncDeclDomain for ($($T,)+) {
+                type ApplicationParam = ($($T::ApplicationParam,)+);
+
+                #[allow(non_snake_case)]
+                fn application_args(a: Self::ApplicationParam) -> Vec<Dynamic> {
+                    let ($($T,)+) = a;
+                    let mut args = Vec::new();
+                    $(
+                        args.extend($T::application_args($T));
+                    )+
+                    args
+                }
+
+                #[allow(non_snake_case)]
+                fn sorts(&self) -> Vec<Sort<Dynamic>> {
+                    let ($($T,)+) = self;
+                    let mut sorts = Vec::new();
+                    $(
+                        sorts.extend($T.sorts());
+                    )+
+                    sorts
+                }
+            }
+        )+
+    };
+}
+
+// Implement for tuples up to arity 6 (can be extended as needed).
+impl_func_decl_domain_for_tuples!(
+    (A),
+    (A, B),
+    (A, B, C),
+    (A, B, C, D),
+    (A, B, C, D, E),
+    (A, B, C, D, E, F)
+);
+
+impl FuncDeclReturn for Bool {
+    fn process(d: Dynamic) -> Self {
+        d.as_bool().unwrap()
+    }
+}
+
+impl FuncDeclReturn for Int {
+    fn process(d: Dynamic) -> Self {
+        d.as_int().unwrap()
+    }
+}
+
+impl FuncDeclReturn for Real {
+    fn process(d: Dynamic) -> Self {
+        d.as_real().unwrap()
+    }
+}
+
+impl FuncDeclReturn for BV {
+    fn process(d: Dynamic) -> Self {
+        d.as_bv().unwrap()
+    }
+}
+
+impl FuncDeclReturn for Float {
+    fn process(d: Dynamic) -> Self {
+        d.as_float().unwrap()
+    }
+}
+
+impl FuncDeclReturn for Char {
+    fn process(d: Dynamic) -> Self {
+        d.as_char().unwrap()
+    }
+}
+
+impl FuncDeclReturn for ast::String {
+    fn process(d: Dynamic) -> Self {
+        d.as_string().unwrap()
+    }
+}
+
+impl FuncDeclReturn for Seq {
+    fn process(d: Dynamic) -> Self {
+        d.as_seq().unwrap()
+    }
+}
+
+impl FuncDeclReturn for Set {
+    fn process(d: Dynamic) -> Self {
+        d.as_set().unwrap()
+    }
+}
+
+impl FuncDeclReturn for Array {
+    fn process(d: Dynamic) -> Self {
+        d.as_array().unwrap()
+    }
+}
+
+impl FuncDeclReturn for Datatype {
+    fn process(d: Dynamic) -> Self {
+        d.as_datatype().unwrap()
+    }
+}
+
+impl FuncDeclReturn for Dynamic {
+    fn process(d: Dynamic) -> Self {
+        d
+    }
+}
+
+impl<A: FuncDeclDomain, R: FuncDeclReturn> FuncDecl<A, R> {
     pub(crate) unsafe fn wrap(ctx: &Context, z3_func_decl: Z3_func_decl) -> Self {
         unsafe {
             Z3_inc_ref(
@@ -16,15 +191,17 @@ impl FuncDecl {
         Self {
             ctx: ctx.clone(),
             z3_func_decl,
+            phantom_a: std::marker::PhantomData,
+            phantom_r: std::marker::PhantomData,
         }
     }
 
-    pub fn new<S: Into<Symbol>>(name: S, domain: &[&Sort], range: &Sort) -> Self {
+    pub fn new<S: Into<Symbol>, RS: Borrow<Sort<R>>>(name: S, domain: A, range: RS) -> Self {
         let ctx = &Context::thread_local();
-        assert!(domain.iter().all(|s| s.ctx.z3_ctx == ctx.z3_ctx));
+        let range = range.borrow();
         assert_eq!(ctx.z3_ctx, range.ctx.z3_ctx);
 
-        let domain: Vec<_> = domain.iter().map(|s| s.z3_sort).collect();
+        let domain: Vec<_> = domain.sorts().iter().map(Sort::get_z3_sort).collect();
         unsafe {
             Self::wrap(
                 ctx,
@@ -40,160 +217,6 @@ impl FuncDecl {
         }
     }
 
-    /// Create a partial order [`FuncDecl`] "Special Relation" over the given [`Sort`].
-    ///
-    /// The [`Sort`] may have many
-    /// partial orders derived this way, distinguished by the second integer argument to this call,
-    /// which represents the "id" of the partial order. Calling this twice with the same ID will
-    /// yield the same partial order [`FuncDecl`].
-    ///
-    /// See <https://microsoft.github.io/z3guide/docs/theories/Special%20Relations/> for more info.
-    ///
-    /// A partial order is a binary relation that is reflexive, antisymmetric, and transitive.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use z3::{FuncDecl, Sort, Solver, SatResult, Symbol};
-    /// # use z3::ast::{Bool, Int};
-    ///
-    ///   let sort = Sort::int();
-    ///   let partial_order = FuncDecl::partial_order(&sort, 0);
-    ///   // Create a solver to assert properties of the partial order.
-    ///   let solver = Solver::new();
-    ///   let x = Int::new_const("x");
-    ///   let y = Int::new_const("y");
-    ///   let z = Int::new_const("z");
-    ///
-    ///   solver.assert(&partial_order.apply(&[&x, &x]).as_bool().unwrap());
-    ///   // test reflexivity
-    ///   assert_eq!(
-    ///       solver.check_assumptions(&[partial_order.apply(&[&x, &x]).as_bool().unwrap().not()]),
-    ///       SatResult::Unsat
-    ///   );
-    ///
-    ///   // test antisymmetry
-    ///   assert_eq!(
-    ///       solver.check_assumptions(&[
-    ///           partial_order.apply(&[&x, &y]).as_bool().unwrap(),
-    ///           partial_order.apply(&[&y, &x]).as_bool().unwrap(),
-    ///           x.eq(&y).not()
-    ///       ]),
-    ///       SatResult::Unsat
-    ///   );
-    ///
-    ///   // test transitivity
-    ///   assert_eq!(
-    ///       solver.check_assumptions(&[
-    ///           partial_order.apply(&[&x, &y]).as_bool().unwrap(),
-    ///           partial_order.apply(&[&y, &z]).as_bool().unwrap(),
-    ///           partial_order.apply(&[&x, &z]).as_bool().unwrap().not(),
-    ///       ]),
-    ///       SatResult::Unsat
-    ///   );
-    /// ```
-    ///
-    /// # See also
-    ///
-    /// - [`piecewise_linear_order`](Self::piecewise_linear_order)
-    /// - [`linear_order`](Self::linear_order)
-    /// - [`tree_order`](Self::tree_order)
-    /// - [`transitive_closure`](Self::transitive_closure)
-    pub fn partial_order<A: Borrow<Sort>>(a: A, id: usize) -> Self {
-        let a = a.borrow();
-        let ctx = &a.ctx;
-        unsafe {
-            Self::wrap(
-                ctx,
-                Z3_mk_partial_order(ctx.z3_ctx.0, a.z3_sort, id as u32).unwrap(),
-            )
-        }
-    }
-
-    /// Create a piecewise linear order [`FuncDecl`] "Special Relation" over the given [`Sort`].
-    ///
-    /// See <https://microsoft.github.io/z3guide/docs/theories/Special%20Relations/> for more info.
-    ///
-    /// # See also
-    ///
-    /// - [`partial_order`](Self::partial_order)
-    /// - [`linear_order`](Self::linear_order)
-    /// - [`tree_order`](Self::tree_order)
-    /// - [`transitive_closure`](Self::transitive_closure)
-    pub fn piecewise_linear_order<A: Borrow<Sort>>(a: A, id: usize) -> Self {
-        let a = a.borrow();
-        let ctx = &a.ctx;
-        unsafe {
-            Self::wrap(
-                ctx,
-                Z3_mk_piecewise_linear_order(ctx.z3_ctx.0, a.z3_sort, id as u32).unwrap(),
-            )
-        }
-    }
-
-    /// Create a linear order [`FuncDecl`] "Special Relation" over the given [`Sort`].
-    ///
-    /// See <https://microsoft.github.io/z3guide/docs/theories/Special%20Relations/> for more info.
-    ///
-    /// # See also
-    ///
-    /// - [`partial_order`](Self::partial_order)
-    /// - [`piecewise_linear_order`](Self::piecewise_linear_order)
-    /// - [`tree_order`](Self::tree_order)
-    /// - [`transitive_closure`](Self::transitive_closure)
-    pub fn linear_order<A: Borrow<Sort>>(a: A, id: usize) -> Self {
-        let a = a.borrow();
-        let ctx = &a.ctx;
-        unsafe {
-            Self::wrap(
-                ctx,
-                Z3_mk_linear_order(ctx.z3_ctx.0, a.z3_sort, id as u32).unwrap(),
-            )
-        }
-    }
-
-    /// Create a tree order [`FuncDecl`] "Special Relation" over the given [`Sort`].
-    ///
-    /// See <https://microsoft.github.io/z3guide/docs/theories/Special%20Relations/> for more info.
-    ///
-    /// # See also
-    ///
-    /// - [`partial_order`](Self::partial_order)
-    /// - [`piecewise_linear_order`](Self::piecewise_linear_order)
-    /// - [`linear_order`](Self::linear_order)
-    /// - [`transitive_closure`](Self::transitive_closure)
-    pub fn tree_order<A: Borrow<Sort>>(a: A, id: usize) -> Self {
-        let a = a.borrow();
-        let ctx = &a.ctx;
-        unsafe {
-            Self::wrap(
-                ctx,
-                Z3_mk_tree_order(ctx.z3_ctx.0, a.z3_sort, id as u32).unwrap(),
-            )
-        }
-    }
-
-    /// Create a transitive closure [`FuncDecl`] "Special Relation" over the given [`FuncDecl`].
-    ///
-    /// See <https://microsoft.github.io/z3guide/docs/theories/Special%20Relations/> for more info.
-    ///
-    /// # See also
-    ///
-    /// - [`partial_order`](Self::partial_order)
-    /// - [`piecewise_linear_order`](Self::piecewise_linear_order)
-    /// - [`linear_order`](Self::linear_order)
-    /// - [`tree_order`](Self::tree_order)
-    pub fn transitive_closure<A: Borrow<FuncDecl>>(a: A) -> Self {
-        let a = a.borrow();
-        let ctx = &a.ctx;
-        unsafe {
-            Self::wrap(
-                ctx,
-                Z3_mk_transitive_closure(ctx.z3_ctx.0, a.z3_func_decl).unwrap(),
-            )
-        }
-    }
-
     /// Return the number of arguments of a function declaration.
     ///
     /// If the function declaration is a constant, then the arity is `0`.
@@ -202,8 +225,8 @@ impl FuncDecl {
     /// # use z3::{Config, Context, FuncDecl, Solver, Sort, Symbol};
     /// let f = FuncDecl::new(
     ///     "f",
-    ///     &[&Sort::int(), &Sort::real()],
-    ///     &Sort::int());
+    ///     vec![Sort::int().as_dyn(), Sort::real().as_dyn()],
+    ///     Sort::int());
     /// assert_eq!(f.arity(), 2);
     /// ```
     pub fn arity(&self) -> usize {
@@ -213,18 +236,25 @@ impl FuncDecl {
     /// Create a constant (if `args` has length 0) or function application (otherwise).
     ///
     /// Note that `args` should have the types corresponding to the `domain` of the `FuncDecl`.
-    pub fn apply(&self, args: &[&dyn ast::Ast]) -> ast::Dynamic {
-        assert!(args.iter().all(|s| s.get_ctx().z3_ctx == self.ctx.z3_ctx));
+    pub fn apply(&self, args: A::ApplicationParam) -> R {
+        let a = A::application_args(args);
+        let d = self.apply_internal(a.into_iter());
+        R::process(d)
+    }
 
-        let args: Vec<_> = args.iter().map(|a| a.get_z3_ast()).collect();
+    fn apply_internal<I: Iterator<Item = Dynamic>>(&self, args: I) -> ast::Dynamic {
+        // Collect Dynamics first to keep them alive (and thus their Z3_ast refcounts > 0)
+        // until after Z3_mk_app returns.
+        let dynamics: Vec<Dynamic> = args.collect();
+        let ast_ptrs: Vec<_> = dynamics.iter().map(|a| a.get_z3_ast()).collect();
 
         unsafe {
             ast::Dynamic::wrap(&self.ctx, {
                 Z3_mk_app(
                     self.ctx.z3_ctx.0,
                     self.z3_func_decl,
-                    args.len().try_into().unwrap(),
-                    args.as_ptr(),
+                    ast_ptrs.len().try_into().unwrap(),
+                    ast_ptrs.as_ptr(),
                 )
                 .unwrap()
             })
@@ -285,7 +315,169 @@ impl FuncDecl {
     }
 }
 
-impl fmt::Display for FuncDecl {
+/// Binary "Special Relation" declarations. Z3's `Z3_mk_partial_order` family always builds a
+/// `Bool`-valued relation between two elements of the same (dynamic) sort, so these constructors
+/// are pinned to that concrete instantiation rather than being generic over arbitrary `A`/`R`.
+impl FuncDecl<(Sort<Dynamic>, Sort<Dynamic>), Bool> {
+    /// Create a partial order [`FuncDecl`] "Special Relation" over the given [`Sort`].
+    ///
+    /// The [`Sort`] may have many
+    /// partial orders derived this way, distinguished by the second integer argument to this call,
+    /// which represents the "id" of the partial order. Calling this twice with the same ID will
+    /// yield the same partial order [`FuncDecl`].
+    ///
+    /// See <https://microsoft.github.io/z3guide/docs/theories/Special%20Relations/> for more info.
+    ///
+    /// A partial order is a binary relation that is reflexive, antisymmetric, and transitive.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use z3::{FuncDecl, Sort, Solver, SatResult, Symbol};
+    /// # use z3::ast::{Ast, Bool, Dynamic, Int};
+    ///
+    ///   let sort = Sort::int().as_dyn();
+    ///   let partial_order = FuncDecl::partial_order(&sort, 0);
+    ///   // Create a solver to assert properties of the partial order.
+    ///   let solver = Solver::new();
+    ///   let x = Int::new_const("x");
+    ///   let y = Int::new_const("y");
+    ///   let z = Int::new_const("z");
+    ///   let dx = Dynamic::from_ast(&x);
+    ///   let dy = Dynamic::from_ast(&y);
+    ///   let dz = Dynamic::from_ast(&z);
+    ///
+    ///   solver.assert(&partial_order.apply((dx.clone(), dx.clone())));
+    ///   // test reflexivity
+    ///   assert_eq!(
+    ///       solver.check_assumptions(&[partial_order.apply((dx.clone(), dx.clone())).not()]),
+    ///       SatResult::Unsat
+    ///   );
+    ///
+    ///   // test antisymmetry
+    ///   assert_eq!(
+    ///       solver.check_assumptions(&[
+    ///           partial_order.apply((dx.clone(), dy.clone())),
+    ///           partial_order.apply((dy.clone(), dx.clone())),
+    ///           x.eq(&y).not()
+    ///       ]),
+    ///       SatResult::Unsat
+    ///   );
+    ///
+    ///   // test transitivity
+    ///   assert_eq!(
+    ///       solver.check_assumptions(&[
+    ///           partial_order.apply((dx.clone(), dy.clone())),
+    ///           partial_order.apply((dy.clone(), dz.clone())),
+    ///           partial_order.apply((dx.clone(), dz.clone())).not(),
+    ///       ]),
+    ///       SatResult::Unsat
+    ///   );
+    /// ```
+    ///
+    /// # See also
+    ///
+    /// - [`piecewise_linear_order`](Self::piecewise_linear_order)
+    /// - [`linear_order`](Self::linear_order)
+    /// - [`tree_order`](Self::tree_order)
+    /// - [`transitive_closure`](Self::transitive_closure)
+    pub fn partial_order<T: Borrow<Sort<Dynamic>>>(a: T, id: usize) -> Self {
+        let a = a.borrow();
+        let ctx = &a.ctx;
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_partial_order(ctx.z3_ctx.0, a.z3_sort, id as u32).unwrap(),
+            )
+        }
+    }
+
+    /// Create a piecewise linear order [`FuncDecl`] "Special Relation" over the given [`Sort`].
+    ///
+    /// See <https://microsoft.github.io/z3guide/docs/theories/Special%20Relations/> for more info.
+    ///
+    /// # See also
+    ///
+    /// - [`partial_order`](Self::partial_order)
+    /// - [`linear_order`](Self::linear_order)
+    /// - [`tree_order`](Self::tree_order)
+    /// - [`transitive_closure`](Self::transitive_closure)
+    pub fn piecewise_linear_order<T: Borrow<Sort<Dynamic>>>(a: T, id: usize) -> Self {
+        let a = a.borrow();
+        let ctx = &a.ctx;
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_piecewise_linear_order(ctx.z3_ctx.0, a.z3_sort, id as u32).unwrap(),
+            )
+        }
+    }
+
+    /// Create a linear order [`FuncDecl`] "Special Relation" over the given [`Sort`].
+    ///
+    /// See <https://microsoft.github.io/z3guide/docs/theories/Special%20Relations/> for more info.
+    ///
+    /// # See also
+    ///
+    /// - [`partial_order`](Self::partial_order)
+    /// - [`piecewise_linear_order`](Self::piecewise_linear_order)
+    /// - [`tree_order`](Self::tree_order)
+    /// - [`transitive_closure`](Self::transitive_closure)
+    pub fn linear_order<T: Borrow<Sort<Dynamic>>>(a: T, id: usize) -> Self {
+        let a = a.borrow();
+        let ctx = &a.ctx;
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_linear_order(ctx.z3_ctx.0, a.z3_sort, id as u32).unwrap(),
+            )
+        }
+    }
+
+    /// Create a tree order [`FuncDecl`] "Special Relation" over the given [`Sort`].
+    ///
+    /// See <https://microsoft.github.io/z3guide/docs/theories/Special%20Relations/> for more info.
+    ///
+    /// # See also
+    ///
+    /// - [`partial_order`](Self::partial_order)
+    /// - [`piecewise_linear_order`](Self::piecewise_linear_order)
+    /// - [`linear_order`](Self::linear_order)
+    /// - [`transitive_closure`](Self::transitive_closure)
+    pub fn tree_order<T: Borrow<Sort<Dynamic>>>(a: T, id: usize) -> Self {
+        let a = a.borrow();
+        let ctx = &a.ctx;
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_tree_order(ctx.z3_ctx.0, a.z3_sort, id as u32).unwrap(),
+            )
+        }
+    }
+
+    /// Create a transitive closure [`FuncDecl`] "Special Relation" over the given [`FuncDecl`].
+    ///
+    /// See <https://microsoft.github.io/z3guide/docs/theories/Special%20Relations/> for more info.
+    ///
+    /// # See also
+    ///
+    /// - [`partial_order`](Self::partial_order)
+    /// - [`piecewise_linear_order`](Self::piecewise_linear_order)
+    /// - [`linear_order`](Self::linear_order)
+    /// - [`tree_order`](Self::tree_order)
+    pub fn transitive_closure<T: Borrow<Self>>(a: T) -> Self {
+        let a = a.borrow();
+        let ctx = &a.ctx;
+        unsafe {
+            Self::wrap(
+                ctx,
+                Z3_mk_transitive_closure(ctx.z3_ctx.0, a.z3_func_decl).unwrap(),
+            )
+        }
+    }
+}
+
+impl<A: FuncDeclDomain, R: FuncDeclReturn> fmt::Display for FuncDecl<A, R> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let p = unsafe { Z3_func_decl_to_string(self.ctx.z3_ctx.0, self.z3_func_decl) };
         if p.is_null() {
@@ -298,13 +490,13 @@ impl fmt::Display for FuncDecl {
     }
 }
 
-impl fmt::Debug for FuncDecl {
+impl<A: FuncDeclDomain, R: FuncDeclReturn> fmt::Debug for FuncDecl<A, R> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         <Self as fmt::Display>::fmt(self, f)
     }
 }
 
-impl Drop for FuncDecl {
+impl<A: FuncDeclDomain, R: FuncDeclReturn> Drop for FuncDecl<A, R> {
     fn drop(&mut self) {
         unsafe {
             Z3_dec_ref(
@@ -315,7 +507,7 @@ impl Drop for FuncDecl {
     }
 }
 
-unsafe impl Translate for FuncDecl {
+unsafe impl<A: FuncDeclDomain, R: FuncDeclReturn> Translate for FuncDecl<A, R> {
     fn translate(&self, dest: &Context) -> Self {
         unsafe {
             let func_decl_ast = Z3_func_decl_to_ast(self.ctx.z3_ctx.0, self.z3_func_decl).unwrap();
@@ -333,13 +525,25 @@ mod test {
 
     #[test]
     pub fn test_translate_func_decl() {
-        let f = FuncDecl::new("foo", &[&Sort::bool()], &Sort::bool());
+        let f = FuncDecl::new("foo", Sort::bool(), Sort::bool());
         let ff = f.synchronized();
         with_z3_config(&Config::new(), || {
             let f = ff.recover();
             assert_eq!(f.name(), "foo");
             assert_eq!(f.arity(), 1);
-            assert!(f.apply(&[&Bool::from_bool(true)]).as_bool().is_some());
+            // `apply` returns a concrete `Bool` directly -- no `.as_bool().unwrap()` needed.
+            let _: Bool = f.apply(Bool::from_bool(true));
         });
+    }
+
+    #[test]
+    pub fn test_func_decl_typed_domain_and_range() {
+        // Sort<Int> domain + Sort<Int> range yields a FuncDecl whose `apply` returns a
+        // concrete `Int`, not `Dynamic` -- no `.as_int().unwrap()` needed at the call site.
+        use crate::ast::Int;
+
+        let f = FuncDecl::new("f", Sort::int(), Sort::int());
+        let three: Int = f.apply(Int::from_i64(3));
+        assert_eq!(three.as_i64(), None); // symbolic application, not evaluated by a model
     }
 }

--- a/z3/src/func_entry.rs
+++ b/z3/src/func_entry.rs
@@ -14,6 +14,8 @@ impl FuncEntry {
         Self {
             ctx: ctx.clone(),
             z3_func_entry,
+            phantom_a: std::marker::PhantomData,
+            phantom_r: std::marker::PhantomData,
         }
     }
 
@@ -62,7 +64,7 @@ impl fmt::Debug for FuncEntry {
     }
 }
 
-impl Drop for FuncEntry {
+impl<A: crate::FuncDeclDomain, R: crate::FuncDeclReturn> Drop for FuncEntry<A, R> {
     fn drop(&mut self) {
         unsafe {
             Z3_func_entry_dec_ref(self.ctx.z3_ctx.0, self.z3_func_entry);

--- a/z3/src/func_interp.rs
+++ b/z3/src/func_interp.rs
@@ -15,6 +15,8 @@ impl FuncInterp {
         Self {
             ctx: ctx.clone(),
             z3_func_interp,
+            phantom_a: std::marker::PhantomData,
+            phantom_r: std::marker::PhantomData,
         }
     }
 
@@ -103,7 +105,7 @@ impl fmt::Debug for FuncInterp {
     }
 }
 
-impl Drop for FuncInterp {
+impl<A: crate::FuncDeclDomain, R: crate::FuncDeclReturn> Drop for FuncInterp<A, R> {
     fn drop(&mut self) {
         unsafe {
             Z3_func_interp_dec_ref(self.ctx.z3_ctx.0, self.z3_func_interp);

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -84,8 +84,11 @@
 
 use std::cell::Cell;
 use std::ffi::CString;
+use std::marker::PhantomData;
 use std::ptr::NonNull;
 use z3_sys::*;
+
+use crate::ast::Dynamic;
 pub use z3_sys::{AstKind, GoalPrec, SortKind};
 
 pub mod ast;
@@ -125,6 +128,7 @@ pub use crate::version::{Version, full_version, version};
 pub use ast_vector::AstVector;
 pub use context::Context;
 pub use datatype_builder::DatatypeAccessor;
+pub use func_decl::{FuncDeclDomain, FuncDeclReturn};
 pub use solver::Solvable;
 /// Configuration used to initialize [logical contexts](Context).
 ///
@@ -157,19 +161,24 @@ pub enum Symbol {
 }
 
 /// Sorts represent the various 'types' of [`Ast`s](ast::Ast).
+///
+/// The type parameter `A` names the concrete [`ast::Ast`] type this sort classifies (e.g.
+/// `Sort<ast::Int>`), when statically known. Sorts that are runtime-derived (loaded from a
+/// [`Model`], or otherwise not known at construction time) use the default `A = Dynamic`.
 //
 // Note for in-crate users: Never construct a `Sort` directly; only use
 // `Sort::new()` which handles Z3 refcounting properly.
-pub struct Sort {
+pub struct Sort<A = Dynamic> {
     ctx: Context,
     z3_sort: Z3_sort,
+    phantom: PhantomData<A>,
 }
 
 /// A struct to represent when two sorts are of different types.
 #[derive(Debug)]
-pub struct SortDiffers {
-    left: Sort,
-    right: Sort,
+pub struct SortDiffers<A = Dynamic, B = Dynamic> {
+    left: Sort<A>,
+    right: Sort<B>,
 }
 
 /// A struct to represent when an ast is not a function application.
@@ -225,29 +234,40 @@ pub struct Fixedpoint {
 /// the sort (i.e., type) of each of its arguments. Note that, in Z3,
 /// a constant is a function with 0 arguments.
 ///
+/// The type parameters track the domain and range at the Rust type level: `A` is the argument
+/// list shape (see [`FuncDeclDomain`] — `()`, a single `Sort<T>`, a tuple of sorts, or the
+/// dynamic-arity default `Vec<Sort<Dynamic>>`), and `R` is the concrete [`ast::Ast`] type
+/// [`apply`](FuncDecl::apply) returns (see [`FuncDeclReturn`], defaulting to `Dynamic`).
+///
 /// # See also:
 ///
 /// - [`RecFuncDecl`]
 //
 // Note for in-crate users: Never construct a `FuncDecl` directly; only use
 // `FuncDecl::new()` which handles Z3 refcounting properly.
-pub struct FuncDecl {
+pub struct FuncDecl<A: FuncDeclDomain = Vec<Sort<Dynamic>>, R: FuncDeclReturn = Dynamic> {
     ctx: Context,
     z3_func_decl: Z3_func_decl,
+    phantom_a: PhantomData<A>,
+    phantom_r: PhantomData<R>,
 }
 
 /// Stores the interpretation of a function in a Z3 model.
 /// <https://z3prover.github.io/api/html/classz3py_1_1_func_interp.html>
-pub struct FuncInterp {
+pub struct FuncInterp<A: FuncDeclDomain = Vec<Sort<Dynamic>>, R: FuncDeclReturn = Dynamic> {
     ctx: Context,
     z3_func_interp: Z3_func_interp,
+    phantom_a: PhantomData<A>,
+    phantom_r: PhantomData<R>,
 }
 
 /// Store the value of the interpretation of a function in a particular point.
 /// <https://z3prover.github.io/api/html/classz3py_1_1_func_entry.html>
-pub struct FuncEntry {
+pub struct FuncEntry<A: FuncDeclDomain = Vec<Sort<Dynamic>>, R: FuncDeclReturn = Dynamic> {
     ctx: Context,
     z3_func_entry: Z3_func_entry,
+    phantom_a: PhantomData<A>,
+    phantom_r: PhantomData<R>,
 }
 
 /// Recursive function declaration. Every function has an associated declaration.
@@ -274,31 +294,39 @@ pub use z3_sys::DeclKind;
 ///
 /// Example:
 /// ```
-/// # use z3::{ DatatypeAccessor, DatatypeBuilder, SatResult, Solver, Sort, ast::{Ast, Datatype, Int}};
+/// # use z3::{ DatatypeAccessor, DatatypeBuilder, SatResult, Solver, Sort, ast::{Ast, Datatype, Dynamic, Int}};
 /// # let solver = Solver::new();
 /// // Like Rust's Option<int> type
 /// let option_int = DatatypeBuilder::new("OptionInt")
 /// .variant("None", vec![])
 /// .variant(
 ///     "Some",
-///     vec![("value", DatatypeAccessor::Sort(Sort::int()))],
+///     vec![("value", DatatypeAccessor::Sort(Sort::int().as_dyn()))],
 /// )
 /// .finish();
 ///
 /// // Assert x.is_none()
 /// let x = Datatype::new_const("x", &option_int.sort);
-/// solver.assert(&option_int.variants[0].tester.apply(&[&x]).as_bool().unwrap());
+/// solver.assert(
+///     &option_int.variants[0]
+///         .tester
+///         .apply(vec![Dynamic::from_ast(&x)])
+///         .as_bool()
+///         .unwrap(),
+/// );
 ///
 /// // Assert y == Some(3)
 /// let y = Datatype::new_const("y", &option_int.sort);
-/// let value = option_int.variants[1].constructor.apply(&[&Int::from_i64(3)]);
+/// let value = option_int.variants[1]
+///     .constructor
+///     .apply(vec![Dynamic::from_ast(&Int::from_i64(3))]);
 /// solver.assert(&y._eq(&value.as_datatype().unwrap()));
 ///
 /// assert_eq!(solver.check(), SatResult::Sat);
 /// let model = solver.get_model().unwrap();
 ///
 /// // Get the value out of Some(3)
-/// let ast = option_int.variants[1].accessors[0].apply(&[&y]);
+/// let ast = option_int.variants[1].accessors[0].apply(vec![Dynamic::from_ast(&y)]);
 /// assert_eq!(3, model.eval(&ast.as_int().unwrap(), true).unwrap().as_i64().unwrap());
 /// ```
 #[derive(Debug)]

--- a/z3/src/rec_func_decl.rs
+++ b/z3/src/rec_func_decl.rs
@@ -45,19 +45,19 @@ impl RecFuncDecl {
     /// Adds the body to a recursive function.
     ///
     /// ```
-    /// # use z3::{Config, Context, RecFuncDecl, Solver, Sort, Symbol, ast::Int, SatResult};
+    /// # use z3::{Config, Context, RecFuncDecl, Solver, Sort, Symbol, ast::{Ast, Dynamic, Int}, SatResult};
     /// # use std::convert::TryInto;
     /// let mut f = RecFuncDecl::new(
     ///     "f",
-    ///     &[&Sort::int()],
-    ///     &Sort::int());
+    ///     &[&Sort::int().as_dyn()],
+    ///     &Sort::int().as_dyn());
     /// let n = Int::new_const("n");
     /// f.add_def(
     ///     &[&n],
     ///     &Int::add(&[&n, &Int::from_i64(1)])
     /// );
     ///
-    /// let f_of_n = &f.apply(&[&n.clone()]);
+    /// let f_of_n = &f.apply(vec![Dynamic::from_ast(&n)]);
     ///
     /// let solver = Solver::new();
     /// let forall: z3::ast::Bool = z3::ast::forall_const(

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use std::ptr::NonNull;
 use z3_sys::*;
 
-use crate::ast::{BV, Bool, Char, Dynamic, Float, Int, Real};
+use crate::ast::{Array, BV, Bool, Char, Dynamic, Float, Int, Real, Seq, Set};
 use crate::{Context, FuncDecl, Sort, SortDiffers, Symbol};
 
 impl<A> Sort<A> {
@@ -214,7 +214,7 @@ impl Sort<Dynamic> {
         }
     }
 
-    pub fn array(domain: &Sort<Dynamic>, range: &Sort<Dynamic>) -> Sort<Dynamic> {
+    pub fn array<D, R>(domain: &Sort<D>, range: &Sort<R>) -> Sort<Array<D, R>> {
         let ctx = &Context::thread_local();
 
         unsafe {
@@ -225,7 +225,7 @@ impl Sort<Dynamic> {
         }
     }
 
-    pub fn set(elt: &Sort<Dynamic>) -> Sort<Dynamic> {
+    pub fn set<Elt>(elt: &Sort<Elt>) -> Sort<Set<Elt>> {
         let ctx = &Context::thread_local();
 
         unsafe {
@@ -236,7 +236,7 @@ impl Sort<Dynamic> {
         }
     }
 
-    pub fn seq(elt: &Sort<Dynamic>) -> Sort<Dynamic> {
+    pub fn seq<Elt>(elt: &Sort<Elt>) -> Sort<Seq<Elt>> {
         let ctx = &Context::thread_local();
 
         unsafe {

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use std::ptr::NonNull;
 use z3_sys::*;
 
-use crate::ast::{Array, BV, Bool, Char, Dynamic, Float, Int, Real, Seq, Set};
+use crate::ast::{Array, Ast, BV, Bool, Char, Dynamic, Float, Int, Real, Seq, Set, SortMarker};
 use crate::{Context, FuncDecl, Sort, SortDiffers, Symbol};
 
 impl<A> Sort<A> {
@@ -36,99 +36,103 @@ impl<A> Sort<A> {
         unsafe { Z3_get_sort_kind(self.ctx.z3_ctx.0, self.z3_sort) }
     }
 
-    /// Returns `Some(e)` where `e` is the number of exponent bits if the sort
-    /// is a `FloatingPoint` and `None` otherwise.
-    pub fn float_exponent_size(&self) -> Option<u32> {
-        if self.kind() == SortKind::FloatingPoint {
-            Some(unsafe { Z3_fpa_get_ebits(self.ctx.z3_ctx.0, self.z3_sort) })
-        } else {
-            None
-        }
-    }
-
-    /// Returns `Some(s)` where `s` is the number of significand bits if the sort
-    /// is a `FloatingPoint` and `None` otherwise.
-    pub fn float_significand_size(&self) -> Option<u32> {
-        if self.kind() == SortKind::FloatingPoint {
-            Some(unsafe { Z3_fpa_get_sbits(self.ctx.z3_ctx.0, self.z3_sort) })
-        } else {
-            None
-        }
+    /// Attempt to narrow this `Sort` to a specific parameterization `T`, e.g.
+    /// `Sort<Array<Int, Bool>>` or `Sort<Float>`, checking the actual runtime shape of the
+    /// sort (including, for parameterized `T`, its domain/range/element sorts) rather than
+    /// just trusting a phantom marker.
+    ///
+    /// This is the only way to reach the type-specific accessors that live on a concrete
+    /// `Sort<Array<D, R>>` (`domain`/`range`) or `Sort<Float>` (`exponent_size`/
+    /// `significand_size`) starting from a `Sort<Dynamic>`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use z3::{Sort, ast::{Array, Bool, Int}};
+    /// let sort = Sort::array(&Sort::int(), &Sort::bool()).as_dyn();
+    /// assert!(sort.narrow::<Array<Int, Bool>>().is_some());
+    /// assert!(sort.narrow::<Array<Bool, Int>>().is_none());
+    /// ```
+    pub fn narrow<T: SortMarker>(&self) -> Option<Sort<T>> {
+        T::sort_matches(&self.as_dyn()).then(|| unsafe { Sort::wrap(&self.ctx, self.z3_sort) })
     }
 }
 
-impl<A> Sort<A> {
-    /// Return if this Sort is for an `Array` or a `Set`.
-    ///
-    /// # Examples
-    /// ```
-    /// # use z3::{Config, Context, Sort, ast::Ast, ast::Int, ast::Bool};
-    /// let bool_sort = Sort::bool().as_dyn();
-    /// let int_sort = Sort::int().as_dyn();
-    /// let array_sort = Sort::array(&int_sort, &bool_sort);
-    /// let set_sort = Sort::set(&int_sort);
-    /// assert!(array_sort.is_array());
-    /// assert!(set_sort.is_array());
-    /// assert!(!int_sort.is_array());
-    /// assert!(!bool_sort.is_array());
-    /// ```
-    pub fn is_array(&self) -> bool {
-        self.kind() == SortKind::Array
-    }
-
+impl<D: Ast, R: Ast> Sort<Array<D, R>> {
     /// Return the `Sort` of the domain for `Array`s of this `Sort`.
     ///
-    /// If this `Sort` is an `Array` or `Set`, it has a domain sort, so return it.
-    /// If this is not an `Array` or `Set` `Sort`, return `None`.
     /// # Examples
     /// ```
-    /// # use z3::{Config, Context, Sort, ast::Ast, ast::Int, ast::Bool};
-    /// let bool_sort = Sort::bool().as_dyn();
-    /// let int_sort = Sort::int().as_dyn();
-    /// let array_sort = Sort::array(&int_sort, &bool_sort);
-    /// let set_sort = Sort::set(&int_sort);
-    /// assert_eq!(array_sort.array_domain().unwrap(), int_sort);
-    /// assert_eq!(set_sort.array_domain().unwrap(), int_sort);
-    /// assert!(int_sort.array_domain().is_none());
-    /// assert!(bool_sort.array_domain().is_none());
+    /// # use z3::Sort;
+    /// let array_sort = Sort::array(&Sort::int(), &Sort::bool());
+    /// assert_eq!(array_sort.domain(), Sort::int());
     /// ```
-    pub fn array_domain(&self) -> Option<Sort<Dynamic>> {
-        if self.is_array() {
-            unsafe {
-                let domain_sort = Z3_get_array_sort_domain(self.ctx.z3_ctx.0, self.z3_sort)?;
-                Some(Sort::wrap(&self.ctx, domain_sort))
-            }
-        } else {
-            None
+    pub fn domain(&self) -> Sort<D> {
+        unsafe {
+            Sort::wrap(
+                &self.ctx,
+                Z3_get_array_sort_domain(self.ctx.z3_ctx.0, self.z3_sort).unwrap(),
+            )
         }
     }
 
     /// Return the `Sort` of the range for `Array`s of this `Sort`.
     ///
-    /// If this `Sort` is an `Array` it has a range sort, so return it.
-    /// If this `Sort` is a `Set`, it has an implied range sort of `Bool`.
-    /// If this is not an `Array` or `Set` `Sort`, return `None`.
     /// # Examples
     /// ```
-    /// # use z3::{Config, Context, Sort, ast::Ast, ast::Int, ast::Bool};
-    /// let bool_sort = Sort::bool().as_dyn();
-    /// let int_sort = Sort::int().as_dyn();
-    /// let array_sort = Sort::array(&int_sort, &bool_sort);
-    /// let set_sort = Sort::set(&int_sort);
-    /// assert_eq!(array_sort.array_range().unwrap(), bool_sort);
-    /// assert_eq!(set_sort.array_range().unwrap(), bool_sort);
-    /// assert!(int_sort.array_range().is_none());
-    /// assert!(bool_sort.array_range().is_none());
+    /// # use z3::Sort;
+    /// let array_sort = Sort::array(&Sort::int(), &Sort::bool());
+    /// assert_eq!(array_sort.range(), Sort::bool());
     /// ```
-    pub fn array_range(&self) -> Option<Sort<Dynamic>> {
-        if self.is_array() {
-            unsafe {
-                let range_sort = Z3_get_array_sort_range(self.ctx.z3_ctx.0, self.z3_sort)?;
-                Some(Sort::wrap(&self.ctx, range_sort))
-            }
-        } else {
-            None
+    pub fn range(&self) -> Sort<R> {
+        unsafe {
+            Sort::wrap(
+                &self.ctx,
+                Z3_get_array_sort_range(self.ctx.z3_ctx.0, self.z3_sort).unwrap(),
+            )
         }
+    }
+}
+
+impl<Elt: Ast> Sort<Set<Elt>> {
+    /// Return the `Sort` of the elements of `Set`s of this `Sort`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use z3::Sort;
+    /// let set_sort = Sort::set(&Sort::int());
+    /// assert_eq!(set_sort.domain(), Sort::int());
+    /// ```
+    pub fn domain(&self) -> Sort<Elt> {
+        unsafe {
+            Sort::wrap(
+                &self.ctx,
+                Z3_get_array_sort_domain(self.ctx.z3_ctx.0, self.z3_sort).unwrap(),
+            )
+        }
+    }
+}
+
+impl Sort<Float> {
+    /// Return the number of exponent bits of this `FloatingPoint` `Sort`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use z3::Sort;
+    /// assert_eq!(Sort::double().exponent_size(), 11);
+    /// ```
+    pub fn exponent_size(&self) -> u32 {
+        unsafe { Z3_fpa_get_ebits(self.ctx.z3_ctx.0, self.z3_sort) }
+    }
+
+    /// Return the number of significand bits of this `FloatingPoint` `Sort`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use z3::Sort;
+    /// assert_eq!(Sort::double().significand_size(), 53);
+    /// ```
+    pub fn significand_size(&self) -> u32 {
+        unsafe { Z3_fpa_get_sbits(self.ctx.z3_ctx.0, self.z3_sort) }
     }
 }
 

--- a/z3/src/sort.rs
+++ b/z3/src/sort.rs
@@ -1,19 +1,22 @@
 use std::convert::TryInto;
 use std::ffi::CStr;
 use std::fmt;
+use std::marker::PhantomData;
 use std::ptr::NonNull;
 use z3_sys::*;
 
+use crate::ast::{BV, Bool, Char, Dynamic, Float, Int, Real};
 use crate::{Context, FuncDecl, Sort, SortDiffers, Symbol};
 
-impl Sort {
-    pub(crate) unsafe fn wrap(ctx: &Context, z3_sort: Z3_sort) -> Sort {
+impl<A> Sort<A> {
+    pub(crate) unsafe fn wrap(ctx: &Context, z3_sort: Z3_sort) -> Sort<A> {
         unsafe {
             Z3_inc_ref(ctx.z3_ctx.0, Z3_sort_to_ast(ctx.z3_ctx.0, z3_sort).unwrap());
         }
         Sort {
             ctx: ctx.clone(),
             z3_sort,
+            phantom: PhantomData,
         }
     }
 
@@ -21,105 +24,211 @@ impl Sort {
         self.z3_sort
     }
 
-    pub fn uninterpreted(name: Symbol) -> Sort {
+    /// Erase the static sort marker, yielding a dynamically-typed `Sort<Dynamic>`.
+    pub fn as_dyn(&self) -> Sort<Dynamic> {
+        unsafe { Sort::wrap(&self.ctx, self.z3_sort) }
+    }
+
+    pub fn kind(&self) -> SortKind {
+        unsafe { Z3_get_sort_kind(self.ctx.z3_ctx.0, self.z3_sort) }
+    }
+
+    /// Returns `Some(e)` where `e` is the number of exponent bits if the sort
+    /// is a `FloatingPoint` and `None` otherwise.
+    pub fn float_exponent_size(&self) -> Option<u32> {
+        if self.kind() == SortKind::FloatingPoint {
+            Some(unsafe { Z3_fpa_get_ebits(self.ctx.z3_ctx.0, self.z3_sort) })
+        } else {
+            None
+        }
+    }
+
+    /// Returns `Some(s)` where `s` is the number of significand bits if the sort
+    /// is a `FloatingPoint` and `None` otherwise.
+    pub fn float_significand_size(&self) -> Option<u32> {
+        if self.kind() == SortKind::FloatingPoint {
+            Some(unsafe { Z3_fpa_get_sbits(self.ctx.z3_ctx.0, self.z3_sort) })
+        } else {
+            None
+        }
+    }
+}
+
+impl<A> Sort<A> {
+    /// Return if this Sort is for an `Array` or a `Set`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use z3::{Config, Context, Sort, ast::Ast, ast::Int, ast::Bool};
+    /// let bool_sort = Sort::bool().as_dyn();
+    /// let int_sort = Sort::int().as_dyn();
+    /// let array_sort = Sort::array(&int_sort, &bool_sort);
+    /// let set_sort = Sort::set(&int_sort);
+    /// assert!(array_sort.is_array());
+    /// assert!(set_sort.is_array());
+    /// assert!(!int_sort.is_array());
+    /// assert!(!bool_sort.is_array());
+    /// ```
+    pub fn is_array(&self) -> bool {
+        self.kind() == SortKind::Array
+    }
+
+    /// Return the `Sort` of the domain for `Array`s of this `Sort`.
+    ///
+    /// If this `Sort` is an `Array` or `Set`, it has a domain sort, so return it.
+    /// If this is not an `Array` or `Set` `Sort`, return `None`.
+    /// # Examples
+    /// ```
+    /// # use z3::{Config, Context, Sort, ast::Ast, ast::Int, ast::Bool};
+    /// let bool_sort = Sort::bool().as_dyn();
+    /// let int_sort = Sort::int().as_dyn();
+    /// let array_sort = Sort::array(&int_sort, &bool_sort);
+    /// let set_sort = Sort::set(&int_sort);
+    /// assert_eq!(array_sort.array_domain().unwrap(), int_sort);
+    /// assert_eq!(set_sort.array_domain().unwrap(), int_sort);
+    /// assert!(int_sort.array_domain().is_none());
+    /// assert!(bool_sort.array_domain().is_none());
+    /// ```
+    pub fn array_domain(&self) -> Option<Sort<Dynamic>> {
+        if self.is_array() {
+            unsafe {
+                let domain_sort = Z3_get_array_sort_domain(self.ctx.z3_ctx.0, self.z3_sort)?;
+                Some(Sort::wrap(&self.ctx, domain_sort))
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Return the `Sort` of the range for `Array`s of this `Sort`.
+    ///
+    /// If this `Sort` is an `Array` it has a range sort, so return it.
+    /// If this `Sort` is a `Set`, it has an implied range sort of `Bool`.
+    /// If this is not an `Array` or `Set` `Sort`, return `None`.
+    /// # Examples
+    /// ```
+    /// # use z3::{Config, Context, Sort, ast::Ast, ast::Int, ast::Bool};
+    /// let bool_sort = Sort::bool().as_dyn();
+    /// let int_sort = Sort::int().as_dyn();
+    /// let array_sort = Sort::array(&int_sort, &bool_sort);
+    /// let set_sort = Sort::set(&int_sort);
+    /// assert_eq!(array_sort.array_range().unwrap(), bool_sort);
+    /// assert_eq!(set_sort.array_range().unwrap(), bool_sort);
+    /// assert!(int_sort.array_range().is_none());
+    /// assert!(bool_sort.array_range().is_none());
+    /// ```
+    pub fn array_range(&self) -> Option<Sort<Dynamic>> {
+        if self.is_array() {
+            unsafe {
+                let range_sort = Z3_get_array_sort_range(self.ctx.z3_ctx.0, self.z3_sort)?;
+                Some(Sort::wrap(&self.ctx, range_sort))
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl Sort<Dynamic> {
+    pub fn uninterpreted(name: Symbol) -> Sort<Dynamic> {
         let ctx = &Context::thread_local();
 
         unsafe {
-            Self::wrap(
+            Sort::wrap(
                 ctx,
                 Z3_mk_uninterpreted_sort(ctx.z3_ctx.0, name.as_z3_symbol()).unwrap(),
             )
         }
     }
 
-    pub fn bool() -> Sort {
+    pub fn bool() -> Sort<Bool> {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_bool_sort(ctx.z3_ctx.0).unwrap())
+            Sort::wrap(ctx, Z3_mk_bool_sort(ctx.z3_ctx.0).unwrap())
         }
     }
 
-    pub fn int() -> Sort {
+    pub fn int() -> Sort<Int> {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_int_sort(ctx.z3_ctx.0).unwrap())
+            Sort::wrap(ctx, Z3_mk_int_sort(ctx.z3_ctx.0).unwrap())
         }
     }
 
-    pub fn real() -> Sort {
+    pub fn real() -> Sort<Real> {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_real_sort(ctx.z3_ctx.0).unwrap())
+            Sort::wrap(ctx, Z3_mk_real_sort(ctx.z3_ctx.0).unwrap())
         }
     }
 
-    pub fn float(ebits: u32, sbits: u32) -> Sort {
+    pub fn float(ebits: u32, sbits: u32) -> Sort<Float> {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.0, ebits, sbits).unwrap())
+            Sort::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.0, ebits, sbits).unwrap())
         }
     }
 
-    pub fn float32() -> Sort {
+    pub fn float32() -> Sort<Float> {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.0, 8, 24).unwrap())
+            Sort::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.0, 8, 24).unwrap())
         }
     }
 
-    pub fn double() -> Sort {
+    pub fn double() -> Sort<Float> {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.0, 11, 53).unwrap())
+            Sort::wrap(ctx, Z3_mk_fpa_sort(ctx.z3_ctx.0, 11, 53).unwrap())
         }
     }
 
-    pub fn string() -> Sort {
+    pub fn string() -> Sort<crate::ast::String> {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_string_sort(ctx.z3_ctx.0).unwrap())
+            Sort::wrap(ctx, Z3_mk_string_sort(ctx.z3_ctx.0).unwrap())
         }
     }
 
-    pub fn char() -> Sort {
+    pub fn char() -> Sort<Char> {
         unsafe {
             let ctx = &Context::thread_local();
-            Self::wrap(ctx, Z3_mk_char_sort(ctx.z3_ctx.0).unwrap())
+            Sort::wrap(ctx, Z3_mk_char_sort(ctx.z3_ctx.0).unwrap())
         }
     }
 
-    pub fn bitvector(sz: u32) -> Sort {
+    pub fn bitvector(sz: u32) -> Sort<BV> {
         let ctx = &Context::thread_local();
 
         unsafe {
-            Self::wrap(
+            Sort::wrap(
                 ctx,
                 Z3_mk_bv_sort(ctx.z3_ctx.0, sz as ::std::os::raw::c_uint).unwrap(),
             )
         }
     }
 
-    pub fn array(domain: &Sort, range: &Sort) -> Sort {
+    pub fn array(domain: &Sort<Dynamic>, range: &Sort<Dynamic>) -> Sort<Dynamic> {
         let ctx = &Context::thread_local();
 
         unsafe {
-            Self::wrap(
+            Sort::wrap(
                 ctx,
                 Z3_mk_array_sort(ctx.z3_ctx.0, domain.z3_sort, range.z3_sort).unwrap(),
             )
         }
     }
 
-    pub fn set(elt: &Sort) -> Sort {
+    pub fn set(elt: &Sort<Dynamic>) -> Sort<Dynamic> {
         let ctx = &Context::thread_local();
 
-        unsafe { Self::wrap(ctx, Z3_mk_set_sort(ctx.z3_ctx.0, elt.z3_sort).unwrap()) }
+        unsafe { Sort::wrap(ctx, Z3_mk_set_sort(ctx.z3_ctx.0, elt.z3_sort).unwrap()) }
     }
 
-    pub fn seq(elt: &Sort) -> Sort {
+    pub fn seq(elt: &Sort<Dynamic>) -> Sort<Dynamic> {
         let ctx = &Context::thread_local();
 
-        unsafe { Self::wrap(ctx, Z3_mk_seq_sort(ctx.z3_ctx.0, elt.z3_sort).unwrap()) }
+        unsafe { Sort::wrap(ctx, Z3_mk_seq_sort(ctx.z3_ctx.0, elt.z3_sort).unwrap()) }
     }
 
     /// Create an enumeration sort.
@@ -134,6 +243,7 @@ impl Sort {
     /// # Examples
     /// ```
     /// # use z3::{Config, Context, SatResult, Solver, Sort, Symbol};
+    /// # use z3::ast::Dynamic;
     /// # let cfg = Config::new();
     /// # let solver = Solver::new();
     /// let (colors, color_consts, color_testers) = Sort::enumeration(
@@ -145,9 +255,9 @@ impl Sort {
     ///     ],
     /// );
     ///
-    /// let red_const = color_consts[0].apply(&[]);
+    /// let red_const = color_consts[0].apply(vec![]);
     /// let red_tester = &color_testers[0];
-    /// let eq = red_tester.apply(&[&red_const]);
+    /// let eq = red_tester.apply(vec![Dynamic::from_ast(&red_const)]);
     ///
     /// assert_eq!(solver.check(), SatResult::Sat);
     /// let model = solver.get_model().unwrap();;
@@ -157,14 +267,14 @@ impl Sort {
     pub fn enumeration(
         name: Symbol,
         enum_names: &[Symbol],
-    ) -> (Sort, Vec<FuncDecl>, Vec<FuncDecl>) {
+    ) -> (Sort<Dynamic>, Vec<FuncDecl>, Vec<FuncDecl>) {
         let ctx = &Context::thread_local();
         let enum_names: Vec<_> = enum_names.iter().map(|s| s.as_z3_symbol()).collect();
         let mut enum_consts = vec![std::ptr::null_mut::<_Z3_func_decl>(); enum_names.len()];
         let mut enum_testers = vec![std::ptr::null_mut::<_Z3_func_decl>(); enum_names.len()];
 
         let sort = unsafe {
-            Self::wrap(
+            Sort::wrap(
                 ctx,
                 Z3_mk_enumeration_sort(
                     ctx.z3_ctx.0,
@@ -208,112 +318,15 @@ impl Sort {
 
         (sort, enum_consts, enum_testers)
     }
-
-    pub fn kind(&self) -> SortKind {
-        unsafe { Z3_get_sort_kind(self.ctx.z3_ctx.0, self.z3_sort) }
-    }
-
-    /// Returns `Some(e)` where `e` is the number of exponent bits if the sort
-    /// is a `FloatingPoint` and `None` otherwise.
-    pub fn float_exponent_size(&self) -> Option<u32> {
-        if self.kind() == SortKind::FloatingPoint {
-            Some(unsafe { Z3_fpa_get_ebits(self.ctx.z3_ctx.0, self.z3_sort) })
-        } else {
-            None
-        }
-    }
-
-    /// Returns `Some(s)` where `s` is the number of significand bits if the sort
-    /// is a `FloatingPoint` and `None` otherwise.
-    pub fn float_significand_size(&self) -> Option<u32> {
-        if self.kind() == SortKind::FloatingPoint {
-            Some(unsafe { Z3_fpa_get_sbits(self.ctx.z3_ctx.0, self.z3_sort) })
-        } else {
-            None
-        }
-    }
-
-    /// Return if this Sort is for an `Array` or a `Set`.
-    ///
-    /// # Examples
-    /// ```
-    /// # use z3::{Config, Context, Sort, ast::Ast, ast::Int, ast::Bool};
-    /// let bool_sort = Sort::bool();
-    /// let int_sort = Sort::int();
-    /// let array_sort = Sort::array(&int_sort, &bool_sort);
-    /// let set_sort = Sort::set(&int_sort);
-    /// assert!(array_sort.is_array());
-    /// assert!(set_sort.is_array());
-    /// assert!(!int_sort.is_array());
-    /// assert!(!bool_sort.is_array());
-    /// ```
-    pub fn is_array(&self) -> bool {
-        self.kind() == SortKind::Array
-    }
-
-    /// Return the `Sort` of the domain for `Array`s of this `Sort`.
-    ///
-    /// If this `Sort` is an `Array` or `Set`, it has a domain sort, so return it.
-    /// If this is not an `Array` or `Set` `Sort`, return `None`.
-    /// # Examples
-    /// ```
-    /// # use z3::{Config, Context, Sort, ast::Ast, ast::Int, ast::Bool};
-    /// let bool_sort = Sort::bool();
-    /// let int_sort = Sort::int();
-    /// let array_sort = Sort::array(&int_sort, &bool_sort);
-    /// let set_sort = Sort::set(&int_sort);
-    /// assert_eq!(array_sort.array_domain().unwrap(), int_sort);
-    /// assert_eq!(set_sort.array_domain().unwrap(), int_sort);
-    /// assert!(int_sort.array_domain().is_none());
-    /// assert!(bool_sort.array_domain().is_none());
-    /// ```
-    pub fn array_domain(&self) -> Option<Sort> {
-        if self.is_array() {
-            unsafe {
-                let domain_sort = Z3_get_array_sort_domain(self.ctx.z3_ctx.0, self.z3_sort)?;
-                Some(Self::wrap(&self.ctx, domain_sort))
-            }
-        } else {
-            None
-        }
-    }
-
-    /// Return the `Sort` of the range for `Array`s of this `Sort`.
-    ///
-    /// If this `Sort` is an `Array` it has a range sort, so return it.
-    /// If this `Sort` is a `Set`, it has an implied range sort of `Bool`.
-    /// If this is not an `Array` or `Set` `Sort`, return `None`.
-    /// # Examples
-    /// ```
-    /// # use z3::{Config, Context, Sort, ast::Ast, ast::Int, ast::Bool};
-    /// let bool_sort = Sort::bool();
-    /// let int_sort = Sort::int();
-    /// let array_sort = Sort::array(&int_sort, &bool_sort);
-    /// let set_sort = Sort::set(&int_sort);
-    /// assert_eq!(array_sort.array_range().unwrap(), bool_sort);
-    /// assert_eq!(set_sort.array_range().unwrap(), bool_sort);
-    /// assert!(int_sort.array_range().is_none());
-    /// assert!(bool_sort.array_range().is_none());
-    /// ```
-    pub fn array_range(&self) -> Option<Sort> {
-        if self.is_array() {
-            unsafe {
-                let range_sort = Z3_get_array_sort_range(self.ctx.z3_ctx.0, self.z3_sort)?;
-                Some(Self::wrap(&self.ctx, range_sort))
-            }
-        } else {
-            None
-        }
-    }
 }
 
-impl Clone for Sort {
+impl<A> Clone for Sort<A> {
     fn clone(&self) -> Self {
         unsafe { Self::wrap(&self.ctx, self.z3_sort) }
     }
 }
 
-impl fmt::Display for Sort {
+impl<A> fmt::Display for Sort<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let p = unsafe { Z3_sort_to_string(self.ctx.z3_ctx.0, self.z3_sort) };
         if p.is_null() {
@@ -326,21 +339,23 @@ impl fmt::Display for Sort {
     }
 }
 
-impl fmt::Debug for Sort {
+impl<A> fmt::Debug for Sort<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         <Self as fmt::Display>::fmt(self, f)
     }
 }
 
-impl PartialEq<Sort> for Sort {
-    fn eq(&self, other: &Sort) -> bool {
+// Sort equality reflects Z3's own runtime sort identity, independent of the phantom marker,
+// so comparisons across differently-typed `Sort<A>`/`Sort<B>` are allowed.
+impl<A, B> PartialEq<Sort<B>> for Sort<A> {
+    fn eq(&self, other: &Sort<B>) -> bool {
         unsafe { Z3_is_eq_sort(self.ctx.z3_ctx.0, self.z3_sort, other.z3_sort) }
     }
 }
 
-impl Eq for Sort {}
+impl<A> Eq for Sort<A> {}
 
-impl Drop for Sort {
+impl<A> Drop for Sort<A> {
     fn drop(&mut self) {
         unsafe {
             Z3_dec_ref(
@@ -351,21 +366,21 @@ impl Drop for Sort {
     }
 }
 
-impl SortDiffers {
-    pub fn new(left: Sort, right: Sort) -> Self {
+impl<A, B> SortDiffers<A, B> {
+    pub fn new(left: Sort<A>, right: Sort<B>) -> Self {
         Self { left, right }
     }
 
-    pub fn left(&self) -> &Sort {
+    pub fn left(&self) -> &Sort<A> {
         &self.left
     }
 
-    pub fn right(&self) -> &Sort {
+    pub fn right(&self) -> &Sort<B> {
         &self.right
     }
 }
 
-impl fmt::Display for SortDiffers {
+impl<A, B> fmt::Display for SortDiffers<A, B> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(
             f,

--- a/z3/tests/datatype_builder_tests.rs
+++ b/z3/tests/datatype_builder_tests.rs
@@ -7,7 +7,7 @@ fn test_datatype_accessor_constructors() {
     let _ = env_logger::try_init();
 
     // Ensure the convenience constructors produce the expected enum variants.
-    let as_sort = DatatypeAccessor::sort(Sort::int());
+    let as_sort = DatatypeAccessor::sort(Sort::int().as_dyn());
     match as_sort {
         DatatypeAccessor::Sort(s) => {
             // A Sort::int() compared to itself should be equal.
@@ -36,7 +36,10 @@ fn test_create_datatypes_with_explicit_accessors_and_constructors() {
     // high-level DatatypeBuilder and DatatypeAccessor helpers, and exercises
     // constructors, testers and accessors via the solver.
     let tree_builder = DatatypeBuilder::new("TreeX")
-        .variant("leaf", vec![("val", DatatypeAccessor::sort(Sort::int()))])
+        .variant(
+            "leaf",
+            vec![("val", DatatypeAccessor::sort(Sort::int().as_dyn()))],
+        )
         .variant(
             "node",
             vec![("children", DatatypeAccessor::datatype("ListX"))],
@@ -75,36 +78,43 @@ fn test_create_datatypes_with_explicit_accessors_and_constructors() {
     let twenty = ast::Int::from_i64(20);
 
     // Create Tree.leaf(10) and Tree.leaf(20)
-    let leaf_ten = tree_sort.variants[0].constructor.apply(&[&ten]);
-    let leaf_twenty = tree_sort.variants[0].constructor.apply(&[&twenty]);
+    let leaf_ten = tree_sort.variants[0]
+        .constructor
+        .apply(vec![ast::Dynamic::from_ast(&ten)]);
+    let leaf_twenty = tree_sort.variants[0]
+        .constructor
+        .apply(vec![ast::Dynamic::from_ast(&twenty)]);
 
     // Create List.cons(leaf_twenty, nil)
-    let nil = list_sort.variants[0].constructor.apply(&[]);
-    let cons_twenty_nil = list_sort.variants[1]
-        .constructor
-        .apply(&[&leaf_twenty, &nil]);
+    let nil = list_sort.variants[0].constructor.apply(vec![]);
+    let cons_twenty_nil = list_sort.variants[1].constructor.apply(vec![
+        ast::Dynamic::from_ast(&leaf_twenty),
+        ast::Dynamic::from_ast(&nil),
+    ]);
 
     // Create List.cons(leaf_ten, cons_twenty_nil)
-    let cons_ten_cons_twenty_nil = list_sort.variants[1]
-        .constructor
-        .apply(&[&leaf_ten, &cons_twenty_nil]);
+    let cons_ten_cons_twenty_nil = list_sort.variants[1].constructor.apply(vec![
+        ast::Dynamic::from_ast(&leaf_ten),
+        ast::Dynamic::from_ast(&cons_twenty_nil),
+    ]);
 
     // Create Tree.node(cons_ten_cons_twenty_nil)
     let node = tree_sort.variants[1]
         .constructor
-        .apply(&[&cons_ten_cons_twenty_nil]);
+        .apply(vec![ast::Dynamic::from_ast(&cons_ten_cons_twenty_nil)]);
 
     // Assert that accessing children of node yields the list we constructed.
-    let children = tree_sort.variants[1].accessors[0].apply(&[&node]);
+    let children = tree_sort.variants[1].accessors[0].apply(vec![ast::Dynamic::from_ast(&node)]);
     solver.assert(children.eq(&cons_ten_cons_twenty_nil));
 
     // Assert that the first element of that list (car) is leaf_ten
-    let first = list_sort.variants[1].accessors[0].apply(&[&cons_ten_cons_twenty_nil]);
+    let first = list_sort.variants[1].accessors[0]
+        .apply(vec![ast::Dynamic::from_ast(&cons_ten_cons_twenty_nil)]);
     solver.assert(first.eq(&leaf_ten));
 
     // Assert that accessing val from leaf_ten gives 10
     let val_from_leaf = tree_sort.variants[0].accessors[0]
-        .apply(&[&leaf_ten])
+        .apply(vec![ast::Dynamic::from_ast(&leaf_ten)])
         .as_int()
         .unwrap();
     solver.assert(val_from_leaf.eq(&ten));

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -228,23 +228,18 @@ fn test_floating_point_bits() {
     let float128 = ast::Float::new_const("float128", 15, 113);
     let i = ast::Int::new_const("int");
 
-    let exp32 = Sort::float_exponent_size(&float32.get_sort());
-    let sig32 = Sort::float_significand_size(&float32.get_sort());
-    let exp64 = Sort::float_exponent_size(&float64.get_sort());
-    let sig64 = Sort::float_significand_size(&float64.get_sort());
-    let exp128 = Sort::float_exponent_size(&float128.get_sort());
-    let sig128 = Sort::float_significand_size(&float128.get_sort());
-    let expi = Sort::float_exponent_size(&i.get_sort());
-    let sigi = Sort::float_significand_size(&i.get_sort());
+    let float32_sort = float32.get_sort().narrow::<ast::Float>().unwrap();
+    let float64_sort = float64.get_sort().narrow::<ast::Float>().unwrap();
+    let float128_sort = float128.get_sort().narrow::<ast::Float>().unwrap();
 
-    assert!(exp32 == Some(8));
-    assert!(sig32 == Some(24));
-    assert!(exp64 == Some(11));
-    assert!(sig64 == Some(53));
-    assert!(exp128 == Some(15));
-    assert!(sig128 == Some(113));
-    assert!(expi.is_none());
-    assert!(sigi.is_none());
+    assert_eq!(float32_sort.exponent_size(), 8);
+    assert_eq!(float32_sort.significand_size(), 24);
+    assert_eq!(float64_sort.exponent_size(), 11);
+    assert_eq!(float64_sort.significand_size(), 53);
+    assert_eq!(float128_sort.exponent_size(), 15);
+    assert_eq!(float128_sort.significand_size(), 113);
+
+    assert!(i.get_sort().narrow::<ast::Float>().is_none());
 }
 
 #[test]

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1177,11 +1177,11 @@ fn test_set_membership() {
     let _ = env_logger::try_init();
 
     let solver = Solver::new();
-    let set = ast::Set::new_const("integer_set", &Sort::int().as_dyn());
+    let set = ast::Set::new_const("integer_set", &Sort::int());
     let one = ast::Int::from_u64(1);
 
     solver.push();
-    solver.assert(set.eq(ast::Set::empty(&Sort::int().as_dyn())));
+    solver.assert(set.eq(ast::Set::empty(&Sort::int())));
 
     solver.push();
     solver.assert(set.member(&one));
@@ -1212,7 +1212,7 @@ fn test_set_membership() {
 
     solver.push();
     // A singleton set of 1 will contain 1
-    solver.assert(set.eq(ast::Set::empty(&Sort::int().as_dyn()).add(&one)));
+    solver.assert(set.eq(ast::Set::empty(&Sort::int()).add(&one)));
     solver.assert(set.member(&one));
     assert_eq!(solver.check(), SatResult::Sat);
     solver.pop(1);
@@ -1227,18 +1227,17 @@ fn test_dynamic_as_set() {
     let array_of_sets = ast::Array::new_const("array_of_sets", &Sort::int().as_dyn(), &set_sort);
     let array_of_arrays =
         ast::Array::new_const("array_of_arrays", &Sort::int().as_dyn(), &array_sort);
-    assert!(
-        array_of_sets
-            .select(&ast::Int::from_u64(0))
-            .as_set()
-            .is_some()
-    );
-    assert!(
-        array_of_arrays
-            .select(&ast::Int::from_u64(0))
-            .as_set()
-            .is_none()
-    );
+
+    // `select` is now statically typed by the array's range sort, so these already come back
+    // as `Set`/`Array` values rather than `Dynamic`; round-trip through `Dynamic` to also
+    // exercise the runtime discrimination.
+    let selected_set: ast::Set =
+        array_of_sets.select(&ast::Dynamic::from_ast(&ast::Int::from_u64(0)));
+    assert!(ast::Dynamic::from(selected_set).as_set().is_some());
+
+    let selected_array: ast::Array =
+        array_of_arrays.select(&ast::Dynamic::from_ast(&ast::Int::from_u64(0)));
+    assert!(ast::Dynamic::from(selected_array).as_set().is_none());
 }
 
 #[test]
@@ -1248,12 +1247,7 @@ fn test_array_store_select() {
     let solver = Solver::new();
     let zero = ast::Int::from_u64(0);
     let one = ast::Int::from_u64(1);
-    let set = ast::Array::new_const(
-        "integer_array",
-        &Sort::int().as_dyn(),
-        &Sort::int().as_dyn(),
-    )
-    .store(&zero, &one);
+    let set = ast::Array::new_const("integer_array", &Sort::int(), &Sort::int()).store(&zero, &one);
 
     solver.assert(set.select(&zero).eq(one).not());
     assert_eq!(solver.check(), SatResult::Unsat);
@@ -1663,11 +1657,7 @@ fn test_regex_union2() {
 fn test_array_example1() {
     let g = Goal::new(true, false, false);
 
-    let aex = Array::new_const(
-        "MyArray",
-        &Sort::int().as_dyn(),
-        &Sort::bitvector(32).as_dyn(),
-    );
+    let aex = Array::new_const("MyArray", &Sort::int(), &Sort::bitvector(32));
 
     let sel = aex.select(&Int::from_u64(0));
 

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1,5 +1,4 @@
 use log::info;
-use std::convert::TryInto;
 use std::ops::Add;
 use std::time::Duration;
 use z3::ast::{Array, Ast, BV, Bool, Int, atleast, atmost};
@@ -37,20 +36,20 @@ fn test_fixedpoint_horn_clauses() {
     let _ = env_logger::try_init();
 
     let fp = Fixedpoint::new();
-    let bool_sort = Sort::bool();
+    let bool_sort = Sort::bool().as_dyn();
 
     // Three 0-ary predicates (propositions in the Horn clause system).
-    let p_decl = FuncDecl::new("p", &[], &bool_sort);
-    let q_decl = FuncDecl::new("q", &[], &bool_sort);
-    let r_decl = FuncDecl::new("r", &[], &bool_sort);
+    let p_decl = FuncDecl::new("p", vec![], &bool_sort);
+    let q_decl = FuncDecl::new("q", vec![], &bool_sort);
+    let r_decl = FuncDecl::new("r", vec![], &bool_sort);
 
     fp.register_relation(&p_decl);
     fp.register_relation(&q_decl);
     fp.register_relation(&r_decl);
 
-    let p = p_decl.apply(&[]).as_bool().unwrap();
-    let q = q_decl.apply(&[]).as_bool().unwrap();
-    let r = r_decl.apply(&[]).as_bool().unwrap();
+    let p = p_decl.apply(vec![]).as_bool().unwrap();
+    let q = q_decl.apply(vec![]).as_bool().unwrap();
+    let r = r_decl.apply(vec![]).as_bool().unwrap();
 
     // Rules: p => q, q => r
     fp.add_rule(&p.implies(&q), Some("p_to_q"));
@@ -376,8 +375,8 @@ fn function_ref_count() {
 
     let int_sort = Sort::int();
 
-    let _f = FuncDecl::new("f", &[&int_sort], &int_sort);
-    let _g = FuncDecl::new("g", &[&int_sort], &int_sort);
+    let _f = FuncDecl::new("f", int_sort.clone(), &int_sort);
+    let _g = FuncDecl::new("g", int_sort.clone(), &int_sort);
 
     assert_eq!(solver.check(), SatResult::Sat);
 }
@@ -597,10 +596,10 @@ fn test_string_as_string() {
 fn test_rec_func_def() {
     let _ = env_logger::try_init();
 
-    let fac = RecFuncDecl::new("fac", &[&Sort::int()], &Sort::int());
+    let fac = RecFuncDecl::new("fac", &[&Sort::int().as_dyn()], &Sort::int().as_dyn());
     let n = ast::Int::new_const("n");
     let n_minus_1 = &n - 1;
-    let fac_of_n_minus_1 = fac.apply(&[&n_minus_1]);
+    let fac_of_n_minus_1 = fac.apply(vec![ast::Dynamic::from_ast(&n_minus_1)]);
     let cond: ast::Bool = n.le(0);
     let body = cond.ite(
         &ast::Int::from_i64(1),
@@ -614,9 +613,19 @@ fn test_rec_func_def() {
 
     let solver = Solver::new();
 
-    solver.assert(x.eq(fac.apply(&[&ast::Int::from_i64(4)]).as_int().unwrap()));
+    solver.assert(
+        x.eq(fac
+            .apply(vec![ast::Dynamic::from_ast(&ast::Int::from_i64(4))])
+            .as_int()
+            .unwrap()),
+    );
     solver.assert(y.eq(ast::Int::mul(&[&ast::Int::from_i64(5), &x])));
-    solver.assert(y.eq(fac.apply(&[&ast::Int::from_i64(5)]).as_int().unwrap()));
+    solver.assert(
+        y.eq(fac
+            .apply(vec![ast::Dynamic::from_ast(&ast::Int::from_i64(5))])
+            .as_int()
+            .unwrap()),
+    );
     solver.assert(y.eq(120));
 
     assert_eq!(solver.check(), SatResult::Sat);
@@ -626,10 +635,10 @@ fn test_rec_func_def() {
 fn test_rec_func_def_unsat() {
     let _ = env_logger::try_init();
 
-    let fac = RecFuncDecl::new("fac", &[&Sort::int()], &Sort::int());
+    let fac = RecFuncDecl::new("fac", &[&Sort::int().as_dyn()], &Sort::int().as_dyn());
     let n = ast::Int::new_const("n");
     let n_minus_1 = ast::Int::sub(&[&n, &ast::Int::from_i64(1)]);
-    let fac_of_n_minus_1 = fac.apply(&[&n_minus_1]);
+    let fac_of_n_minus_1 = fac.apply(vec![ast::Dynamic::from_ast(&n_minus_1)]);
     let cond: ast::Bool = n.le(0);
     let body = cond.ite(
         &ast::Int::from_i64(1),
@@ -643,9 +652,19 @@ fn test_rec_func_def_unsat() {
 
     let solver = Solver::new();
 
-    solver.assert(x.eq(fac.apply(&[&ast::Int::from_i64(4)]).as_int().unwrap()));
+    solver.assert(
+        x.eq(fac
+            .apply(vec![ast::Dynamic::from_ast(&ast::Int::from_i64(4))])
+            .as_int()
+            .unwrap()),
+    );
     solver.assert(y.eq(ast::Int::mul(&[&ast::Int::from_i64(5), &x])));
-    solver.assert(y.eq(fac.apply(&[&ast::Int::from_i64(5)]).as_int().unwrap()));
+    solver.assert(
+        y.eq(fac
+            .apply(vec![ast::Dynamic::from_ast(&ast::Int::from_i64(5))])
+            .as_int()
+            .unwrap()),
+    );
 
     // If fac was an uninterpreted function, this assertion would work.
     // To see this, comment out `fac.add_def(&[&n.into()], &body);`
@@ -809,43 +828,48 @@ fn test_datatype_builder() {
 
     let maybe_int = DatatypeBuilder::new("MaybeInt")
         .variant("Nothing", vec![])
-        .variant("Just", vec![("int", DatatypeAccessor::Sort(Sort::int()))])
+        .variant(
+            "Just",
+            vec![("int", DatatypeAccessor::Sort(Sort::int().as_dyn()))],
+        )
         .finish();
 
-    let nothing = maybe_int.variants[0].constructor.apply(&[]);
+    let nothing = maybe_int.variants[0].constructor.apply(vec![]);
     let five = ast::Int::from_i64(5);
-    let just_five = maybe_int.variants[1].constructor.apply(&[&five]);
+    let just_five = maybe_int.variants[1]
+        .constructor
+        .apply(vec![ast::Dynamic::from_ast(&five)]);
 
     let nothing_is_nothing = maybe_int.variants[0]
         .tester
-        .apply(&[&nothing])
+        .apply(vec![ast::Dynamic::from_ast(&nothing)])
         .as_bool()
         .unwrap();
     solver.assert(&nothing_is_nothing);
 
     let nothing_is_just = maybe_int.variants[1]
         .tester
-        .apply(&[&nothing])
+        .apply(vec![ast::Dynamic::from_ast(&nothing)])
         .as_bool()
         .unwrap();
     solver.assert(nothing_is_just.not());
 
     let just_five_is_nothing = maybe_int.variants[0]
         .tester
-        .apply(&[&just_five])
+        .apply(vec![ast::Dynamic::from_ast(&just_five)])
         .as_bool()
         .unwrap();
     solver.assert(just_five_is_nothing.not());
 
     let just_five_is_just = maybe_int.variants[1]
         .tester
-        .apply(&[&just_five])
+        .apply(vec![ast::Dynamic::from_ast(&just_five)])
         .as_bool()
         .unwrap();
     solver.assert(&just_five_is_just);
 
     let five_two = maybe_int.variants[1].accessors[0]
-        .apply(&[&just_five])
+        .apply(vec![ast::Dynamic::from_ast(&just_five)])
         .as_int()
         .unwrap();
     solver.assert(five.eq(&five_two));
@@ -856,7 +880,7 @@ fn test_datatype_builder() {
         .unwrap()
         .update_field(&maybe_int.variants[1].accessors[0], &four);
     let four_two = maybe_int.variants[1].accessors[0]
-        .apply(&[&just_four])
+        .apply(vec![ast::Dynamic::from_ast(&just_four)])
         .as_int()
         .unwrap();
     solver.assert(four.eq(four_two));
@@ -875,54 +899,57 @@ fn test_recursive_datatype() {
         .variant(
             "cons",
             vec![
-                ("car", DatatypeAccessor::Sort(Sort::int())),
+                ("car", DatatypeAccessor::Sort(Sort::int().as_dyn())),
                 ("cdr", DatatypeAccessor::Datatype("List".into())),
             ],
         )
         .finish();
 
     assert_eq!(list_sort.variants.len(), 2);
-    let nil = list_sort.variants[0].constructor.apply(&[]);
+    let nil = list_sort.variants[0].constructor.apply(vec![]);
     let five = ast::Int::from_i64(5);
-    let cons_five_nil = list_sort.variants[1].constructor.apply(&[&five, &nil]);
+    let cons_five_nil = list_sort.variants[1].constructor.apply(vec![
+        ast::Dynamic::from_ast(&five),
+        ast::Dynamic::from_ast(&nil),
+    ]);
 
     let nil_is_nil = list_sort.variants[0]
         .tester
-        .apply(&[&nil])
+        .apply(vec![ast::Dynamic::from_ast(&nil)])
         .as_bool()
         .unwrap();
     solver.assert(&nil_is_nil);
 
     let nil_is_cons = list_sort.variants[1]
         .tester
-        .apply(&[&nil])
+        .apply(vec![ast::Dynamic::from_ast(&nil)])
         .as_bool()
         .unwrap();
     solver.assert(nil_is_cons.not());
 
     let cons_five_nil_is_nil = list_sort.variants[0]
         .tester
-        .apply(&[&cons_five_nil])
+        .apply(vec![ast::Dynamic::from_ast(&cons_five_nil)])
         .as_bool()
         .unwrap();
     solver.assert(cons_five_nil_is_nil.not());
 
     let cons_five_nil_is_cons = list_sort.variants[1]
         .tester
-        .apply(&[&cons_five_nil])
+        .apply(vec![ast::Dynamic::from_ast(&cons_five_nil)])
         .as_bool()
         .unwrap();
     solver.assert(&cons_five_nil_is_cons);
 
     let car_cons_five_is_five = list_sort.variants[1].accessors[0]
-        .apply(&[&cons_five_nil])
+        .apply(vec![ast::Dynamic::from_ast(&cons_five_nil)])
         .as_int()
         .unwrap();
     solver.assert(car_cons_five_is_five.eq(&five));
     assert_eq!(solver.check(), SatResult::Sat);
 
     let cdr_cons_five_is_nil = list_sort.variants[1].accessors[1]
-        .apply(&[&cons_five_nil])
+        .apply(vec![ast::Dynamic::from_ast(&cons_five_nil)])
         .as_datatype()
         .unwrap();
     solver.assert(cdr_cons_five_is_nil.eq(nil.as_datatype().unwrap()));
@@ -936,7 +963,10 @@ fn test_mutually_recursive_datatype() {
     let solver = Solver::new();
 
     let tree_builder = DatatypeBuilder::new("Tree")
-        .variant("leaf", vec![("val", DatatypeAccessor::Sort(Sort::int()))])
+        .variant(
+            "leaf",
+            vec![("val", DatatypeAccessor::Sort(Sort::int().as_dyn()))],
+        )
         .variant(
             "node",
             vec![("children", DatatypeAccessor::Datatype("TreeList".into()))],
@@ -965,39 +995,54 @@ fn test_mutually_recursive_datatype() {
     assert_eq!(tree_list_sort.variants[1].accessors.len(), 2);
 
     let ten = ast::Int::from_i64(10);
-    let leaf_ten = tree_sort.variants[0].constructor.apply(&[&ten]);
+    let leaf_ten = tree_sort.variants[0]
+        .constructor
+        .apply(vec![ast::Dynamic::from_ast(&ten)]);
     let leaf_ten_val_is_ten = tree_sort.variants[0].accessors[0]
-        .apply(&[&leaf_ten])
+        .apply(vec![ast::Dynamic::from_ast(&leaf_ten)])
         .as_int()
         .unwrap();
     solver.assert(leaf_ten_val_is_ten.eq(ten.clone()));
     assert_eq!(solver.check(), SatResult::Sat);
 
-    let nil = tree_list_sort.variants[0].constructor.apply(&[]);
+    let nil = tree_list_sort.variants[0].constructor.apply(vec![]);
     let twenty = ast::Int::from_i64(20);
-    let leaf_twenty = tree_sort.variants[0].constructor.apply(&[&twenty]);
-    let cons_leaf_twenty_nil = tree_list_sort.variants[1]
+    let leaf_twenty = tree_sort.variants[0]
         .constructor
-        .apply(&[&leaf_twenty, &nil]);
-    let cons_leaf_ten_cons_leaf_twenty_nil = tree_list_sort.variants[1]
-        .constructor
-        .apply(&[&leaf_ten, &cons_leaf_twenty_nil]);
+        .apply(vec![ast::Dynamic::from_ast(&twenty)]);
+    let cons_leaf_twenty_nil = tree_list_sort.variants[1].constructor.apply(vec![
+        ast::Dynamic::from_ast(&leaf_twenty),
+        ast::Dynamic::from_ast(&nil),
+    ]);
+    let cons_leaf_ten_cons_leaf_twenty_nil = tree_list_sort.variants[1].constructor.apply(vec![
+        ast::Dynamic::from_ast(&leaf_ten),
+        ast::Dynamic::from_ast(&cons_leaf_twenty_nil),
+    ]);
 
     // n1 = Tree.node(TreeList.cons(Tree.leaf(10), TreeList.cons(Tree.leaf(20), TreeList.nil)))
     let n1 = tree_sort.variants[1]
         .constructor
-        .apply(&[&cons_leaf_ten_cons_leaf_twenty_nil]);
+        .apply(vec![ast::Dynamic::from_ast(
+            &cons_leaf_ten_cons_leaf_twenty_nil,
+        )]);
 
-    let n1_cons_nil = tree_list_sort.variants[1].constructor.apply(&[&n1, &nil]);
+    let n1_cons_nil = tree_list_sort.variants[1].constructor.apply(vec![
+        ast::Dynamic::from_ast(&n1),
+        ast::Dynamic::from_ast(&nil),
+    ]);
     // n2 = Tree.node(TreeList.cons(n1, TreeList.nil))
-    let n2 = tree_sort.variants[1].constructor.apply(&[&n1_cons_nil]);
+    let n2 = tree_sort.variants[1]
+        .constructor
+        .apply(vec![ast::Dynamic::from_ast(&n1_cons_nil)]);
 
     solver.assert(n2.eq(&n1).not());
 
     // assert(TreeList.car(Tree.children(n2)) == n1)
     solver.assert(
         tree_list_sort.variants[1].accessors[0]
-            .apply(&[&tree_sort.variants[1].accessors[0].apply(&[&n2])])
+            .apply(vec![ast::Dynamic::from_ast(
+                &tree_sort.variants[1].accessors[0].apply(vec![ast::Dynamic::from_ast(&n2)]),
+            )])
             .eq(&n1),
     );
     assert_eq!(solver.check(), SatResult::Sat);
@@ -1132,11 +1177,11 @@ fn test_set_membership() {
     let _ = env_logger::try_init();
 
     let solver = Solver::new();
-    let set = ast::Set::new_const("integer_set", &Sort::int());
+    let set = ast::Set::new_const("integer_set", &Sort::int().as_dyn());
     let one = ast::Int::from_u64(1);
 
     solver.push();
-    solver.assert(set.eq(ast::Set::empty(&Sort::int())));
+    solver.assert(set.eq(ast::Set::empty(&Sort::int().as_dyn())));
 
     solver.push();
     solver.assert(set.member(&one));
@@ -1167,7 +1212,7 @@ fn test_set_membership() {
 
     solver.push();
     // A singleton set of 1 will contain 1
-    solver.assert(set.eq(ast::Set::empty(&Sort::int()).add(&one)));
+    solver.assert(set.eq(ast::Set::empty(&Sort::int().as_dyn()).add(&one)));
     solver.assert(set.member(&one));
     assert_eq!(solver.check(), SatResult::Sat);
     solver.pop(1);
@@ -1177,10 +1222,11 @@ fn test_set_membership() {
 fn test_dynamic_as_set() {
     let _ = env_logger::try_init();
 
-    let set_sort = Sort::set(&Sort::int());
-    let array_sort = Sort::array(&Sort::int(), &Sort::int());
-    let array_of_sets = ast::Array::new_const("array_of_sets", &Sort::int(), &set_sort);
-    let array_of_arrays = ast::Array::new_const("array_of_arrays", &Sort::int(), &array_sort);
+    let set_sort = Sort::set(&Sort::int().as_dyn());
+    let array_sort = Sort::array(&Sort::int().as_dyn(), &Sort::int().as_dyn());
+    let array_of_sets = ast::Array::new_const("array_of_sets", &Sort::int().as_dyn(), &set_sort);
+    let array_of_arrays =
+        ast::Array::new_const("array_of_arrays", &Sort::int().as_dyn(), &array_sort);
     assert!(
         array_of_sets
             .select(&ast::Int::from_u64(0))
@@ -1202,7 +1248,12 @@ fn test_array_store_select() {
     let solver = Solver::new();
     let zero = ast::Int::from_u64(0);
     let one = ast::Int::from_u64(1);
-    let set = ast::Array::new_const("integer_array", &Sort::int(), &Sort::int()).store(&zero, &one);
+    let set = ast::Array::new_const(
+        "integer_array",
+        &Sort::int().as_dyn(),
+        &Sort::int().as_dyn(),
+    )
+    .store(&zero, &one);
 
     solver.assert(set.select(&zero).eq(one).not());
     assert_eq!(solver.check(), SatResult::Unsat);
@@ -1556,12 +1607,12 @@ fn test_ast_safe_decl() {
     let x_not = x.not();
     assert_eq!(x_not.safe_decl().unwrap().kind(), DeclKind::Not);
 
-    let f = FuncDecl::new("f", &[&Sort::int()], &Sort::int());
+    let f = FuncDecl::new("f", Sort::int(), Sort::int());
     assert_eq!(f.domain(0), Some(SortKind::Int));
     assert_eq!(f.range(), SortKind::Int);
 
     let x = ast::Int::new_const("x");
-    let f_x: ast::Int = f.apply(&[&x]).try_into().unwrap();
+    let f_x: ast::Int = f.apply(x.clone());
     let f_x_pattern: Pattern = Pattern::new(&[&f_x]);
     let forall = ast::forall_const(&[&x], &[&f_x_pattern], &x.eq(&f_x));
     assert!(forall.safe_decl().is_err());
@@ -1612,7 +1663,11 @@ fn test_regex_union2() {
 fn test_array_example1() {
     let g = Goal::new(true, false, false);
 
-    let aex = Array::new_const("MyArray", &Sort::int(), &Sort::bitvector(32));
+    let aex = Array::new_const(
+        "MyArray",
+        &Sort::int().as_dyn(),
+        &Sort::bitvector(32).as_dyn(),
+    );
 
     let sel = aex.select(&Int::from_u64(0));
 
@@ -1620,9 +1675,9 @@ fn test_array_example1() {
 
     let xc = Int::new_const("x");
 
-    let fd = FuncDecl::new("f", &[&Sort::int()], &Sort::int());
+    let fd = FuncDecl::new("f", vec![Sort::int().as_dyn()], Sort::int().as_dyn());
 
-    let fapp = fd.apply(&[&xc as &dyn Ast]);
+    let fapp = fd.apply(vec![ast::Dynamic::from_ast(&xc)]);
 
     g.assert(&Int::from_u64(123).eq(xc.clone().add(&fapp.as_int().unwrap())));
 
@@ -1659,20 +1714,33 @@ fn test_array_example1() {
 #[test]
 /// <https://z3prover.github.io/api/html/classz3py_1_1_func_entry.html>
 fn return_number_args_in_given_entry() {
-    let f = FuncDecl::new("f", &[&Sort::int(), &Sort::int()], &Sort::int());
+    let f = FuncDecl::new(
+        "f",
+        vec![Sort::int().as_dyn(), Sort::int().as_dyn()],
+        Sort::int().as_dyn(),
+    );
 
     let solver = Solver::new();
     solver.assert(
-        f.apply(&[&Int::from_u64(0), &Int::from_u64(1)])
-            .eq(Int::from_u64(10)),
+        f.apply(vec![
+            ast::Dynamic::from_ast(&Int::from_u64(0)),
+            ast::Dynamic::from_ast(&Int::from_u64(1)),
+        ])
+        .eq(Int::from_u64(10)),
     );
     solver.assert(
-        f.apply(&[&Int::from_u64(1), &Int::from_u64(2)])
-            .eq(Int::from_u64(20)),
+        f.apply(vec![
+            ast::Dynamic::from_ast(&Int::from_u64(1)),
+            ast::Dynamic::from_ast(&Int::from_u64(2)),
+        ])
+        .eq(Int::from_u64(20)),
     );
     solver.assert(
-        f.apply(&[&Int::from_u64(1), &Int::from_u64(0)])
-            .eq(Int::from_u64(10)),
+        f.apply(vec![
+            ast::Dynamic::from_ast(&Int::from_u64(1)),
+            ast::Dynamic::from_ast(&Int::from_u64(0)),
+        ])
+        .eq(Int::from_u64(10)),
     );
 
     assert!(solver.check() == SatResult::Sat);
@@ -1712,14 +1780,14 @@ fn iterate_all_solutions() {
             .iter()
             .map(|fd| {
                 modifications.push(
-                    fd.apply(&[])
-                        .eq(model.get_const_interp(&fd.apply(&[])).unwrap())
+                    fd.apply(vec![])
+                        .eq(model.get_const_interp(&fd.apply(vec![])).unwrap())
                         .not(),
                 );
                 format!(
                     "{} = {}",
                     fd.name(),
-                    model.get_const_interp(&fd.apply(&[])).unwrap()
+                    model.get_const_interp(&fd.apply(vec![])).unwrap()
                 )
             })
             .collect::<Vec<_>>()
@@ -1839,14 +1907,14 @@ fn test_model_iter() {
     fn consume_model(model: Model) -> Vec<ast::Dynamic> {
         let mut asts = vec![];
         for func in &model {
-            asts.push(func.apply(&[]));
+            asts.push(func.apply(vec![]));
         }
         asts
     }
 
     assert_eq!(
         consume_model(model),
-        vec![ast::Dynamic::new_const("a", &Sort::int())]
+        vec![ast::Dynamic::new_const("a", &Sort::int().as_dyn())]
     );
 }
 

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1241,6 +1241,73 @@ fn test_dynamic_as_set() {
 }
 
 #[test]
+fn test_dynamic_narrow_parameterized() {
+    let _ = env_logger::try_init();
+
+    let arr = ast::Array::new_const("a", &Sort::int(), &Sort::bool());
+    let dynamic_arr = ast::Dynamic::from(arr);
+
+    // The domain and range sorts both match.
+    assert!(
+        dynamic_arr
+            .narrow::<ast::Array<ast::Int, ast::Bool>>()
+            .is_some()
+    );
+    // Swapped domain/range don't match, even though both are still "some `Array`".
+    assert!(
+        dynamic_arr
+            .narrow::<ast::Array<ast::Bool, ast::Int>>()
+            .is_none()
+    );
+    // Wrong domain only.
+    assert!(
+        dynamic_arr
+            .narrow::<ast::Array<ast::Real, ast::Bool>>()
+            .is_none()
+    );
+    // Fully dynamic still matches anything.
+    assert!(
+        dynamic_arr
+            .narrow::<ast::Array<ast::Dynamic, ast::Dynamic>>()
+            .is_some()
+    );
+
+    let set = ast::Set::new_const("s", &Sort::int());
+    let dynamic_set = ast::Dynamic::from(set);
+    assert!(dynamic_set.narrow::<ast::Set<ast::Int>>().is_some());
+    assert!(dynamic_set.narrow::<ast::Set<ast::Bool>>().is_none());
+    // In Z3, a `Set` is represented as an `Array` to `Bool`, so this also narrows.
+    assert!(
+        dynamic_set
+            .narrow::<ast::Array<ast::Int, ast::Bool>>()
+            .is_some()
+    );
+
+    let seq = ast::Seq::new_const("q", &Sort::int());
+    let dynamic_seq = ast::Dynamic::from(seq);
+    assert!(dynamic_seq.narrow::<ast::Seq<ast::Int>>().is_some());
+    assert!(dynamic_seq.narrow::<ast::Seq<ast::Bool>>().is_none());
+
+    // Nested: an array of `Int`-indexed `Bool` sets.
+    let array_of_sets = ast::Array::new_const(
+        "array_of_sets",
+        &Sort::int(),
+        &Sort::set(&Sort::int().as_dyn()),
+    );
+    let dynamic_array_of_sets = ast::Dynamic::from(array_of_sets);
+    assert!(
+        dynamic_array_of_sets
+            .narrow::<ast::Array<ast::Int, ast::Set<ast::Int>>>()
+            .is_some()
+    );
+    assert!(
+        dynamic_array_of_sets
+            .narrow::<ast::Array<ast::Int, ast::Set<ast::Bool>>>()
+            .is_none()
+    );
+}
+
+#[test]
 fn test_array_store_select() {
     let _ = env_logger::try_init();
 

--- a/z3/tests/objectives.rs
+++ b/z3/tests/objectives.rs
@@ -14,32 +14,20 @@ fn test_optimize_assert_soft_and_get_objectives() {
     let opt = Optimize::new();
 
     let int = Sort::int();
-    let well_ordered_fn = FuncDecl::new("well_ordered_fn", &[&int], &int);
+    // Typed domain/range: `apply` returns a concrete `Int` directly, no `.as_int().unwrap()`.
+    let well_ordered_fn = FuncDecl::new("well_ordered_fn", int.clone(), &int);
 
     // i < j in the order
     for i in 0..COUNT {
         opt.assert(ast::Bool::and(&[
-            &well_ordered_fn
-                .apply(&[&ast::Int::from_u64(i)])
-                .as_int()
-                .unwrap()
-                .lt(COUNT),
-            &well_ordered_fn
-                .apply(&[&ast::Int::from_u64(i)])
-                .as_int()
-                .unwrap()
-                .ge(0),
+            &well_ordered_fn.apply(ast::Int::from_u64(i)).lt(COUNT),
+            &well_ordered_fn.apply(ast::Int::from_u64(i)).ge(0),
         ]));
         for j in 0..i {
             opt.assert_soft(
                 &well_ordered_fn
-                    .apply(&[&ast::Int::from_u64(i)])
-                    .as_int()
-                    .unwrap()
-                    .lt(well_ordered_fn
-                        .apply(&[&ast::Int::from_u64(j)])
-                        .as_int()
-                        .unwrap()),
+                    .apply(ast::Int::from_u64(i))
+                    .lt(well_ordered_fn.apply(ast::Int::from_u64(j))),
                 1,
                 None,
             );
@@ -49,13 +37,8 @@ fn test_optimize_assert_soft_and_get_objectives() {
     // incorrect assertion: COUNT-1 > 0
     opt.assert_soft(
         &well_ordered_fn
-            .apply(&[&ast::Int::from_u64(0)])
-            .as_int()
-            .unwrap()
-            .lt(well_ordered_fn
-                .apply(&[&ast::Int::from_u64(COUNT - 1)])
-                .as_int()
-                .unwrap()),
+            .apply(ast::Int::from_u64(0))
+            .lt(well_ordered_fn.apply(ast::Int::from_u64(COUNT - 1))),
         1,
         None,
     );
@@ -66,17 +49,13 @@ fn test_optimize_assert_soft_and_get_objectives() {
 
     for i in 0..COUNT {
         let i_new_pos = model
-            .eval(&well_ordered_fn.apply(&[&ast::Int::from_u64(i)]), true)
-            .unwrap()
-            .as_int()
+            .eval(&well_ordered_fn.apply(ast::Int::from_u64(i)), true)
             .unwrap()
             .as_u64()
             .unwrap();
         for j in 0..i {
             let j_new_pos = model
-                .eval(&well_ordered_fn.apply(&[&ast::Int::from_u64(j)]), true)
-                .unwrap()
-                .as_int()
+                .eval(&well_ordered_fn.apply(ast::Int::from_u64(j)), true)
                 .unwrap()
                 .as_u64()
                 .unwrap();
@@ -88,19 +67,12 @@ fn test_optimize_assert_soft_and_get_objectives() {
     // the penalty of all other soft assertions
     assert!(
         model
-            .eval(&well_ordered_fn.apply(&[&ast::Int::from_u64(0)]), true)
-            .unwrap()
-            .as_int()
+            .eval(&well_ordered_fn.apply(ast::Int::from_u64(0)), true)
             .unwrap()
             .as_u64()
             .unwrap()
             > model
-                .eval(
-                    &well_ordered_fn.apply(&[&ast::Int::from_u64(COUNT - 1)]),
-                    true
-                )
-                .unwrap()
-                .as_int()
+                .eval(&well_ordered_fn.apply(ast::Int::from_u64(COUNT - 1)), true)
                 .unwrap()
                 .as_u64()
                 .unwrap()

--- a/z3/tests/ops.rs
+++ b/z3/tests/ops.rs
@@ -306,13 +306,16 @@ fn test_ast_attributes() {
     assert_ast_attributes(&not_a, false);
     assert_ast_attributes(a_or_b, false);
 
-    assert_ast_attributes(&Array::new_const("arr", &Sort::int(), &Sort::bool()), true);
+    assert_ast_attributes(
+        &Array::new_const("arr", &Sort::int().as_dyn(), &Sort::bool().as_dyn()),
+        true,
+    );
     assert_ast_attributes(&BV::new_const("bv", 512), true);
     assert_ast_attributes(&Real::new_const("r"), true);
     assert_ast_attributes(&ast::String::new_const("st"), true);
 
     let int_expr = Int::new_const("i");
-    let set_expr = ast::Set::new_const("set", &Sort::int());
+    let set_expr = ast::Set::new_const("set", &Sort::int().as_dyn());
     assert_ast_attributes(&int_expr, true);
     assert_ast_attributes(&set_expr, true);
     assert_ast_attributes(&set_expr.add(&Dynamic::from_ast(&int_expr)), false);
@@ -320,17 +323,21 @@ fn test_ast_attributes() {
 
 #[test]
 fn test_func_decl_attributes() {
-    let const_decl = FuncDecl::new("c", &[], &Sort::bool());
+    let const_decl = FuncDecl::new("c", (), Sort::bool());
     assert_eq!(const_decl.kind(), DeclKind::Uninterpreted);
     assert_eq!(const_decl.name(), "c");
     assert_eq!(const_decl.arity(), 0);
 
-    let unary_decl = FuncDecl::new("unary", &[&Sort::bool()], &Sort::bool());
+    let unary_decl = FuncDecl::new("unary", Sort::bool(), Sort::bool());
     assert_eq!(unary_decl.kind(), DeclKind::Uninterpreted);
     assert_eq!(unary_decl.name(), "unary");
     assert_eq!(unary_decl.arity(), 1);
 
-    let binary_decl = FuncDecl::new("binary", &[&Sort::bool(), &Sort::bool()], &Sort::bool());
+    let binary_decl = FuncDecl::new(
+        "binary",
+        vec![Sort::bool().as_dyn(), Sort::bool().as_dyn()],
+        Sort::bool(),
+    );
     assert_eq!(binary_decl.kind(), DeclKind::Uninterpreted);
     assert_eq!(binary_decl.name(), "binary");
     assert_eq!(binary_decl.arity(), 2);


### PR DESCRIPTION
Right now we have `Ast`s that have `Sort`s. In terms of SMT, some Sorts have parameters (e.g. `Set<Elt>` and `Array<Domain, Range>`). However, the rust bindings currently do not expose this. `ast::Array` is just an `Array`: `Array::select` takes in a `Dynamic` and returns a `Dynamic`. This fails if `select` is given an index element of the wrong sort and any returned value is also `Dynamic` must be manually unwrapped into the proper `Ast` type.

This is kind of gross because you generally know a priori what the sorts of an array are (indeed, you _HAVE_ to know the domain sort to be able to construct select asts). So it would be nice to be able to represent this in Rust's type system.

However, we also don't want to lose the ability to handle unknown sorts of parameterized sorts with unknown parameterizations.

This PR adapts some earlier manual work I did in the `sort-parameterization` branch (summarized in #447) exploring this concept. I had claude complete my partial implementation, apply it a cross the rest of the API surface and get it all compiling.

This also includes the original motivation of this work: cleaning up the `FuncDecl` API

The basic idea is:
* Sort becomes `Sort<T>`: `T` is the rust type representing asts of this sort: so `Sort<Int>` is the sort of the sort returned by `Int::sort()`
* `Sort` has a fallback default type of `Dynamic` allowing existing behavior to still compile.
* This kind of sets up a two-way mapping between sorts and asts.
* Introduces a trait to allow querying a sort to ensure it matches a given sort. This is used to allow implementing a `narrow` function on both asts and sorts, allowing `Dynamic` and `Sort<Dynamic>` to be safely narrowed to arbitrary concrete asts/sorts
* `FuncDecl` becomes similarly parameterized. There's a bunch of traits flying around to implement this but basically `FuncDecl` gets a domain and range as well. Domain is generally `Vec<Dynamic>` or a tuple of heterogenous `Sort`s. Range is either `Dynamic` or a sort.

I'm quite happy with how this has turned out so far and I think this reduces boilerplate in a lot of common cases.

My remaining concerns are:
* Cases where this adds boilerplate (e.g. dynamically-typed funcdecls)
* Whether this plays nicely with recursive func decls
* Whether this plays nicely with datatypes
* How to integrate this with issues like #463, which overlap this but represent a different set of missing capabilities