### PR TITLE
fix: correct Model/FuncInterp handling of constant interpretations

### DIFF
--- a/z3/src/func_interp.rs
+++ b/z3/src/func_interp.rs
@@ -2,9 +2,42 @@ use std::fmt;
 use z3_sys::*;
 
 use crate::{
-    AstVector, Context, FuncEntry, FuncInterp,
+    AstVector, Context, FuncEntry, FuncInterp, Interp,
     ast::{Ast, Dynamic},
 };
+
+impl Interp {
+    /// Returns the const interpretation, if this is [`Interp::Const`].
+    pub fn as_const(&self) -> Option<&Dynamic> {
+        match self {
+            Interp::Const(d) => Some(d),
+            Interp::Func(_) => None,
+        }
+    }
+
+    /// Returns the func interpretation, if this is [`Interp::Func`].
+    pub fn as_func(&self) -> Option<&FuncInterp> {
+        match self {
+            Interp::Const(_) => None,
+            Interp::Func(f) => Some(f),
+        }
+    }
+}
+
+impl fmt::Display for Interp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            Interp::Const(d) => write!(f, "{d}"),
+            Interp::Func(func_interp) => write!(f, "{func_interp}"),
+        }
+    }
+}
+
+impl fmt::Debug for Interp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        <Self as fmt::Display>::fmt(self, f)
+    }
+}
 
 impl FuncInterp {
     pub(crate) unsafe fn wrap(ctx: &Context, z3_func_interp: Z3_func_interp) -> Self {
@@ -55,14 +88,13 @@ impl FuncInterp {
     }
 
     /// Returns the else value of the function interpretation.
-    /// Returns None if the else value is not set by Z3.
-    pub fn get_else(&self) -> Dynamic {
-        unsafe {
-            Dynamic::wrap(
-                &self.ctx,
-                Z3_func_interp_get_else(self.ctx.z3_ctx.as_ptr(), self.z3_func_interp).unwrap(),
-            )
-        }
+    ///
+    /// Returns `None` if the interpretation is partial, i.e. Z3 has not assigned a
+    /// default value for arguments not covered by [`FuncInterp::get_entries`].
+    pub fn get_else(&self) -> Option<Dynamic> {
+        let ast =
+            unsafe { Z3_func_interp_get_else(self.ctx.z3_ctx.as_ptr(), self.z3_func_interp) }?;
+        Some(unsafe { Dynamic::wrap(&self.ctx, ast) })
     }
 
     /// Sets the else value of the function interpretation.
@@ -95,7 +127,10 @@ impl fmt::Display for FuncInterp {
             }
             write!(f, " -> {}, ", e.get_value())
         })?;
-        write!(f, "else -> {}", self.get_else())?;
+        match self.get_else() {
+            Some(else_value) => write!(f, "else -> {else_value}")?,
+            None => write!(f, "else -> <partial>")?,
+        }
         write!(f, "]")
     }
 }

--- a/z3/src/lib.rs
+++ b/z3/src/lib.rs
@@ -243,6 +243,25 @@ pub struct FuncInterp {
     z3_func_interp: Z3_func_interp,
 }
 
+/// The interpretation of a [`FuncDecl`] in a [`Model`].
+///
+/// A `FuncDecl` with arity 0 (a constant) is interpreted directly as an [`ast::Dynamic`],
+/// unless it is an array-sorted constant that Z3 represents as an alias for another
+/// `FuncDecl`'s [`FuncInterp`] (an "as-array" value), in which case that [`FuncInterp`] is
+/// returned instead. A `FuncDecl` with arity greater than 0 is always interpreted as a
+/// [`FuncInterp`].
+///
+/// # See also:
+///
+/// - [`Model::get_interp`]
+pub enum Interp {
+    /// The interpretation of a constant (arity-0 `FuncDecl`).
+    Const(ast::Dynamic),
+    /// The interpretation of a function (arity > 0, or an array-sorted constant that
+    /// aliases another `FuncDecl`'s interpretation).
+    Func(FuncInterp),
+}
+
 /// Store the value of the interpretation of a function in a particular point.
 /// <https://z3prover.github.io/api/html/classz3py_1_1_func_entry.html>
 pub struct FuncEntry {

--- a/z3/src/model.rs
+++ b/z3/src/model.rs
@@ -3,7 +3,8 @@ use std::{ffi::CStr, iter::FusedIterator};
 use z3_sys::*;
 
 use crate::{
-    AstVector, Context, FuncDecl, FuncInterp, Model, Optimize, Solver, Sort, Translate, ast::Ast,
+    AstVector, Context, FuncDecl, FuncInterp, Interp, Model, Optimize, Solver, Sort, Translate,
+    ast::{Ast, Dynamic},
 };
 
 impl Model {
@@ -55,9 +56,11 @@ impl Model {
         Some(unsafe { T::wrap(&self.ctx, ret?) })
     }
 
-    /// Returns the interpretation of the given `f` in the `Model`
-    /// Returns `None` if there is no interpretation in the `Model`
-    pub fn get_func_interp(&self, f: &FuncDecl) -> Option<FuncInterp> {
+    /// Returns the interpretation of the given `f` in the `Model`, regardless of whether
+    /// `f` is a constant (arity 0) or a function (arity > 0).
+    ///
+    /// Returns `None` if there is no interpretation in the `Model`.
+    pub fn get_interp(&self, f: &FuncDecl) -> Option<Interp> {
         if f.arity() == 0 {
             let ret = unsafe {
                 Z3_model_get_const_interp(self.ctx.z3_ctx.as_ptr(), self.z3_mdl, f.z3_func_decl)
@@ -68,27 +71,36 @@ impl Model {
                     Z3_get_range(self.ctx.z3_ctx.as_ptr(), f.z3_func_decl).unwrap(),
                 )
             };
-            match sort_kind {
-                SortKind::Array => {
-                    if unsafe { Z3_is_as_array(self.ctx.z3_ctx.as_ptr(), ret) } {
-                        let fd = unsafe {
-                            FuncDecl::wrap(
-                                &self.ctx,
-                                Z3_get_as_array_func_decl(self.ctx.z3_ctx.as_ptr(), ret).unwrap(),
-                            )
-                        };
-                        self.get_func_interp(&fd)
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
+            if sort_kind == SortKind::Array
+                && unsafe { Z3_is_as_array(self.ctx.z3_ctx.as_ptr(), ret) }
+            {
+                let fd = unsafe {
+                    FuncDecl::wrap(
+                        &self.ctx,
+                        Z3_get_as_array_func_decl(self.ctx.z3_ctx.as_ptr(), ret).unwrap(),
+                    )
+                };
+                self.get_interp(&fd)
+            } else {
+                Some(Interp::Const(unsafe { Dynamic::wrap(&self.ctx, ret) }))
             }
         } else {
             let ret = unsafe {
                 Z3_model_get_func_interp(self.ctx.z3_ctx.as_ptr(), self.z3_mdl, f.z3_func_decl)
-            };
-            Some(unsafe { FuncInterp::wrap(&self.ctx, ret?) })
+            }?;
+            Some(Interp::Func(unsafe { FuncInterp::wrap(&self.ctx, ret) }))
+        }
+    }
+
+    /// Returns the function-table interpretation of the given `f` in the `Model`.
+    ///
+    /// Returns `None` if `f` has no interpretation in the `Model`, or if its interpretation
+    /// is a plain constant rather than a function table (see [`Model::get_interp`] and
+    /// [`Model::get_const_interp`] for that case).
+    pub fn get_func_interp(&self, f: &FuncDecl) -> Option<FuncInterp> {
+        match self.get_interp(f)? {
+            Interp::Func(func_interp) => Some(func_interp),
+            Interp::Const(_) => None,
         }
     }
 

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1693,6 +1693,90 @@ fn func_interp_get_else_on_partial_interp() {
 }
 
 #[test]
+fn get_interp_returns_none_for_arity_0_without_interp() {
+    let f = FuncDecl::new("unconstrained_const", &[], &Sort::int());
+    let solver = Solver::new();
+    assert!(solver.check() == SatResult::Sat);
+    let model = solver.get_model().unwrap();
+
+    assert!(model.get_interp(&f).is_none());
+    assert!(model.get_func_interp(&f).is_none());
+}
+
+#[test]
+fn get_interp_returns_none_for_arity_gt_0_without_interp() {
+    let f = FuncDecl::new("unconstrained_fn", &[&Sort::int()], &Sort::int());
+    let solver = Solver::new();
+    assert!(solver.check() == SatResult::Sat);
+    let model = solver.get_model().unwrap();
+
+    assert!(model.get_interp(&f).is_none());
+    assert!(model.get_func_interp(&f).is_none());
+}
+
+#[test]
+fn get_interp_of_arity_gt_0_returns_func_variant() {
+    let f = FuncDecl::new("f", &[&Sort::int()], &Sort::int());
+    let solver = Solver::new();
+    solver.assert(
+        f.apply(&[&Int::from_u64(0)])
+            .as_int()
+            .unwrap()
+            .eq(Int::from_u64(1)),
+    );
+    assert!(solver.check() == SatResult::Sat);
+    let model = solver.get_model().unwrap();
+
+    let interp = model.get_interp(&f).unwrap();
+    assert!(interp.as_const().is_none());
+    let func_interp = interp.as_func().unwrap();
+    assert!(func_interp.to_string() == model.get_func_interp(&f).unwrap().to_string());
+}
+
+#[test]
+fn get_interp_of_array_const_returns_const_variant() {
+    let aex = Array::new_const("MyArray", &Sort::int(), &Sort::bitvector(32));
+    let sel = aex.select(&Int::from_u64(0));
+    let solver = Solver::new();
+    solver.assert(sel.eq(BV::from_u64(42, 32)));
+    assert!(solver.check() == SatResult::Sat);
+    let model = solver.get_model().unwrap();
+
+    let fd = aex.decl();
+    let interp = model.get_interp(&fd).unwrap();
+    assert!(interp.as_func().is_none());
+    let const_interp = interp.as_const().unwrap();
+    assert!(const_interp.to_string() == "((as const (Array Int (_ BitVec 32))) #x0000002a)");
+    assert!(model.get_func_interp(&fd).is_none());
+}
+
+#[test]
+fn interp_display_and_debug_match_underlying_variant() {
+    let f = FuncDecl::new("hi", &[], &Sort::int());
+    let solver = Solver::new();
+    solver.assert(f.apply(&[]).as_int().unwrap().eq(Int::from_u64(5)));
+    assert!(solver.check() == SatResult::Sat);
+    let model = solver.get_model().unwrap();
+    let const_interp = model.get_interp(&f).unwrap();
+    assert!(const_interp.to_string() == "5");
+    assert!(format!("{const_interp:?}") == "5");
+
+    let g = FuncDecl::new("g", &[&Sort::int()], &Sort::int());
+    let solver = Solver::new();
+    solver.assert(
+        g.apply(&[&Int::from_u64(0)])
+            .as_int()
+            .unwrap()
+            .eq(Int::from_u64(1)),
+    );
+    assert!(solver.check() == SatResult::Sat);
+    let model = solver.get_model().unwrap();
+    let func_interp = model.get_interp(&g).unwrap();
+    assert!(func_interp.to_string() == func_interp.as_func().unwrap().to_string());
+    assert!(format!("{func_interp:?}") == func_interp.to_string());
+}
+
+#[test]
 /// <https://z3prover.github.io/api/html/classz3py_1_1_func_entry.html>
 fn return_number_args_in_given_entry() {
     let f = FuncDecl::new("f", &[&Sort::int(), &Sort::int()], &Sort::int());

--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -1657,6 +1657,42 @@ fn test_array_example1() {
 }
 
 #[test]
+/// <https://github.com/prove-rs/z3.rs/issues/461>
+fn get_interp_of_arity_0_non_array_func_decl() {
+    let solver = Solver::new();
+    let f = FuncDecl::new("hi", &[], &Sort::int());
+    solver.assert(f.apply(&[]).as_int().unwrap().eq(Int::from_u64(5)));
+    assert!(solver.check() == SatResult::Sat);
+    let model = solver.get_model().unwrap();
+
+    assert!(model.get_func_interp(&f).is_none());
+
+    let interp = model.get_interp(&f).unwrap();
+    let const_interp = interp.as_const().unwrap();
+    assert!(const_interp.to_string() == "5");
+}
+
+#[test]
+/// <https://github.com/prove-rs/z3.rs/issues/460>
+fn func_interp_get_else_on_partial_interp() {
+    let f = FuncDecl::new("f", &[&Sort::int()], &Sort::int());
+    let solver = Solver::new();
+    solver.assert(
+        f.apply(&[&Int::from_u64(0)])
+            .as_int()
+            .unwrap()
+            .eq(Int::from_u64(1)),
+    );
+    assert!(solver.check() == SatResult::Sat);
+    let model = solver.get_model().unwrap();
+    let f_i = model.get_func_interp(&f).unwrap();
+
+    // The else value may or may not be assigned by Z3 depending on how the model was
+    // constructed; either way, `get_else` must not panic.
+    let _ = f_i.get_else();
+}
+
+#[test]
 /// <https://z3prover.github.io/api/html/classz3py_1_1_func_entry.html>
 fn return_number_args_in_given_entry() {
     let f = FuncDecl::new("f", &[&Sort::int(), &Sort::int()], &Sort::int());


### PR DESCRIPTION
## Summary
- `Model::get_func_interp` panicked for arity-0 `FuncDecl`s with a non-array range,
  since Z3 only exposes a const interp (not a func interp) in that case. Add
  `Model::get_interp`, returning a new `Interp` enum (`Const`/`Func`), so callers can
  fetch a `FuncDecl`'s interpretation without knowing its arity ahead of time.
  `get_func_interp` is now a thin wrapper over it that returns `None` for the
  plain-constant case instead of panicking.
- `FuncInterp::get_else` unwrapped a value that Z3 can genuinely return as null for
  partial function interpretations, causing a panic. It now returns `Option<Dynamic>`.

Fixes #461
Fixes #460